### PR TITLE
Release 1.4.3

### DIFF
--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -20,7 +20,8 @@ describe('Config tests', () => {
   it('checking addINIValuesOnLinux', async () => {
     let linux: string = await config.addINIValues(
       'post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata',
-      'linux'
+      'linux',
+      true
     );
     expect(linux).toContain(
       'echo "post_max_size=256M\nshort_open_tag=On\ndate.timezone=Asia/Kolkata" >> $ini_file'

--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -17,10 +17,10 @@ describe('Config tests', () => {
     );
 
     win32 = await coverage.addCoverage('pcov', '7.0', 'win32');
-    expect(win32).toContain('PCOV requires PHP 7.1 or newer');
+    expect(win32).toContain('PHP 7.1 or newer is required');
 
     win32 = await coverage.addCoverage('pcov', '5.6', 'win32');
-    expect(win32).toContain('PCOV requires PHP 7.1 or newer');
+    expect(win32).toContain('PHP 7.1 or newer is required');
   });
 
   it('checking addCoverage with PCOV on linux', async () => {

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -19,9 +19,14 @@ describe('Extension tests', () => {
     );
     expect(win32).toContain('Install-PhpExtension pcov');
 
-    win32 = await extensions.addExtension('does_not_exist', '7.2', 'win32');
+    win32 = await extensions.addExtension(
+      'does_not_exist',
+      '7.2',
+      'win32',
+      true
+    );
     expect(win32).toContain(
-      'Add-Extension does_not_exist "Install-PhpExtension does_not_exist" extension "Add Extension"'
+      'Add-Extension does_not_exist "Install-PhpExtension does_not_exist" extension'
     );
 
     win32 = await extensions.addExtension('xdebug', '7.2', 'fedora');
@@ -84,7 +89,12 @@ describe('Extension tests', () => {
     darwin = await extensions.addExtension('xdebug', '7.2', 'darwin');
     expect(darwin).toContain('sudo pecl install xdebug');
 
-    darwin = await extensions.addExtension('does_not_exist', '7.2', 'darwin');
+    darwin = await extensions.addExtension(
+      'does_not_exist',
+      '7.2',
+      'darwin',
+      false
+    );
     expect(darwin).toContain('add_extension does_not_exist');
 
     darwin = await extensions.addExtension('xdebug', '7.2', 'fedora');

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -61,6 +61,11 @@ describe('Utils tests', () => {
     expect(await utils.readScript('fedora.sh', '7.3', 'fedora')).toContain(
       'Platform fedora is not supported'
     );
+    await cleanup('./config.yaml');
+    await cleanup('./pcov.sh');
+    await cleanup('./phalcon.sh');
+    await cleanup('./php_pcov.dll');
+    await cleanup('./xdebug_darwin.sh');
   });
 
   it('checking writeScripts', async () => {
@@ -101,53 +106,48 @@ describe('Utils tests', () => {
     let message: string = 'Test message';
 
     let warning_log: string = await utils.log(message, 'win32', 'warning');
-    expect(warning_log).toEqual(
-      "Write-Host '" + message + "' -ForegroundColor yellow"
-    );
+    expect(warning_log).toEqual('printf "\\033[33;1m' + message + ' \\033[0m"');
     warning_log = await utils.log(message, 'linux', 'warning');
     expect(warning_log).toEqual('echo "\\033[33;1m' + message + '\\033[0m"');
     warning_log = await utils.log(message, 'darwin', 'warning');
     expect(warning_log).toEqual('echo "\\033[33;1m' + message + '\\033[0m"');
 
     let error_log: string = await utils.log(message, 'win32', 'error');
-    expect(error_log).toEqual(
-      "Write-Host '" + message + "' -ForegroundColor red"
-    );
+    expect(error_log).toEqual('printf "\\033[31;1m' + message + ' \\033[0m"');
     error_log = await utils.log(message, 'linux', 'error');
     expect(error_log).toEqual('echo "\\033[31;1m' + message + '\\033[0m"');
     error_log = await utils.log(message, 'darwin', 'error');
     expect(error_log).toEqual('echo "\\033[31;1m' + message + '\\033[0m"');
 
     let success_log: string = await utils.log(message, 'win32', 'success');
-    expect(success_log).toEqual(
-      "Write-Host '" + message + "' -ForegroundColor green"
-    );
+    expect(success_log).toEqual('printf "\\033[32;1m' + message + ' \\033[0m"');
     success_log = await utils.log(message, 'linux', 'success');
     expect(success_log).toEqual('echo "\\033[32;1m' + message + '\\033[0m"');
     success_log = await utils.log(message, 'darwin', 'success');
     expect(success_log).toEqual('echo "\\033[32;1m' + message + '\\033[0m"');
 
-    success_log = await utils.log(message, 'win32', 'success', 'Test win');
-    expect(success_log).toEqual(
-      "Write-Host 'Test win: " + message + "' -ForegroundColor green"
-    );
-  });
+    let step_log: string = await utils.stepLog(message, 'win32');
+    expect(step_log).toEqual('Step-Log "Test message"');
+    step_log = await utils.stepLog(message, 'linux');
+    expect(step_log).toEqual('step_log "Test message"');
+    step_log = await utils.stepLog(message, 'darwin');
+    expect(step_log).toEqual('step_log "Test message"');
+    step_log = await utils.stepLog(message, 'fedora');
+    expect(step_log).toContain('Platform fedora is not supported');
 
-  it('checking log with prefix', async () => {
-    let message: string = 'Test message';
-    let prefix_log: string = await utils.log(
-      message,
-      'linux',
-      'success',
-      'Test Prefix'
+    let add_log: string = await utils.addLog(
+      'tick',
+      'xdebug',
+      'enabled',
+      'win32'
     );
-    expect(prefix_log).toEqual(
-      'echo "\\033[32;1mTest Prefix: ' + message + '\\033[0m"'
-    );
-    prefix_log = await utils.log(message, 'darwin', 'success', 'Test');
-    expect(prefix_log).toEqual(
-      'echo "\\033[32;1mTest: ' + message + '\\033[0m"'
-    );
+    expect(add_log).toEqual('Add-Log "tick" "xdebug" "enabled"');
+    add_log = await utils.addLog('tick', 'xdebug', 'enabled', 'linux');
+    expect(add_log).toEqual('add_log "tick" "xdebug" "enabled"');
+    add_log = await utils.addLog('tick', 'xdebug', 'enabled', 'darwin');
+    expect(add_log).toEqual('add_log "tick" "xdebug" "enabled"');
+    add_log = await utils.addLog('tick', 'xdebug', 'enabled', 'fedora');
+    expect(add_log).toContain('Platform fedora is not supported');
   });
 
   it('checking getExtensionPrefix', async () => {
@@ -157,5 +157,14 @@ describe('Utils tests', () => {
     expect(await utils.getExtensionPrefix('xsl')).toEqual('extension');
     expect(await utils.getExtensionPrefix('xdebug')).toEqual('zend_extension');
     expect(await utils.getExtensionPrefix('opcache')).toEqual('zend_extension');
+  });
+
+  it('checking suppressOutput', async () => {
+    expect(await utils.suppressOutput('win32')).toEqual(' >$null 2>&1');
+    expect(await utils.suppressOutput('linux')).toEqual(' >/dev/null 2>&1');
+    expect(await utils.suppressOutput('darwin')).toEqual(' >/dev/null 2>&1');
+    expect(await utils.suppressOutput('fedora')).toContain(
+      'Platform fedora is not supported'
+    );
   });
 });

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,16 +23,29 @@ const utils = __importStar(require("./utils"));
  * @param ini_values_csv
  * @param os_version
  */
-function addINIValues(ini_values_csv, os_version) {
+function addINIValues(ini_values_csv, os_version, no_step = false) {
     return __awaiter(this, void 0, void 0, function* () {
+        let script = '\n';
+        switch (no_step) {
+            case true:
+                script +=
+                    (yield utils.stepLog('Add php.ini values', os_version)) +
+                        (yield utils.suppressOutput(os_version)) +
+                        '\n';
+                break;
+            case false:
+            default:
+                script += (yield utils.stepLog('Add php.ini values', os_version)) + '\n';
+                break;
+        }
         switch (os_version) {
             case 'win32':
-                return yield addINIValuesWindows(ini_values_csv);
+                return script + (yield addINIValuesWindows(ini_values_csv));
             case 'darwin':
             case 'linux':
-                return yield addINIValuesUnix(ini_values_csv);
+                return script + (yield addINIValuesUnix(ini_values_csv));
             default:
-                return yield utils.log('Platform ' + os_version + ' is not supported', os_version, 'error', 'Add Config');
+                return yield utils.log('Platform ' + os_version + ' is not supported', os_version, 'error');
         }
     });
 }
@@ -45,7 +58,14 @@ exports.addINIValues = addINIValues;
 function addINIValuesUnix(ini_values_csv) {
     return __awaiter(this, void 0, void 0, function* () {
         let ini_values = yield utils.INIArray(ini_values_csv);
-        return '\necho "' + ini_values.join('\n') + '" >> $ini_file\n';
+        let script = '\n';
+        yield utils.asyncForEach(ini_values, function (line) {
+            return __awaiter(this, void 0, void 0, function* () {
+                script +=
+                    (yield utils.addLog('$tick', line, 'Added to php.ini', 'linux')) + '\n';
+            });
+        });
+        return 'echo "' + ini_values.join('\n') + '" >> $ini_file' + script;
     });
 }
 exports.addINIValuesUnix = addINIValuesUnix;
@@ -57,7 +77,17 @@ exports.addINIValuesUnix = addINIValuesUnix;
 function addINIValuesWindows(ini_values_csv) {
     return __awaiter(this, void 0, void 0, function* () {
         let ini_values = yield utils.INIArray(ini_values_csv);
-        return ('Add-Content C:\\tools\\php\\php.ini "' + ini_values.join('\n') + '"\n');
+        let script = '\n';
+        yield utils.asyncForEach(ini_values, function (line) {
+            return __awaiter(this, void 0, void 0, function* () {
+                script +=
+                    (yield utils.addLog('$tick', line, 'Added to php.ini', 'win32')) + '\n';
+            });
+        });
+        return ('Add-Content C:\\tools\\php\\php.ini "' +
+            ini_values.join('\n') +
+            '"' +
+            script);
     });
 }
 exports.addINIValuesWindows = addINIValuesWindows;

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -29,13 +29,14 @@ const config = __importStar(require("./config"));
 function addCoverage(coverage_driver, version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
         coverage_driver.toLowerCase();
+        let script = '\n' + (yield utils.stepLog('Setup Coverage', os_version));
         switch (coverage_driver) {
             case 'pcov':
-                return addCoveragePCOV(version, os_version);
+                return script + (yield addCoveragePCOV(version, os_version));
             case 'xdebug':
-                return addCoverageXdebug(version, os_version);
+                return script + (yield addCoverageXdebug(version, os_version));
             case 'none':
-                return disableCoverage(version, os_version);
+                return script + (yield disableCoverage(version, os_version));
             default:
                 return '';
         }
@@ -50,10 +51,10 @@ exports.addCoverage = addCoverage;
  */
 function addCoverageXdebug(version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
-        let script = '\n';
-        script += yield extensions.addExtension('xdebug', version, os_version, 'Set Coverage Driver');
-        script += yield utils.log('Xdebug enabled as coverage driver', os_version, 'success', 'Set Coverage Driver');
-        return script;
+        return ((yield extensions.addExtension('xdebug', version, os_version, true)) +
+            (yield utils.suppressOutput(os_version)) +
+            '\n' +
+            (yield utils.addLog('$tick', 'xdebug', 'Xdebug enabled as coverage driver', os_version)));
     });
 }
 exports.addCoverageXdebug = addCoverageXdebug;
@@ -68,8 +69,12 @@ function addCoveragePCOV(version, os_version) {
         let script = '\n';
         switch (version) {
             default:
-                script += yield extensions.addExtension('pcov', version, os_version, 'Set Coverage Driver');
-                script += yield config.addINIValues('pcov.enabled=1', os_version);
+                script +=
+                    (yield extensions.addExtension('pcov', version, os_version, true)) +
+                        (yield utils.suppressOutput(os_version)) +
+                        '\n';
+                script +=
+                    (yield config.addINIValues('pcov.enabled=1', os_version, true)) + '\n';
                 // add command to disable xdebug and enable pcov
                 switch (os_version) {
                     case 'linux':
@@ -90,12 +95,12 @@ function addCoveragePCOV(version, os_version) {
                         break;
                 }
                 // success
-                script += yield utils.log('PCOV enabled as coverage driver', os_version, 'success', 'Set Coverage Driver');
+                script += yield utils.addLog('$tick', 'coverage: pcov', 'PCOV enabled as coverage driver', os_version);
                 // version is not supported
                 break;
             case '5.6':
             case '7.0':
-                script += yield utils.log('PCOV requires PHP 7.1 or newer', os_version, 'warning', 'Set Coverage Driver');
+                script += yield utils.addLog('$cross', 'pcov', 'PHP 7.1 or newer is required', os_version);
                 break;
         }
         return script;
@@ -139,7 +144,7 @@ function disableCoverage(version, os_version) {
                     'if(php -m | findstr -i pcov) { Disable-PhpExtension pcov C:\\tools\\php }\n';
                 break;
         }
-        script += yield utils.log('Disabled Xdebug and PCOV', os_version, 'success', 'Set Coverage Driver');
+        script += yield utils.addLog('$tick', 'none', 'Disabled Xdebug and PCOV', os_version);
         return script;
     });
 }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -25,17 +25,29 @@ const utils = __importStar(require("./utils"));
  * @param os_version
  * @param log_prefix
  */
-function addExtension(extension_csv, version, os_version, log_prefix = 'Add Extension') {
+function addExtension(extension_csv, version, os_version, no_step = false) {
     return __awaiter(this, void 0, void 0, function* () {
+        let script = '\n';
+        switch (no_step) {
+            case true:
+                script +=
+                    (yield utils.stepLog('Setup Extensions', os_version)) +
+                        (yield utils.suppressOutput(os_version));
+                break;
+            case false:
+            default:
+                script += yield utils.stepLog('Setup Extensions', os_version);
+                break;
+        }
         switch (os_version) {
             case 'win32':
-                return yield addExtensionWindows(extension_csv, version, log_prefix);
+                return script + (yield addExtensionWindows(extension_csv, version));
             case 'darwin':
-                return yield addExtensionDarwin(extension_csv, version, log_prefix);
+                return script + (yield addExtensionDarwin(extension_csv, version));
             case 'linux':
-                return yield addExtensionLinux(extension_csv, version, log_prefix);
+                return script + (yield addExtensionLinux(extension_csv, version));
             default:
-                return yield utils.log('Platform ' + os_version + ' is not supported', os_version, 'error', log_prefix);
+                return yield utils.log('Platform ' + os_version + ' is not supported', os_version, 'error');
         }
     });
 }
@@ -46,7 +58,7 @@ exports.addExtension = addExtension;
  * @param extension_csv
  * @param version
  */
-function addExtensionDarwin(extension_csv, version, log_prefix) {
+function addExtensionDarwin(extension_csv, version) {
     return __awaiter(this, void 0, void 0, function* () {
         let extensions = yield utils.extensionArray(extension_csv);
         let script = '\n';
@@ -72,15 +84,12 @@ function addExtensionDarwin(extension_csv, version, log_prefix) {
                         break;
                 }
                 script +=
-                    'add_extension ' +
+                    '\nadd_extension ' +
                         extension +
                         ' "' +
                         install_command +
                         '" ' +
-                        (yield utils.getExtensionPrefix(extension)) +
-                        ' "' +
-                        log_prefix +
-                        '"\n';
+                        (yield utils.getExtensionPrefix(extension));
             });
         });
         return script;
@@ -93,7 +102,7 @@ exports.addExtensionDarwin = addExtensionDarwin;
  * @param extension_csv
  * @param version
  */
-function addExtensionWindows(extension_csv, version, log_prefix) {
+function addExtensionWindows(extension_csv, version) {
     return __awaiter(this, void 0, void 0, function* () {
         let extensions = yield utils.extensionArray(extension_csv);
         let script = '\n';
@@ -117,15 +126,12 @@ function addExtensionWindows(extension_csv, version, log_prefix) {
                         break;
                 }
                 script +=
-                    'Add-Extension ' +
+                    '\nAdd-Extension ' +
                         extension +
                         ' "' +
                         install_command +
                         '" ' +
-                        (yield utils.getExtensionPrefix(extension)) +
-                        ' "' +
-                        log_prefix +
-                        '"\n';
+                        (yield utils.getExtensionPrefix(extension));
             });
         });
         return script;
@@ -138,7 +144,7 @@ exports.addExtensionWindows = addExtensionWindows;
  * @param extension_csv
  * @param version
  */
-function addExtensionLinux(extension_csv, version, log_prefix) {
+function addExtensionLinux(extension_csv, version) {
     return __awaiter(this, void 0, void 0, function* () {
         let extensions = yield utils.extensionArray(extension_csv);
         let script = '\n';
@@ -174,15 +180,12 @@ function addExtensionLinux(extension_csv, version, log_prefix) {
                         break;
                 }
                 script +=
-                    'add_extension ' +
+                    '\nadd_extension ' +
                         extension +
                         ' "' +
                         install_command +
                         '" ' +
-                        (yield utils.getExtensionPrefix(extension)) +
-                        ' "' +
-                        log_prefix +
-                        '"\n';
+                        (yield utils.getExtensionPrefix(extension));
             });
         });
         return script;

--- a/lib/install.js
+++ b/lib/install.js
@@ -23,45 +23,55 @@ const extensions = __importStar(require("./extensions"));
 const config = __importStar(require("./config"));
 const coverage = __importStar(require("./coverage"));
 /**
+ * Build the script
+ *
+ * @param filename
+ * @param version
+ * @param os_version
+ */
+function build(filename, version, os_version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // taking inputs
+        let extension_csv = yield utils.getInput('extension-csv', false);
+        let ini_values_csv = yield utils.getInput('ini-values-csv', false);
+        let coverage_driver = yield utils.getInput('coverage', false);
+        let script = yield utils.readScript(filename, version, os_version);
+        if (extension_csv) {
+            script += yield extensions.addExtension(extension_csv, version, os_version);
+        }
+        if (ini_values_csv) {
+            script += yield config.addINIValues(ini_values_csv, os_version);
+        }
+        if (coverage_driver) {
+            script += yield coverage.addCoverage(coverage_driver, version, os_version);
+        }
+        yield utils.writeScript(filename, version, script);
+    });
+}
+/**
  * Run the script
  */
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            // taking inputs
-            let version = yield utils.getInput('php-version', true);
-            let extension_csv = yield utils.getInput('extension-csv', false);
-            let ini_values_csv = yield utils.getInput('ini-values-csv', false);
-            let coverage_driver = yield utils.getInput('coverage', false);
             let os_version = process.platform;
+            let version = yield utils.getInput('php-version', true);
             // check the os version and run the respective script
             if (os_version == 'darwin') {
-                let darwin = yield utils.readScript('darwin.sh', version, os_version);
-                darwin += yield extensions.addExtension(extension_csv, version, os_version);
-                darwin += yield config.addINIValues(ini_values_csv, os_version);
-                darwin += yield coverage.addCoverage(coverage_driver, version, os_version);
-                yield utils.writeScript('darwin.sh', version, darwin);
+                yield build('darwin.sh', version, os_version);
                 yield exec_1.exec('sh ./' + version + 'darwin.sh ' + version);
             }
             else if (os_version == 'win32') {
-                let windows = yield utils.readScript('win32.ps1', version, os_version);
-                windows += yield extensions.addExtension(extension_csv, version, os_version);
-                windows += yield config.addINIValues(ini_values_csv, os_version);
-                windows += yield coverage.addCoverage(coverage_driver, version, os_version);
-                yield utils.writeScript('win32.ps1', version, windows);
+                yield build('win32.ps1', version, os_version);
                 yield exec_1.exec('powershell .\\' + version + 'win32.ps1 -version ' + version);
             }
             else if (os_version == 'linux') {
-                let linux = yield utils.readScript('linux.sh', version, os_version);
-                linux += yield extensions.addExtension(extension_csv, version, os_version);
-                linux += yield config.addINIValues(ini_values_csv, os_version);
-                linux += yield coverage.addCoverage(coverage_driver, version, os_version);
-                yield utils.writeScript('linux.sh', version, linux);
+                yield build('linux.sh', version, os_version);
                 yield exec_1.exec('./' + version + 'linux.sh ' + version);
             }
         }
-        catch (err) {
-            core.setFailed(err.message);
+        catch (error) {
+            core.setFailed(error.message);
         }
     });
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,14 +58,14 @@ exports.asyncForEach = asyncForEach;
  *
  * @param files
  */
-function readFiles74(files) {
+function moveFiles(files) {
     return __awaiter(this, void 0, void 0, function* () {
         yield asyncForEach(files, function (filename) {
             fs.createReadStream(path.join(__dirname, '../src/' + filename)).pipe(fs.createWriteStream(filename.split('/')[1], { mode: 0o755 }));
         });
     });
 }
-exports.readFiles74 = readFiles74;
+exports.moveFiles = moveFiles;
 /**
  * Read the scripts
  *
@@ -79,7 +79,7 @@ function readScript(filename, version, os_version) {
             case 'darwin':
                 switch (version) {
                     case '7.4':
-                        yield readFiles74([
+                        yield moveFiles([
                             'configs/config.yaml',
                             'scripts/xdebug_darwin.sh',
                             'scripts/pcov.sh'
@@ -89,18 +89,17 @@ function readScript(filename, version, os_version) {
                 break;
             case 'linux':
                 let files = ['scripts/phalcon.sh'];
-                yield readFiles74(['scripts/phalcon.sh']);
                 switch (version) {
                     case '7.4':
-                        files.concat(['scripts/xdebug.sh', 'scripts/pcov.sh']);
+                        files = files.concat(['scripts/xdebug.sh', 'scripts/pcov.sh']);
                         break;
                 }
-                yield readFiles74(files);
+                yield moveFiles(files);
                 break;
             case 'win32':
                 switch (version) {
                     case '7.4':
-                        yield readFiles74(['ext/php_pcov.dll']);
+                        yield moveFiles(['ext/php_pcov.dll']);
                         break;
                 }
                 break;
@@ -166,42 +165,68 @@ function INIArray(ini_values_csv) {
     });
 }
 exports.INIArray = INIArray;
-function log(message, os_version, log_type, prefix = '') {
+/**
+ * Function to log a step
+ *
+ * @param message
+ * @param os_version
+ */
+function stepLog(message, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
-        const unix_color = {
+        switch (os_version) {
+            case 'win32':
+                return 'Step-Log "' + message + '"';
+            case 'linux':
+            case 'darwin':
+                return 'step_log "' + message + '"';
+            default:
+                return yield log('Platform ' + os_version + ' is not supported', os_version, 'error');
+        }
+    });
+}
+exports.stepLog = stepLog;
+/**
+ * Function to log a result
+ * @param mark
+ * @param subject
+ * @param message
+ */
+function addLog(mark, subject, message, os_version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        switch (os_version) {
+            case 'win32':
+                return 'Add-Log "' + mark + '" "' + subject + '" "' + message + '"';
+            case 'linux':
+            case 'darwin':
+                return 'add_log "' + mark + '" "' + subject + '" "' + message + '"';
+            default:
+                return yield log('Platform ' + os_version + ' is not supported', os_version, 'error');
+        }
+    });
+}
+exports.addLog = addLog;
+/**
+ * Log to console
+ *
+ * @param message
+ * @param os_version
+ * @param log_type
+ * @param prefix
+ */
+function log(message, os_version, log_type) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const color = {
             error: '31',
             success: '32',
             warning: '33'
         };
-        switch (prefix) {
-            case '':
-                prefix = '';
-                break;
-            default:
-                prefix = prefix + ': ';
-                break;
-        }
         switch (os_version) {
             case 'win32':
-                const color = {
-                    error: 'red',
-                    success: 'green',
-                    warning: 'yellow'
-                };
-                return ("Write-Host '" +
-                    prefix +
-                    message +
-                    "' -ForegroundColor " +
-                    color[log_type]);
+                return ('printf "\\033[' + color[log_type] + ';1m' + message + ' \\033[0m"');
             case 'linux':
             case 'darwin':
             default:
-                return ('echo "\\033[' +
-                    unix_color[log_type] +
-                    ';1m' +
-                    prefix +
-                    message +
-                    '\\033[0m"');
+                return 'echo "\\033[' + color[log_type] + ';1m' + message + '\\033[0m"';
         }
     });
 }
@@ -225,3 +250,22 @@ function getExtensionPrefix(extension) {
     });
 }
 exports.getExtensionPrefix = getExtensionPrefix;
+/**
+ * Function to get the suffix to suppress console output
+ *
+ * @param os_version
+ */
+function suppressOutput(os_version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        switch (os_version) {
+            case 'win32':
+                return ' >$null 2>&1';
+            case 'linux':
+            case 'darwin':
+                return ' >/dev/null 2>&1';
+            default:
+                return yield log('Platform ' + os_version + ' is not supported', os_version, 'error');
+        }
+    });
+}
+exports.suppressOutput = suppressOutput;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -525,9 +525,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.18",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.18.tgz",
-      "integrity": "sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==",
+      "version": "24.0.19",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.19.tgz",
+      "integrity": "sha512-YYiqfSjocv7lk5H/T+v5MjATYjaTMsUkbDnjGqSMoO88jWdtJXJV4ST/7DKZcoMHMBvB2SeSfyOzZfkxXHR5xg==",
       "dev": true,
       "requires": {
         "@types/jest-diff": "*"
@@ -540,9 +540,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
+      "integrity": "sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -5021,9 +5021,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
+      "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": false,
   "description": "Setup php action",
   "main": "lib/setup-php.js",

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -12,21 +12,33 @@ export async function addExtension(
   extension_csv: string,
   version: string,
   os_version: string,
-  log_prefix = 'Add Extension'
+  no_step = false
 ): Promise<string> {
+  let script: string = '\n';
+  switch (no_step) {
+    case true:
+      script +=
+        (await utils.stepLog('Setup Extensions', os_version)) +
+        (await utils.suppressOutput(os_version));
+      break;
+    case false:
+    default:
+      script += await utils.stepLog('Setup Extensions', os_version);
+      break;
+  }
+
   switch (os_version) {
     case 'win32':
-      return await addExtensionWindows(extension_csv, version, log_prefix);
+      return script + (await addExtensionWindows(extension_csv, version));
     case 'darwin':
-      return await addExtensionDarwin(extension_csv, version, log_prefix);
+      return script + (await addExtensionDarwin(extension_csv, version));
     case 'linux':
-      return await addExtensionLinux(extension_csv, version, log_prefix);
+      return script + (await addExtensionLinux(extension_csv, version));
     default:
       return await utils.log(
         'Platform ' + os_version + ' is not supported',
         os_version,
-        'error',
-        log_prefix
+        'error'
       );
   }
 }
@@ -39,8 +51,7 @@ export async function addExtension(
  */
 export async function addExtensionDarwin(
   extension_csv: string,
-  version: string,
-  log_prefix: string
+  version: string
 ): Promise<string> {
   let extensions: Array<string> = await utils.extensionArray(extension_csv);
   let script: string = '\n';
@@ -65,15 +76,12 @@ export async function addExtensionDarwin(
         break;
     }
     script +=
-      'add_extension ' +
+      '\nadd_extension ' +
       extension +
       ' "' +
       install_command +
       '" ' +
-      (await utils.getExtensionPrefix(extension)) +
-      ' "' +
-      log_prefix +
-      '"\n';
+      (await utils.getExtensionPrefix(extension));
   });
   return script;
 }
@@ -86,8 +94,7 @@ export async function addExtensionDarwin(
  */
 export async function addExtensionWindows(
   extension_csv: string,
-  version: string,
-  log_prefix: string
+  version: string
 ): Promise<string> {
   let extensions: Array<string> = await utils.extensionArray(extension_csv);
   let script: string = '\n';
@@ -112,15 +119,12 @@ export async function addExtensionWindows(
         break;
     }
     script +=
-      'Add-Extension ' +
+      '\nAdd-Extension ' +
       extension +
       ' "' +
       install_command +
       '" ' +
-      (await utils.getExtensionPrefix(extension)) +
-      ' "' +
-      log_prefix +
-      '"\n';
+      (await utils.getExtensionPrefix(extension));
   });
   return script;
 }
@@ -133,8 +137,7 @@ export async function addExtensionWindows(
  */
 export async function addExtensionLinux(
   extension_csv: string,
-  version: string,
-  log_prefix: string
+  version: string
 ): Promise<string> {
   let extensions: Array<string> = await utils.extensionArray(extension_csv);
   let script: string = '\n';
@@ -170,15 +173,12 @@ export async function addExtensionLinux(
         break;
     }
     script +=
-      'add_extension ' +
+      '\nadd_extension ' +
       extension +
       ' "' +
       install_command +
       '" ' +
-      (await utils.getExtensionPrefix(extension)) +
-      ' "' +
-      log_prefix +
-      '"\n';
+      (await utils.getExtensionPrefix(extension));
   });
   return script;
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -6,75 +6,51 @@ import * as config from './config';
 import * as coverage from './coverage';
 
 /**
+ * Build the script
+ *
+ * @param filename
+ * @param version
+ * @param os_version
+ */
+async function build(filename: string, version: string, os_version: string) {
+  // taking inputs
+  let extension_csv: string = await utils.getInput('extension-csv', false);
+  let ini_values_csv: string = await utils.getInput('ini-values-csv', false);
+  let coverage_driver: string = await utils.getInput('coverage', false);
+
+  let script: string = await utils.readScript(filename, version, os_version);
+  if (extension_csv) {
+    script += await extensions.addExtension(extension_csv, version, os_version);
+  }
+  if (ini_values_csv) {
+    script += await config.addINIValues(ini_values_csv, os_version);
+  }
+  if (coverage_driver) {
+    script += await coverage.addCoverage(coverage_driver, version, os_version);
+  }
+  await utils.writeScript(filename, version, script);
+}
+
+/**
  * Run the script
  */
 async function run() {
   try {
-    // taking inputs
-    let version: string = await utils.getInput('php-version', true);
-    let extension_csv: string = await utils.getInput('extension-csv', false);
-    let ini_values_csv: string = await utils.getInput('ini-values-csv', false);
-    let coverage_driver: string = await utils.getInput('coverage', false);
-
     let os_version: string = process.platform;
+    let version: string = await utils.getInput('php-version', true);
     // check the os version and run the respective script
     if (os_version == 'darwin') {
-      let darwin: string = await utils.readScript(
-        'darwin.sh',
-        version,
-        os_version
-      );
-
-      darwin += await extensions.addExtension(
-        extension_csv,
-        version,
-        os_version
-      );
-      darwin += await config.addINIValues(ini_values_csv, os_version);
-      darwin += await coverage.addCoverage(
-        coverage_driver,
-        version,
-        os_version
-      );
-      await utils.writeScript('darwin.sh', version, darwin);
+      await build('darwin.sh', version, os_version);
       await exec('sh ./' + version + 'darwin.sh ' + version);
     } else if (os_version == 'win32') {
-      let windows: string = await utils.readScript(
-        'win32.ps1',
-        version,
-        os_version
-      );
-      windows += await extensions.addExtension(
-        extension_csv,
-        version,
-        os_version
-      );
-      windows += await config.addINIValues(ini_values_csv, os_version);
-      windows += await coverage.addCoverage(
-        coverage_driver,
-        version,
-        os_version
-      );
-      await utils.writeScript('win32.ps1', version, windows);
+      await build('win32.ps1', version, os_version);
       await exec('powershell .\\' + version + 'win32.ps1 -version ' + version);
     } else if (os_version == 'linux') {
-      let linux: string = await utils.readScript(
-        'linux.sh',
-        version,
-        os_version
-      );
-      linux += await extensions.addExtension(
-        extension_csv,
-        version,
-        os_version
-      );
-      linux += await config.addINIValues(ini_values_csv, os_version);
-      linux += await coverage.addCoverage(coverage_driver, version, os_version);
-      await utils.writeScript('linux.sh', version, linux);
+      await build('linux.sh', version, os_version);
       await exec('./' + version + 'linux.sh ' + version);
     }
-  } catch (err) {
-    core.setFailed(err.message);
+  } catch (error) {
+    core.setFailed(error.message);
   }
 }
 

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -1,37 +1,57 @@
+tick="✓"
+cross="✗"
+
+step_log() {
+  message=$1
+  printf "\n\033[90;1m==> \033[0m\033[37;1m%s\033[0m\n" "$message"
+}
+
+add_log() {
+  mark=$1
+  subject=$2
+  message=$3
+  if [ "$mark" = "$tick" ]; then
+    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  else
+    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  fi
+}
+
 version=$1
 export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
 if [ "$1" = "5.6" ] || [ "$1" = "7.0" ]; then
   brew tap exolnet/homebrew-deprecated >/dev/null 2>&1
 fi
+step_log "Setup PHP and Composer"
 brew install php@"$1" composer >/dev/null 2>&1
 brew link --force --overwrite php@"$1" >/dev/null 2>&1
-ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+echo "date.timezone=UTC" >> "$ini_file"
 ext_dir=$(php -i | grep "extension_dir => /usr" | sed -e "s|.*=> s*||")
 sudo chmod 777 "$ini_file"
 mkdir -p "$(pecl config-get ext_dir)"
 composer global require hirak/prestissimo >/dev/null 2>&1
-php -v
-composer -V
+add_log "$tick" "PHP" "Installed PHP$version"
+add_log "$tick" "Composer" "Installed"
 
-add_extension()
-{
+add_extension() {
   extension=$1
   install_command=$2
   prefix=$3
-  log_prefix=$4
   if ! php -m | grep -i -q "$extension" && [ -e "$ext_dir/$extension.so" ]; then
-    echo "$prefix=$extension" >> "$ini_file" && echo "\033[32;1m$log_prefix: Enabled $extension\033[0m";
+    echo "$prefix=$extension" >>"$ini_file" && add_log $tick "$extension" "Enabled"
   elif php -m | grep -i -q "$extension"; then
-    echo "\033[33;1m$log_prefix: $extension was already enabled\033[0m";
+    add_log "$tick" "$extension" "Enabled"
   elif ! php -m | grep -i -q "$extension"; then
     exists=$(curl -sL https://pecl.php.net/json.php?package="$extension" -w "%{http_code}" -o /dev/null)
     if [ "$exists" = "200" ]; then
-      eval "$install_command" && \
-      echo "\033[32;1m$log_prefix: Installed and enabled $extension\033[0m" || \
-      echo "\033[31;1m$log_prefix: Could not install $extension on PHP$version\033[0m";
+      (
+        eval "$install_command" && \
+        add_log "$tick" "$extension" "Installed and enabled"
+      ) || add_log "$cross" "$extension" "Could not install $extension on PHP$version"
     else
       if ! php -m | grep -i -q "$extension"; then
-        echo "\033[31;1m$log_prefix: Could not find $extension for PHP$version on PECL\033[0m";
+        add_log "$cross" "$extension" "Could not find $extension for PHP$version on PECL"
       fi
     fi
   fi

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -1,5 +1,25 @@
+tick="✓"
+cross="✗"
+
+step_log() {
+  message=$1
+  printf "\n\033[90;1m==> \033[0m\033[37;1m%s\033[0m\n" "$message"
+}
+
+add_log() {
+  mark=$1
+  subject=$2
+  message=$3
+  if [ "$mark" = "$tick" ]; then
+    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  else
+    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  fi
+}
 existing_version=$(php-config --version | cut -c 1-3)
 version=$1
+status="Switched to PHP$version"
+step_log "Setup PHP and Composer"
 if [ "$existing_version" != "$1" ]; then
 	if [ ! -e "/usr/bin/php$1" ]; then
 		sudo DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:ondrej/php -y >/dev/null 2>&1
@@ -9,13 +29,22 @@ if [ "$existing_version" != "$1" ]; then
 		else
 		  sudo DEBIAN_FRONTEND=noninteractive apt install -y php"$1" php"$1"-dev curl php"$1"-curl >/dev/null 2>&1
 		fi
+		status="Installed PHP$version"
 	fi
+
+
 	for tool in php phar phar.phar php-cgi php-config phpize; do
 		if [ -e "/usr/bin/$tool$1" ]; then
-			sudo update-alternatives --set $tool /usr/bin/"$tool$1" &
+			sudo update-alternatives --set $tool /usr/bin/"$tool$1" >/dev/null 2>&1 &
 		fi
 	done
-fi	
+fi
+
+ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+ext_dir=$(php -i | grep "extension_dir => /usr" | sed -e "s|.*=> s*||")
+sudo chmod 777 "$ini_file"
+sudo mkdir -p /run/php
+add_log "$tick" "PHP" "$status"
 
 if [ ! -e "/usr/bin/composer" ]; then
 	curl -s -L https://getcomposer.org/installer > composer-setup.php
@@ -27,28 +56,22 @@ if [ ! -e "/usr/bin/composer" ]; then
 	fi
 	rm composer-setup.php	
 fi
-
 composer global require hirak/prestissimo >/dev/null 2>&1
-ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
-ext_dir=$(php -i | grep "extension_dir => /usr" | sed -e "s|.*=> s*||")
-sudo chmod 777 "$ini_file"
-sudo mkdir -p /run/php
-php -v
-composer -V
+add_log "$tick" "Composer" "Installed"
 
 add_extension()
 {
   extension=$1
   install_command=$2
   prefix=$3
-  log_prefix=$4
   if ! php -m | grep -i -q "$extension" && [ -e "$ext_dir/$extension.so" ]; then
-    echo "$prefix=$extension" >> "$ini_file" && echo "\033[32;1m$log_prefix: Enabled $extension\033[0m";
+    echo "$prefix=$extension" >> "$ini_file" && add_log "$tick" "$extension" "Enabled"
   elif php -m | grep -i -q "$extension"; then
-    echo "\033[33;1m$log_prefix: $extension was already enabled\033[0m";
+    add_log "$tick" "$extension" "Enabled"
   elif ! php -m | grep -i -q "$extension"; then
-      eval "$install_command" && \
-      echo "\033[32;1m$log_prefix: Installed and enabled $extension\033[0m" || \
-      echo "\033[31;1m$log_prefix: Could not find php$version-$extension on APT repository\033[0m";
+      (
+        eval "$install_command" && \
+        add_log "$tick" "$extension" "Installed and enabled"
+      ) || add_log "$cross" "$extension" "Could not find php$version-$extension"
   fi
 }


### PR DESCRIPTION
- Improve logs.
- Shift from `Write-Host ` to `printf` on `windows` for logging.
- Shift from `echo` to `printf` on `macOS` and `ubuntu` for logging.
- Fix tests to cleanup files created.
- Fix `Xdebug` and `PCOV` installation on `PHP7.4` on ubuntu.
- Bump version to 1.4.3.