### PR TITLE
Add option to disable coverage drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,23 +48,38 @@ Setup PHP with required extensions, php.ini configuration and composer in [GitHu
 - Extensions which cannot be installed gracefully leave an error message in the logs, the action is not interrupted.
 
 ## :signal_strength: Coverage support
-- Specify `coverage: xdebug` to use `Xdebug`.
-    - Runs on all [PHP versions supported](#tada-php-support)    
+
+### Xdebug
+
+Specify `coverage: xdebug` to use `Xdebug`.
+Runs on all [PHP versions supported](#tada-php-support)    
 ```
 uses: shivammathur/setup-php@master
 with:
   php-version: 7.3  
   coverage: xdebug
 ```
-- Specify `coverage: pcov` to use `PCOV`. `PCOV` is way faster than `Xdebug`
-    - For `pcov.directory` to be other than `src`, `lib` or, `app`, specify it using the `ini-values-csv` input.
-    - `PCOV` needs `PHPUnit >= 8.0` and `PHP >= 7.1`, `PHPUnit` needs `PHP >= 7.2`. So use `PHP >= 7.2` with `PCOV`
+
+### PCOV
+
+Specify `coverage: pcov` to use `PCOV`. `PCOV` is way faster than `Xdebug`.
+For `pcov.directory` to be other than `src`, `lib` or, `app`, specify it using the `ini-values-csv` input.
+`PCOV` needs `PHPUnit >= 8.0` and `PHP >= 7.1`, `PHPUnit` needs `PHP >= 7.2`. So use `PHP >= 7.2` with `PCOV`
 ```
 uses: shivammathur/setup-php@master
 with:
   php-version: 7.3
   ini-values-csv: 'pcov.directory=api' #optional, see above for usage.
   coverage: pcov
+```
+
+### Disable coverage
+Specify `coverage: none` to disable both `Xdebug` and `PCOV`.
+```
+uses: shivammathur/setup-php@master
+with:
+  php-version: 7.3
+  coverage: none
 ```
 
 ## :memo: Usage

--- a/__tests__/features.test.ts
+++ b/__tests__/features.test.ts
@@ -178,6 +178,10 @@ describe('Features tests', () => {
     win32 = await features.addCoverage('pcov', '5.6', 'win32');
     expect(win32).toContain('PCOV requires PHP 7.1 or newer');
 
+    win32 = await features.addCoverage('none', '7.4', 'win32');
+    expect(win32).toContain('Disable-PhpExtension xdebug');
+    expect(win32).toContain('Disable-PhpExtension pcov');
+
     win32 = await features.addCoverage('', '7.4', 'win32');
     expect(win32).toEqual('');
   });
@@ -190,6 +194,12 @@ describe('Features tests', () => {
     expect(linux).toContain('./pcov.sh');
     expect(linux).toContain('sudo sed -i "/xdebug/d" $ini_file');
     expect(linux).toContain('sudo phpdismod xdebug');
+
+    linux = await features.addCoverage('none', '7.4', 'linux');
+    expect(linux).toContain('sudo phpdismod xdebug');
+    expect(linux).toContain('sudo phpdismod pcov');
+    expect(linux).toContain('sudo sed -i "/xdebug/d" $ini_file');
+    expect(linux).toContain('sudo sed -i "/pcov/d" $ini_file');
 
     linux = await features.addCoverage('', '7.4', 'linux');
     expect(linux).toEqual('');
@@ -204,6 +214,10 @@ describe('Features tests', () => {
 
     darwin = await features.addCoverage('pcov', '7.4', 'darwin');
     expect(darwin).toContain('sh ./pcov.sh');
+
+    darwin = await features.addCoverage('none', '7.4', 'darwin');
+    expect(darwin).toContain('sudo sed -i \'\' "/xdebug/d" $ini_file');
+    expect(darwin).toContain('sudo sed -i \'\' "/pcov/d" $ini_file');
 
     darwin = await features.addCoverage('', '7.4', 'win32');
     expect(darwin).toEqual('');

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: '(Optional) Custom values you want to set in php.ini'
     required: false
   coverage: 
-    description: '(Optional) Driver to calculate code coverage (Accepts: xdebug and pcov)'
+    description: '(Optional) Driver to calculate code coverage (Accepts: xdebug, pcov and none)'
     required: false
 runs:
   using: 'node12'

--- a/lib/features.js
+++ b/lib/features.js
@@ -297,8 +297,7 @@ function addINIValuesWindows(ini_values_csv) {
 exports.addINIValuesWindows = addINIValuesWindows;
 function addCoverage(coverage, version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
-        let script = '';
-        script += '\n';
+        let script = '\n';
         coverage = coverage.toLowerCase();
         // pcov
         switch (coverage) {
@@ -340,7 +339,33 @@ function addCoverage(coverage, version, os_version) {
                 script += yield addExtension('xdebug', version, os_version, 'Set Coverage Driver');
                 script += yield utils.log('Xdebug enabled as coverage driver', os_version, 'success', 'Set Coverage Driver');
                 break;
-            // unknown coverage driver
+            case 'none':
+                switch (os_version) {
+                    case 'linux':
+                        script +=
+                            'if [ -e /etc/php/' +
+                                version +
+                                '/mods-available/xdebug.ini ]; then sudo phpdismod xdebug; fi\n';
+                        script +=
+                            'if [ -e /etc/php/' +
+                                version +
+                                '/mods-available/pcov.ini ]; then sudo phpdismod pcov; fi\n';
+                        script += 'sudo sed -i "/xdebug/d" $ini_file\n';
+                        script += 'sudo sed -i "/pcov/d" $ini_file\n';
+                        break;
+                    case 'darwin':
+                        script += 'sudo sed -i \'\' "/xdebug/d" $ini_file\n';
+                        script += 'sudo sed -i \'\' "/pcov/d" $ini_file\n';
+                        break;
+                    case 'win32':
+                        script +=
+                            'if(php -m | findstr -i xdebug) { Disable-PhpExtension xdebug C:\\tools\\php }\n';
+                        script +=
+                            'if(php -m | findstr -i pcov) { Disable-PhpExtension pcov C:\\tools\\php }\n';
+                        break;
+                }
+                script += yield utils.log('Disabled Xdebug and PCOV', os_version, 'success', 'Set Coverage Driver');
+                break;
             default:
                 script = '';
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "private": false,
   "description": "Setup php action",
   "main": "lib/setup-php.js",

--- a/src/features.ts
+++ b/src/features.ts
@@ -364,8 +364,7 @@ export async function addCoverage(
   version: string,
   os_version: string
 ): Promise<string> {
-  let script: string = '';
-  script += '\n';
+  let script: string = '\n';
   coverage = coverage.toLowerCase();
   // pcov
   switch (coverage) {
@@ -434,7 +433,38 @@ export async function addCoverage(
         'Set Coverage Driver'
       );
       break;
-    // unknown coverage driver
+    case 'none':
+      switch (os_version) {
+        case 'linux':
+          script +=
+            'if [ -e /etc/php/' +
+            version +
+            '/mods-available/xdebug.ini ]; then sudo phpdismod xdebug; fi\n';
+          script +=
+            'if [ -e /etc/php/' +
+            version +
+            '/mods-available/pcov.ini ]; then sudo phpdismod pcov; fi\n';
+          script += 'sudo sed -i "/xdebug/d" $ini_file\n';
+          script += 'sudo sed -i "/pcov/d" $ini_file\n';
+          break;
+        case 'darwin':
+          script += 'sudo sed -i \'\' "/xdebug/d" $ini_file\n';
+          script += 'sudo sed -i \'\' "/pcov/d" $ini_file\n';
+          break;
+        case 'win32':
+          script +=
+            'if(php -m | findstr -i xdebug) { Disable-PhpExtension xdebug C:\\tools\\php }\n';
+          script +=
+            'if(php -m | findstr -i pcov) { Disable-PhpExtension pcov C:\\tools\\php }\n';
+          break;
+      }
+      script += await utils.log(
+        'Disabled Xdebug and PCOV',
+        os_version,
+        'success',
+        'Set Coverage Driver'
+      );
+      break;
     default:
       script = '';
   }


### PR DESCRIPTION
---
name: ⚙ Improvement
about: Add option to disable coverage drivers
labels: enhancement
---

Fixes #53 

### Description

Add option to disable coverage drivers
specifying `coverage: none` will disable `Xdebug` and `PCOV` if enabled.

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] `npm test` returns with no unit test errors.