### PR TITLE
Add support for php.ini customization and fix bugs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,10 +21,21 @@ jobs:
     - name: Installing NPM
       run: npm install  
 
-    - name: Installing PHP
+    - name: Installing PHP with extensions and custom config
       run: node lib/install.js
       env:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: "mbstring, curl, mysqli, json, xml, xdebug, pcov, phpdbg"
-    - name: Testing
-      run: php -v && composer -V && php -m
+        extension-csv: "mbstring, xdebug, pcov" #optional
+        ini-values-csv: "post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata" #optional
+
+    - name: Testing PHP version
+      run: php -v
+    - name: Testing Composer version
+      run: composer -V
+    - name: Testing Extensions
+      run: php -m
+    - name: Testing ini values
+      run: |
+        php -r "echo \"post_max_size: \" . ini_get('post_max_size') . \"\n\";"
+        php -r "echo \"short_open_tag: \" . ini_get('short_open_tag') . \"\n\";"
+        php -r "echo \"date.timezone: \" . ini_get('date.timezone') . \"\n\";"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <a href="https://github.com/shivammathur/setup-php/blob/master/LICENSE"><img alt="LICENSE" src="https://img.shields.io/badge/license-MIT-428f7e.svg"></a>
 </p>
 
-[GitHub Action](https://github.com/features/actions) to install PHP with required extensions and composer. This action can be added as a step in your action workflow and it will setup the PHP environment you need to test your application. Refer to [Usage](#usage) section to see how to use this.
+[GitHub Action](https://github.com/features/actions) to install PHP with required extensions, php.ini configuration and composer. This action can be added as a step in your action workflow and it will setup the PHP environment you need to test your application. Refer to [Usage](#usage) section to see how to use this.
 
 ## PHP Versions Support
 - 5.6
@@ -36,9 +36,15 @@
 
 ## Usage
 
-See [action.yml](action.yml) for inputs this action supports.
+Inputs supported by this GitHub Action.
 
-### Basic
+- php-version
+- extension-csv (optional)
+- ini-values-csv (optional)
+
+See [action.yml](action.yml) for more info
+
+### Basic Usage
 
 ```yaml
 steps:
@@ -48,7 +54,8 @@ steps:
   uses: shivammathur/setup-php@master
   with:
     php-version: 7.3
-    extension-csv: mbstring, xdebug
+    extension-csv: mbstring, xdebug #optional
+    ini-values-csv: "post_max_size=256M, short_open_tag=On" #optional
 - name: Check PHP Version
   run: php -v
 - name: Check Composer Version
@@ -76,7 +83,8 @@ jobs:
       uses: shivammathur/setup-php@master
       with:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring, xdebug
+        extension-csv: mbstring, xdebug #optional
+        ini-values-csv: "post_max_size=256M, short_open_tag=On" #optional
     - name: Check PHP Version
       run: php -v
     - name: Check Composer Version

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   extension-csv:
     description: '(Optional) Comma seperated list of PHP extensions to be installed.'
     required: false
+  ini-values-csv: 
+    description: '(Optional) Custom values you want to set in php.ini'
+    required: false
 runs:
   using: 'node12'
   main: 'lib/install.js'

--- a/lib/install.js
+++ b/lib/install.js
@@ -86,7 +86,7 @@ function addExtension(extension_csv, version) {
                 // else add script to attempt to install the extension
                 if (os_version == 'linux') {
                     linux +=
-                        'sudo apt install -y php' +
+                        'sudo DEBIAN_FRONTEND=noninteractive apt install -y php' +
                             version +
                             '-' +
                             extension +
@@ -129,7 +129,28 @@ function addExtension(extension_csv, version) {
                 }
             });
         });
-        linux += 'sudo apt autoremove -y';
+        linux += 'sudo DEBIAN_FRONTEND=noninteractive apt autoremove -y';
+    });
+}
+/*
+Add script to set custom ini values
+*/
+function addINIValues(ini_values_csv) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let ini_values = ini_values_csv
+            .split(',')
+            .map(function (ini_value) {
+            return ini_value.trim();
+        });
+        yield asyncForEach(ini_values, function (ini_value) {
+            return __awaiter(this, void 0, void 0, function* () {
+                // add script to set ini value
+                linux += '\necho "' + ini_value + '" >> $ini_file';
+                darwin += '\necho "' + ini_value + '" >> $ini_file';
+                windows +=
+                    '\nAdd-Content C:\\tools\\php$version\\php.ini "' + ini_value + '"';
+            });
+        });
     });
 }
 /*
@@ -166,7 +187,7 @@ function run() {
             if (!version) {
                 version = core.getInput('php-version', { required: true });
             }
-            console.log('Input: ' + version);
+            console.log('Version: ' + version);
             if (version == '7.4') {
                 darwin = fs.readFileSync(path.join(__dirname, '../src/7.4.sh'), 'utf8');
             }
@@ -175,8 +196,16 @@ function run() {
                 extension_csv = core.getInput('extension-csv');
             }
             if (extension_csv) {
-                console.log('Input: ' + extension_csv);
+                console.log('Extensions: ' + extension_csv);
                 yield addExtension(extension_csv, version);
+            }
+            let ini_values_csv = process.env['ini-values-csv'];
+            if (!ini_values_csv) {
+                ini_values_csv = core.getInput('ini-values-csv');
+            }
+            if (ini_values_csv) {
+                console.log('INI Values: ' + ini_values_csv);
+                yield addINIValues(ini_values_csv);
             }
             // check the os version and run the respective script
             if (os_version == 'darwin') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": false,
   "description": "Setup php action",
   "main": "lib/setup-php.js",

--- a/src/darwin.sh
+++ b/src/darwin.sh
@@ -4,8 +4,11 @@ if [ "$version" != "$1" ]; then
 	brew unlink php;
 	brew install php@$1;
 	brew link --force --overwrite php@$1;
+else
+	sudo cp /etc/php.ini.default /etc/php.ini	
 fi
-
+ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+sudo chmod 777 $ini_file
 curl -sS https://getcomposer.org/installer | php
 chmod +x composer.phar
 mv composer.phar /usr/local/bin/composer

--- a/src/linux.sh
+++ b/src/linux.sh
@@ -1,26 +1,23 @@
-ua()
-{	
-	for tool in php phar phar.phar php-cgi php-config phpize; do
-		if [ -e "/usr/bin/$tool$version" ]; then
-			sudo update-alternatives --set $tool /usr/bin/$tool$1;
-		fi
-	done
-}
-
 version=$(php-config --version | cut -c 1-3)
 if [ "$version" != "$1" ]; then
 	if [ ! -e "/usr/bin/php$1" ]; then
-		sudo add-apt-repository ppa:ondrej/php -y
-		sudo apt update -y		
-		sudo apt install -y php$1 curl;
-		sudo apt autoremove -y;		
+		sudo DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:ondrej/php -y
+		sudo DEBIAN_FRONTEND=noninteractive apt update -y		
+		sudo DEBIAN_FRONTEND=noninteractive apt install -y php$1 curl;
+		sudo DEBIAN_FRONTEND=noninteractive apt autoremove -y;		
 	fi
-	ua $1;
+	for tool in php phar phar.phar php-cgi php-config phpize; do
+		if [ -e "/usr/bin/$tool$1" ]; then
+			sudo update-alternatives --set $tool /usr/bin/$tool$1;
+		fi
+	done
 fi	
 
 if [ ! -e "/usr/bin/composer" ]; then
 	sudo curl -s https://getcomposer.org/installer | php;
 	sudo mv composer.phar /usr/local/bin/composer;
 fi
+ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+sudo chmod 777 $ini_file
 php -v
 composer -V


### PR DESCRIPTION
- Add support for `php.ini` customization
- Copy `php.ini.default` to `php.ini` if required PHP version already installed in darwin.
- Fix debconf warnings #14 