### PR TITLE
PHP 7.4RC4, pdo_* extensions and test workflow.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,16 +24,20 @@ jobs:
     - name: Installing NPM packages
       run: npm install  
 
-    - name: Run tests and send coverage
-      run: |
-        npm test
-        curl -s https://codecov.io/bash | bash -s -- -t ${{secrets.CODECOV_TOKEN}} -f coverage/clover.xml -n github-actions-codecov-${{ matrix.operating-system }}-php${{ matrix.php-versions }}
+    - name: Run tests
+      run: npm test
+
+    - name: Send Coverage
+      continue-on-error: true
+      timeout-minutes: 2
+      shell: pwsh
+      run: curl -s https://codecov.io/bash | bash -s -- -t ${{secrets.CODECOV_TOKEN}} -f coverage/clover.xml -n github-actions-codecov-${{ matrix.operating-system }}-php${{ matrix.php-versions }}
 
     - name: Installing PHP with extensions and custom config
       run: node lib/install.js
       env:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring, xdebug, pcov, pdo_mysql #optional
+        extension-csv: mbstring, xdebug, pcov #optional
         ini-values-csv: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
 
     - name: Testing PHP version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,7 +33,7 @@ jobs:
       run: node lib/install.js
       env:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring, xdebug, pcov #optional
+        extension-csv: mbstring, xdebug, pcov, pdo_mysql #optional
         ini-values-csv: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
 
     - name: Testing PHP version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,7 +33,7 @@ jobs:
       shell: pwsh
       run: curl -s https://codecov.io/bash | bash -s -- -t ${{secrets.CODECOV_TOKEN}} -f coverage/clover.xml -n github-actions-codecov-${{ matrix.operating-system }}-php${{ matrix.php-versions }}
 
-    - name: Installing PHP with extensions and custom config
+    - name: Setup PHP with extensions and custom config
       run: node lib/install.js
       env:
         php-version: ${{ matrix.php-versions }}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Setup PHP with required extensions, php.ini configuration and composer in [GitHu
 |7.1|`Stable`|`Security fixes only`|
 |7.2|`Stable`|`Active`|
 |7.3|`Stable`|`Active`|
-|7.4|`RC3`|`Active`|
+|7.4|`RC3`/`RC4`|`Active`|
 
 **Note:** PHP 7.4 is currently in development, do not use in production/release branches.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See [action.yml](action.yml "Metadata for this GitHub Action") and usage below f
 steps:
 - name: Checkout
   uses: actions/checkout@master
-- name: Installing PHP
+- name: Setup PHP
   uses: shivammathur/setup-php@master
   with:
     php-version: '7.3'
@@ -138,7 +138,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Install PHP
+    - name: Setup PHP
       uses: shivammathur/setup-php@master
       with:
         php-version: ${{ matrix.php-versions }}
@@ -186,7 +186,7 @@ Contributions are welcome! See [Contributor's Guide](.github/CONTRIBUTING.md "sh
 ## :sparkling_heart: Support this project
 
 - Please star the project and share it.
-- Consider supporting on <a href="https://www.patreon.com/shivammathur"><img alt="Support me on Patreon" src="https://shivammathur.com/badges/patreon.svg"></a> and <a href="https://www.paypal.me/shivammathur"><img alt="Support me on Paypal" src="https://shivammathur.com/badges/paypal.svg"></a>.
+- Please support on <a href="https://www.patreon.com/shivammathur"><img alt="Support me on Patreon" src="https://shivammathur.com/badges/patreon.svg"></a> and <a href="https://www.paypal.me/shivammathur"><img alt="Support me on Paypal" src="https://shivammathur.com/badges/paypal.svg"></a>.
 
 ## :bookmark: This action uses the following works
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -139,7 +139,9 @@ function extensionArray(extension_csv) {
                     return extension
                         .trim()
                         .replace('php-', '')
-                        .replace('php_', '');
+                        .replace('php_', '')
+                        .replace('pdo_', '')
+                        .replace('pdo-', '');
                 });
         }
     });

--- a/src/scripts/7.4.sh
+++ b/src/scripts/7.4.sh
@@ -16,7 +16,7 @@ add_log() {
     printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
   fi
 }
-version='7.4.0RC3'
+version='7.4.0RC4'
 step_log "Setup dependencies"
 for package in pkg-config autoconf bison re2c openssl@1.1 krb5 enchant libffi freetype intltool icu4c libiconv t1lib gd libzip gmp tidyp libxml2 libxslt postgresql curl;
 do

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,7 +140,9 @@ export async function extensionArray(
         return extension
           .trim()
           .replace('php-', '')
-          .replace('php_', '');
+          .replace('php_', '')
+          .replace('pdo_', '')
+          .replace('pdo-', '');
       });
   }
 }


### PR DESCRIPTION
- Switch to `PHP7.4RC4` on `windows` and `macOS`
- Add support for extensions with pdo prefix like `pdo_mysql` and `pdo_sqlite`. Fixes #61 
- Fix test workflow to timeout `codecov` command