### PR TITLE
Fix installation on darwin after #32

### DIFF
--- a/src/darwin.sh
+++ b/src/darwin.sh
@@ -21,8 +21,8 @@ if [ ! -e "/usr/bin/composer" ]; then
 	sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 	RESULT=$?
 	rm composer-setup.php
-	exit $RESULT
+	echo $RESULT
 fi
-composer global require hirak/prestissimo
+sudo composer global require hirak/prestissimo
 php -v
 composer -V


### PR DESCRIPTION
---
name: 🐞 Bug Fix
about: Fix installation on darwin after #32
labels: bug
---

- Do not exit after composer install 
- install `hirak/prestissimo` with sudo, else leads to permission errors.