### PR TITLE
1.4.5

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,10 +16,10 @@ jobs:
       with:
         fetch-depth: 1
 
-    - name: Setup Node.js 10.x
+    - name: Setup Node.js 12.x
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 12.x
 
     - name: Installing NPM packages
       run: npm install  

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Setup PHP with required extensions, php.ini configuration and composer in [GitHu
 |7.1|`Stable`|`Security fixes only`|
 |7.2|`Stable`|`Active`|
 |7.3|`Stable`|`Active`|
-|7.4|`RC3`/`RC4`|`Active`|
+|7.4|`RC4`|`Active`|
 
 **Note:** PHP 7.4 is currently in development, do not use in production/release branches.
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -24,7 +24,7 @@ describe('Config tests', () => {
       true
     );
     expect(linux).toContain(
-      'echo "post_max_size=256M\nshort_open_tag=On\ndate.timezone=Asia/Kolkata" >> $ini_file'
+      'echo "post_max_size=256M\nshort_open_tag=On\ndate.timezone=Asia/Kolkata"'
     );
 
     linux = await config.addINIValues(
@@ -40,7 +40,7 @@ describe('Config tests', () => {
       'darwin'
     );
     expect(darwin).toContain(
-      'echo "post_max_size=256M\nshort_open_tag=On\ndate.timezone=Asia/Kolkata" >> $ini_file'
+      'echo "post_max_size=256M\nshort_open_tag=On\ndate.timezone=Asia/Kolkata"'
     );
 
     darwin = await config.addINIValues(

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -47,16 +47,16 @@ describe('Extension tests', () => {
     );
 
     linux = await extensions.addExtension('xdebug, pcov', '7.4', 'linux');
-    expect(linux).toContain('./xdebug.sh');
-    expect(linux).toContain('./pcov.sh');
+    expect(linux).toContain('xdebug.sh');
+    expect(linux).toContain('pcov.sh');
 
     linux = await extensions.addExtension('phalcon3, phalcon4', '7.2', 'linux');
-    expect(linux).toContain('./phalcon.sh master 7.2');
-    expect(linux).toContain('./phalcon.sh 4.0.x 7.2');
+    expect(linux).toContain('phalcon.sh master 7.2');
+    expect(linux).toContain('phalcon.sh 4.0.x 7.2');
 
     linux = await extensions.addExtension('phalcon3, phalcon4', '7.3', 'linux');
-    expect(linux).toContain('./phalcon.sh master 7.3');
-    expect(linux).toContain('./phalcon.sh 4.0.x 7.3');
+    expect(linux).toContain('phalcon.sh master 7.3');
+    expect(linux).toContain('phalcon.sh 4.0.x 7.3');
 
     linux = await extensions.addExtension('xdebug', '7.2', 'fedora');
     expect(linux).toContain('Platform fedora is not supported');
@@ -81,10 +81,10 @@ describe('Extension tests', () => {
     expect(darwin).toContain('sudo pecl install xdebug-2.5.5');
 
     darwin = await extensions.addExtension('xdebug', '7.4', 'darwin');
-    expect(darwin).toContain('sh ./xdebug_darwin.sh');
+    expect(darwin).toContain('xdebug_darwin.sh');
 
     darwin = await extensions.addExtension('pcov', '7.4', 'darwin');
-    expect(darwin).toContain('sh ./pcov.sh');
+    expect(darwin).toContain('pcov.sh');
 
     darwin = await extensions.addExtension('xdebug', '7.2', 'darwin');
     expect(darwin).toContain('sudo pecl install xdebug');

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -61,23 +61,17 @@ describe('Utils tests', () => {
     expect(await utils.readScript('fedora.sh', '7.3', 'fedora')).toContain(
       'Platform fedora is not supported'
     );
-    await cleanup('./config.yaml');
-    await cleanup('./pcov.sh');
-    await cleanup('./phalcon.sh');
-    await cleanup('./php_pcov.dll');
-    await cleanup('./xdebug_darwin.sh');
   });
 
   it('checking writeScripts', async () => {
     let testString: string = 'sudo apt-get install php';
-    await utils.writeScript('test.sh', '10', testString);
-    await fs.readFile(path.join(__dirname, '../10test.sh'), function(
-      error: any,
-      data: Buffer
-    ) {
+    let runner_dir: string = process.env['RUNNER_TOOL_CACHE'] || '';
+    let script_path: string = path.join(runner_dir, 'test.sh');
+    await utils.writeScript('test.sh', testString);
+    await fs.readFile(script_path, function(error: any, data: Buffer) {
       expect(testString).toBe(data.toString());
     });
-    await cleanup('./10test.sh');
+    await cleanup(script_path);
   });
 
   it('checking extensionArray', async () => {

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: 'Setup PHP Action'
+name: 'Setup PHP for use with GitHub Actions'
 author: shivammathur
 description: 'GitHub action to setup PHP with required extensions, php.ini configuration, code-coverage support and composer'
 branding:
-  icon: 'activity'  
+  icon: 'play'
   color: 'purple'
 inputs:
   php-version:

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -16,6 +16,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const path = __importStar(require("path"));
 const utils = __importStar(require("./utils"));
 /**
  * Install and enable extensions
@@ -70,11 +71,15 @@ function addExtensionDarwin(extension_csv, version) {
                 switch (version + extension) {
                     case '7.4xdebug':
                         install_command =
-                            'sh ./xdebug_darwin.sh >/dev/null 2>&1 && echo "zend_extension=xdebug.so" >> $ini_file';
+                            'sh ' +
+                                path.join(__dirname, '../src/scripts/xdebug_darwin.sh') +
+                                ' >/dev/null 2>&1 && echo "zend_extension=xdebug.so" >> $ini_file';
                         break;
                     case '7.4pcov':
                         install_command =
-                            'sh ./pcov.sh >/dev/null 2>&1 && echo "extension=pcov.so" >> $ini_file';
+                            'sh ' +
+                                path.join(__dirname, '../src/scripts/pcov.sh') +
+                                ' >/dev/null 2>&1 && echo "extension=pcov.so" >> $ini_file';
                         break;
                     case '5.6xdebug':
                         install_command = 'sudo pecl install xdebug-2.5.5 >/dev/null 2>&1';
@@ -156,19 +161,34 @@ function addExtensionLinux(extension_csv, version) {
                 switch (version + extension) {
                     case '7.4xdebug':
                         install_command =
-                            './xdebug.sh >/dev/null 2>&1 && echo "zend_extension=xdebug.so" >> $ini_file';
+                            'sh ' +
+                                path.join(__dirname, '../src/scripts/xdebug.sh') +
+                                ' >/dev/null 2>&1 && echo "zend_extension=xdebug.so" >> $ini_file';
                         break;
                     case '7.4pcov':
                         install_command =
-                            './pcov.sh >/dev/null 2>&1 && echo "extension=pcov.so" >> $ini_file';
+                            'sh ' +
+                                path.join(__dirname, '../src/scripts/pcov.sh') +
+                                ' >/dev/null 2>&1 && echo "extension=pcov.so" >> $ini_file';
                         break;
                     case '7.2phalcon3':
                     case '7.3phalcon3':
-                        install_command = './phalcon.sh master ' + version + ' >/dev/null 2>&1';
+                        install_command =
+                            'sh ' +
+                                path.join(__dirname, '../src/scripts/phalcon.sh') +
+                                ' master ' +
+                                version +
+                                ' >/dev/null 2>&1';
                         break;
                     case '7.2phalcon4':
                     case '7.3phalcon4':
-                        install_command = './phalcon.sh 4.0.x ' + version + ' >/dev/null 2>&1';
+                    case '7.4phalcon4':
+                        install_command =
+                            'sh ' +
+                                path.join(__dirname, '../src/scripts/phalcon.sh') +
+                                ' 4.0.x ' +
+                                version +
+                                ' >/dev/null 2>&1';
                         break;
                     default:
                         install_command =

--- a/lib/install.js
+++ b/lib/install.js
@@ -18,10 +18,10 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const exec_1 = require("@actions/exec/lib/exec");
 const core = __importStar(require("@actions/core"));
-const utils = __importStar(require("./utils"));
-const extensions = __importStar(require("./extensions"));
 const config = __importStar(require("./config"));
 const coverage = __importStar(require("./coverage"));
+const extensions = __importStar(require("./extensions"));
+const utils = __importStar(require("./utils"));
 /**
  * Build the script
  *
@@ -45,7 +45,7 @@ function build(filename, version, os_version) {
         if (coverage_driver) {
             script += yield coverage.addCoverage(coverage_driver, version, os_version);
         }
-        yield utils.writeScript(filename, version, script);
+        return yield utils.writeScript(filename, script);
     });
 }
 /**
@@ -58,16 +58,16 @@ function run() {
             let version = yield utils.getInput('php-version', true);
             // check the os version and run the respective script
             if (os_version == 'darwin') {
-                yield build('darwin.sh', version, os_version);
-                yield exec_1.exec('sh ./' + version + 'darwin.sh ' + version);
+                let script_path = yield build('darwin.sh', version, os_version);
+                yield exec_1.exec('sh ' + script_path + ' ' + version + ' ' + __dirname);
             }
             else if (os_version == 'win32') {
-                yield build('win32.ps1', version, os_version);
-                yield exec_1.exec('pwsh .\\' + version + 'win32.ps1 -version ' + version);
+                let script_path = yield build('win32.ps1', version, os_version);
+                yield exec_1.exec('pwsh ' + script_path + ' -version ' + version + ' -dir ' + __dirname);
             }
             else if (os_version == 'linux') {
-                yield build('linux.sh', version, os_version);
-                yield exec_1.exec('./' + version + 'linux.sh ' + version);
+                let script_path = yield build('linux.sh', version, os_version);
+                yield exec_1.exec('sh ' + script_path + ' ' + version + ' ' + __dirname);
             }
         }
         catch (error) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,19 +54,6 @@ function asyncForEach(array, callback) {
 }
 exports.asyncForEach = asyncForEach;
 /**
- * Copy config
- *
- * @param files
- */
-function moveFiles(files) {
-    return __awaiter(this, void 0, void 0, function* () {
-        yield asyncForEach(files, function (filename) {
-            fs.createReadStream(path.join(__dirname, '../src/' + filename)).pipe(fs.createWriteStream(filename.split('/')[1], { mode: 0o755 }));
-        });
-    });
-}
-exports.moveFiles = moveFiles;
-/**
  * Read the scripts
  *
  * @param filename
@@ -79,34 +66,15 @@ function readScript(filename, version, os_version) {
             case 'darwin':
                 switch (version) {
                     case '7.4':
-                        yield moveFiles([
-                            'configs/config.yaml',
-                            'scripts/xdebug_darwin.sh',
-                            'scripts/pcov.sh'
-                        ]);
                         return fs.readFileSync(path.join(__dirname, '../src/scripts/7.4.sh'), 'utf8');
                 }
-                break;
+                return fs.readFileSync(path.join(__dirname, '../src/scripts/' + filename), 'utf8');
             case 'linux':
-                let files = ['scripts/phalcon.sh'];
-                switch (version) {
-                    case '7.4':
-                        files = files.concat(['scripts/xdebug.sh', 'scripts/pcov.sh']);
-                        break;
-                }
-                yield moveFiles(files);
-                break;
             case 'win32':
-                switch (version) {
-                    case '7.4':
-                        yield moveFiles(['ext/php_pcov.dll']);
-                        break;
-                }
-                break;
+                return fs.readFileSync(path.join(__dirname, '../src/scripts/' + filename), 'utf8');
             default:
                 return yield log('Platform ' + os_version + ' is not supported', os_version, 'error');
         }
-        return fs.readFileSync(path.join(__dirname, '../src/scripts/' + filename), 'utf8');
     });
 }
 exports.readScript = readScript;
@@ -117,9 +85,12 @@ exports.readScript = readScript;
  * @param version
  * @param script
  */
-function writeScript(filename, version, script) {
+function writeScript(filename, script) {
     return __awaiter(this, void 0, void 0, function* () {
-        fs.writeFileSync(version + filename, script, { mode: 0o755 });
+        let runner_dir = yield getInput('RUNNER_TOOL_CACHE', false);
+        let script_path = path.join(runner_dir, filename);
+        fs.writeFileSync(script_path, script, { mode: 0o755 });
+        return script_path;
     });
 }
 exports.writeScript = writeScript;

--- a/node_modules/@actions/core/package.json
+++ b/node_modules/@actions/core/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "@actions/core@1.2.0",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "@actions/core@1.2.0",
@@ -28,7 +28,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.0.tgz",
   "_spec": "1.2.0",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "bugs": {
     "url": "https://github.com/actions/toolkit/issues"
   },

--- a/node_modules/@actions/exec/package.json
+++ b/node_modules/@actions/exec/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "@actions/exec@1.0.1",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "@actions/exec@1.0.1",
@@ -27,7 +27,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.1.tgz",
   "_spec": "1.0.1",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "bugs": {
     "url": "https://github.com/actions/toolkit/issues"
   },

--- a/node_modules/@actions/io/package.json
+++ b/node_modules/@actions/io/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "@actions/io@1.0.1",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "@actions/io@1.0.1",
@@ -27,7 +27,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.1.tgz",
   "_spec": "1.0.1",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "bugs": {
     "url": "https://github.com/actions/toolkit/issues"
   },

--- a/node_modules/@actions/tool-cache/package.json
+++ b/node_modules/@actions/tool-cache/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "@actions/tool-cache@1.1.2",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "@actions/tool-cache@1.1.2",
@@ -27,7 +27,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.1.2.tgz",
   "_spec": "1.1.2",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "bugs": {
     "url": "https://github.com/actions/toolkit/issues"
   },

--- a/node_modules/fs/package.json
+++ b/node_modules/fs/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "fs@0.0.1-security",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "fs@0.0.1-security",
@@ -26,7 +26,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
   "_spec": "0.0.1-security",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "author": "",
   "bugs": {
     "url": "https://github.com/npm/security-holder/issues"

--- a/node_modules/semver/package.json
+++ b/node_modules/semver/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "semver@6.3.0",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "semver@6.3.0",
@@ -28,7 +28,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
   "_spec": "6.3.0",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "bin": {
     "semver": "./bin/semver.js"
   },

--- a/node_modules/semver/package.json
+++ b/node_modules/semver/package.json
@@ -23,8 +23,10 @@
   },
   "_requiredBy": [
     "/@actions/tool-cache",
+    "/eslint-plugin-compat",
     "/istanbul-lib-instrument",
-    "/jest-snapshot"
+    "/jest-snapshot",
+    "/node-releases"
   ],
   "_resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
   "_spec": "6.3.0",

--- a/node_modules/tunnel/package.json
+++ b/node_modules/tunnel/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "tunnel@0.0.4",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "tunnel@0.0.4",
@@ -26,7 +26,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
   "_spec": "0.0.4",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "author": {
     "name": "Koichi Kobayashi",
     "email": "koichik@improvement.jp"

--- a/node_modules/typed-rest-client/package.json
+++ b/node_modules/typed-rest-client/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "typed-rest-client@1.5.0",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "typed-rest-client@1.5.0",
@@ -26,7 +26,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.5.0.tgz",
   "_spec": "1.5.0",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/node_modules/underscore/package.json
+++ b/node_modules/underscore/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "underscore@1.8.3",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "underscore@1.8.3",
@@ -26,7 +26,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
   "_spec": "1.8.3",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "author": {
     "name": "Jeremy Ashkenas",
     "email": "jeremy@documentcloud.org"

--- a/node_modules/uuid/package.json
+++ b/node_modules/uuid/package.json
@@ -2,7 +2,7 @@
   "_args": [
     [
       "uuid@3.3.3",
-      "E:\\python\\setup-php"
+      "C:\\wamp64\\www\\setup-php"
     ]
   ],
   "_from": "uuid@3.3.3",
@@ -27,7 +27,7 @@
   ],
   "_resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
   "_spec": "3.3.3",
-  "_where": "E:\\python\\setup-php",
+  "_where": "C:\\wamp64\\www\\setup-php",
   "bin": {
     "uuid": "./bin/uuid"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -182,6 +182,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
@@ -525,9 +534,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.19",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.19.tgz",
-      "integrity": "sha512-YYiqfSjocv7lk5H/T+v5MjATYjaTMsUkbDnjGqSMoO88jWdtJXJV4ST/7DKZcoMHMBvB2SeSfyOzZfkxXHR5xg==",
+      "version": "24.0.20",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.20.tgz",
+      "integrity": "sha512-M8ebEkOpykGdLoRrmew7UowTZ1DANeeP0HiSIChl/4DGgmnSC1ntitNtkyNSXjMTsZvXuaxJrxjImEnRWNPsPw==",
       "dev": true,
       "requires": {
         "@types/jest-diff": "*"
@@ -709,6 +718,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "ast-metadata-inferer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz",
+      "integrity": "sha512-hc9w8Qrgg9Lf9iFcZVhNjUnhrd2BBpTlyCnegPVvCe6O0yMrF57a6Cmh7k+xUsfUOMh9wajOL5AsGOBNEyTCcw==",
       "dev": true
     },
     "astral-regex": {
@@ -933,6 +948,17 @@
         }
       }
     },
+    "browserslist": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
+      "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001004",
+        "electron-to-chromium": "^1.3.295",
+        "node-releases": "^1.1.38"
+      }
+    },
     "bs-logger": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
@@ -1002,6 +1028,18 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-db": {
+      "version": "1.0.30001005",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001005.tgz",
+      "integrity": "sha512-MSRfm2N6FRDSpAJ00ipCuFe0CNink5JJOFzl4S7fLSBJdowhGq3uMxzkWGTjvvReo1PuWfK5YYJydJJ+9mJebw==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001005",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001005.tgz",
+      "integrity": "sha512-g78miZm1Z5njjYR216a5812oPiLgV1ssndgGxITHWUopmjUrCswMisA0a2kSB7a0vZRox6JOKhM51+efmYN8Mg==",
       "dev": true
     },
     "capture-exit": {
@@ -1345,6 +1383,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.296",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.296.tgz",
+      "integrity": "sha512-s5hv+TSJSVRsxH190De66YHb50pBGTweT9XGWYu/LMR20KX6TsjFzObo36CjVAzM+PUeeKSBRtm/mISlCzeojQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -1423,6 +1467,21 @@
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-compat": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.3.0.tgz",
+      "integrity": "sha512-QCgYy3pZ+zH10dkBJus1xER0359h1UhJjufhQRqp9Owm6BEoLZeSqxf2zINwL1OGao9Yc96xPYIW3nQj5HUryg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "ast-metadata-inferer": "^0.1.1",
+        "browserslist": "^4.6.3",
+        "caniuse-db": "^1.0.30000977",
+        "lodash.memoize": "4.1.2",
+        "mdn-browser-compat-data": "^0.0.84",
+        "semver": "^6.1.2"
       }
     },
     "esprima": {
@@ -1739,8 +1798,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2155,8 +2213,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2212,7 +2269,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2256,14 +2312,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2342,11 +2396,12 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.0.tgz",
+      "integrity": "sha512-yss1ZbupTpRfe86dpM1abxnnSfxa6eIRn3laqBPIgRYy87qgYtX6xinSOeybjYo/4AVzdTTWK5Kr06A6AllxJg==",
       "dev": true,
       "requires": {
+        "eslint-plugin-compat": "^3.3.0",
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
@@ -3552,6 +3607,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "mdn-browser-compat-data": {
+      "version": "0.0.84",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.84.tgz",
+      "integrity": "sha512-fAznuGNaQMQiWLVf+gyp33FaABTglYWqMT7JqvH+4RZn2UQPD12gbMqxwP9m0lj8AAbNpu5/kD6n4Ox1SOffpw==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.2"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3728,6 +3792,15 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
+      }
+    },
+    "node-releases": {
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
+      "integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
       }
     },
     "normalize-package-data": {
@@ -4213,6 +4286,12 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -4632,9 +4711,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.15.tgz",
+      "integrity": "sha512-wYF5aX1J0+V51BDT3Om7uXNn0ct2FWiV4bvwiGVefxkm+1S1o5jsecE5lb2U28DDblzxzxeIDbTVpXHI9D/9hA==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "setup-php",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": false,
-  "description": "Setup php action",
+  "description": "Setup PHP for use with GitHub Actions",
   "main": "lib/setup-php.js",
   "scripts": {
     "build": "tsc",

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as utils from './utils';
 
 /**
@@ -62,11 +63,15 @@ export async function addExtensionDarwin(
     switch (version + extension) {
       case '7.4xdebug':
         install_command =
-          'sh ./xdebug_darwin.sh >/dev/null 2>&1 && echo "zend_extension=xdebug.so" >> $ini_file';
+          'sh ' +
+          path.join(__dirname, '../src/scripts/xdebug_darwin.sh') +
+          ' >/dev/null 2>&1 && echo "zend_extension=xdebug.so" >> $ini_file';
         break;
       case '7.4pcov':
         install_command =
-          'sh ./pcov.sh >/dev/null 2>&1 && echo "extension=pcov.so" >> $ini_file';
+          'sh ' +
+          path.join(__dirname, '../src/scripts/pcov.sh') +
+          ' >/dev/null 2>&1 && echo "extension=pcov.so" >> $ini_file';
         break;
       case '5.6xdebug':
         install_command = 'sudo pecl install xdebug-2.5.5 >/dev/null 2>&1';
@@ -149,19 +154,34 @@ export async function addExtensionLinux(
     switch (version + extension) {
       case '7.4xdebug':
         install_command =
-          './xdebug.sh >/dev/null 2>&1 && echo "zend_extension=xdebug.so" >> $ini_file';
+          'sh ' +
+          path.join(__dirname, '../src/scripts/xdebug.sh') +
+          ' >/dev/null 2>&1 && echo "zend_extension=xdebug.so" >> $ini_file';
         break;
       case '7.4pcov':
         install_command =
-          './pcov.sh >/dev/null 2>&1 && echo "extension=pcov.so" >> $ini_file';
+          'sh ' +
+          path.join(__dirname, '../src/scripts/pcov.sh') +
+          ' >/dev/null 2>&1 && echo "extension=pcov.so" >> $ini_file';
         break;
       case '7.2phalcon3':
       case '7.3phalcon3':
-        install_command = './phalcon.sh master ' + version + ' >/dev/null 2>&1';
+        install_command =
+          'sh ' +
+          path.join(__dirname, '../src/scripts/phalcon.sh') +
+          ' master ' +
+          version +
+          ' >/dev/null 2>&1';
         break;
       case '7.2phalcon4':
       case '7.3phalcon4':
-        install_command = './phalcon.sh 4.0.x ' + version + ' >/dev/null 2>&1';
+      case '7.4phalcon4':
+        install_command =
+          'sh ' +
+          path.join(__dirname, '../src/scripts/phalcon.sh') +
+          ' 4.0.x ' +
+          version +
+          ' >/dev/null 2>&1';
         break;
       default:
         install_command =

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,9 +1,10 @@
 import {exec} from '@actions/exec/lib/exec';
 import * as core from '@actions/core';
-import * as utils from './utils';
-import * as extensions from './extensions';
+import * as path from 'path';
 import * as config from './config';
 import * as coverage from './coverage';
+import * as extensions from './extensions';
+import * as utils from './utils';
 
 /**
  * Build the script
@@ -12,7 +13,11 @@ import * as coverage from './coverage';
  * @param version
  * @param os_version
  */
-async function build(filename: string, version: string, os_version: string) {
+async function build(
+  filename: string,
+  version: string,
+  os_version: string
+): Promise<string> {
   // taking inputs
   let extension_csv: string = await utils.getInput('extension-csv', false);
   let ini_values_csv: string = await utils.getInput('ini-values-csv', false);
@@ -28,7 +33,8 @@ async function build(filename: string, version: string, os_version: string) {
   if (coverage_driver) {
     script += await coverage.addCoverage(coverage_driver, version, os_version);
   }
-  await utils.writeScript(filename, version, script);
+
+  return await utils.writeScript(filename, script);
 }
 
 /**
@@ -40,14 +46,16 @@ async function run() {
     let version: string = await utils.getInput('php-version', true);
     // check the os version and run the respective script
     if (os_version == 'darwin') {
-      await build('darwin.sh', version, os_version);
-      await exec('sh ./' + version + 'darwin.sh ' + version);
+      let script_path: string = await build('darwin.sh', version, os_version);
+      await exec('sh ' + script_path + ' ' + version + ' ' + __dirname);
     } else if (os_version == 'win32') {
-      await build('win32.ps1', version, os_version);
-      await exec('pwsh .\\' + version + 'win32.ps1 -version ' + version);
+      let script_path: string = await build('win32.ps1', version, os_version);
+      await exec(
+        'pwsh ' + script_path + ' -version ' + version + ' -dir ' + __dirname
+      );
     } else if (os_version == 'linux') {
-      await build('linux.sh', version, os_version);
-      await exec('./' + version + 'linux.sh ' + version);
+      let script_path: string = await build('linux.sh', version, os_version);
+      await exec('sh ' + script_path + ' ' + version + ' ' + __dirname);
     }
   } catch (error) {
     core.setFailed(error.message);

--- a/src/scripts/7.4.sh
+++ b/src/scripts/7.4.sh
@@ -58,7 +58,7 @@ echo 'export EXTRA_LIBS="/usr/local/opt/readline/lib/libhistory.dylib
 /usr/local/opt/icu4c/lib/libicutu.dylib
 /usr/local/opt/icu4c/lib/libicuuc.dylib"'
 } >> ~/.bash_profile
-config_file=$(pwd)/config.yaml
+config_file=$2/../src/configs/config.yaml
 
 step_log "Setup PHPBrew"
 curl -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew >/dev/null 2>&1

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -34,7 +34,7 @@ if [ "$existing_version" != "$1" ]; then
 
 	for tool in php phar phar.phar php-cgi php-config phpize; do
 		if [ -e "/usr/bin/$tool$1" ]; then
-			sudo update-alternatives --set $tool /usr/bin/"$tool$1" >/dev/null 2>&1 &
+			sudo update-alternatives --set $tool /usr/bin/"$tool$1" >/dev/null 2>&1
 		fi
 	done
 fi

--- a/src/scripts/pcov.sh
+++ b/src/scripts/pcov.sh
@@ -1,7 +1,5 @@
-git clone --depth=1 https://github.com/krakjoe/pcov.git
-(
+cd ~ && git clone --depth=1 https://github.com/krakjoe/pcov.git
 cd pcov && phpize
 ./configure --enable-pcov
 make
 sudo make install
-)

--- a/src/scripts/phalcon.sh
+++ b/src/scripts/phalcon.sh
@@ -1,19 +1,21 @@
 ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
-sudo DEBIAN_FRONTEND=noninteractive apt install php"$2"-dev php-pear -y
+sudo DEBIAN_FRONTEND=noninteractive apt install php"$2"-dev -y
 for tool in php-config phpize; do
   if [ -e "/usr/bin/$tool$2" ]; then
-    sudo update-alternatives --set $tool /usr/bin/"$tool$2" &
+    sudo update-alternatives --set $tool /usr/bin/"$tool$2"
   fi
 done
-sudo pecl config-set php_ini "$ini_file"
-sudo pear config-set php_ini "$ini_file"
-sudo pecl install psr
+
+cd ~ && git clone --depth=1 https://github.com/jbboehr/php-psr.git
+cd php-psr && sudo /usr/bin/phpize"$2"
+./configure --with-php-config=/usr/bin/php-config"$2"
+make -j2 && sudo make -j2 install
+echo "extension=psr.so" >> "$ini_file"
+
 if [ "$1" = "master" ]; then
   sudo DEBIAN_FRONTEND=noninteractive apt install php"$2"-phalcon -y
 else
-  git clone --depth=1 -v https://github.com/phalcon/cphalcon.git -b "$1"
-  (
-    cd cphalcon/build && sudo ./install --phpize /usr/bin/phpize"$2" --php-config /usr/bin/php-config"$2"
-    echo "extension=phalcon.so" >> "$ini_file"
-  )
+  cd ~ && git clone --depth=1 -v https://github.com/phalcon/cphalcon.git -b "$1"
+  cd cphalcon/build && sudo ./install --phpize /usr/bin/phpize"$2" --php-config /usr/bin/php-config"$2"
+  echo "extension=phalcon.so" >> "$ini_file"
 fi

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$version = "7.3"  
+    [Parameter(Mandatory=$true)][string]$version = "7.3",
+    [Parameter(Mandatory=$true)][string]$dir
 )
 
 $tick = ([char]8730)
@@ -41,7 +42,7 @@ if($version -lt '7.4') {
   Enable-PhpExtension curl
 } else {
   Add-Content C:\tools\php\php.ini "extension=php_openssl.dll`nextension=php_curl.dll"
-  Copy-Item "php_pcov.dll" -Destination $ext_dir"\php_pcov.dll"
+  Copy-Item $dir"\..\src\ext\php_pcov.dll" -Destination $ext_dir"\php_pcov.dll"
 }
 Add-Log $tick "PHP" $status
 

--- a/src/scripts/xdebug.sh
+++ b/src/scripts/xdebug.sh
@@ -1,5 +1,3 @@
-git clone --depth=1 https://github.com/xdebug/xdebug.git
-(
-  cd xdebug || echo "cd failed"
-  sudo ./rebuild.sh
-)
+cd ~ && git clone --depth=1 https://github.com/xdebug/xdebug.git
+cd xdebug || echo "Failed to clone Xdebug"
+sudo ./rebuild.sh

--- a/src/scripts/xdebug_darwin.sh
+++ b/src/scripts/xdebug_darwin.sh
@@ -1,8 +1,6 @@
-git clone --depth=1 https://github.com/xdebug/xdebug.git
-(
-  cd xdebug || echo "cd failed"
-  sudo phpize
-  sudo ./configure
-  sudo make
-  sudo cp modules/xdebug.so "$(php -i | grep "extension_dir => /opt" | sed -e "s|.*=> s*||")"
-)
+cd ~ && git clone --depth=1 https://github.com/xdebug/xdebug.git
+cd xdebug || echo "Failed to clone Xdebug"
+sudo phpize
+sudo ./configure
+sudo make
+sudo cp modules/xdebug.so "$(php -i | grep "extension_dir => /opt" | sed -e "s|.*=> s*||")"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,19 +39,6 @@ export async function asyncForEach(
 }
 
 /**
- * Copy config
- *
- * @param files
- */
-export async function moveFiles(files: Array<string>) {
-  await asyncForEach(files, function(filename: string) {
-    fs.createReadStream(path.join(__dirname, '../src/' + filename)).pipe(
-      fs.createWriteStream(filename.split('/')[1], {mode: 0o755})
-    );
-  });
-}
-
-/**
  * Read the scripts
  *
  * @param filename
@@ -67,33 +54,21 @@ export async function readScript(
     case 'darwin':
       switch (version) {
         case '7.4':
-          await moveFiles([
-            'configs/config.yaml',
-            'scripts/xdebug_darwin.sh',
-            'scripts/pcov.sh'
-          ]);
           return fs.readFileSync(
             path.join(__dirname, '../src/scripts/7.4.sh'),
             'utf8'
           );
       }
-      break;
+      return fs.readFileSync(
+        path.join(__dirname, '../src/scripts/' + filename),
+        'utf8'
+      );
     case 'linux':
-      let files: Array<string> = ['scripts/phalcon.sh'];
-      switch (version) {
-        case '7.4':
-          files = files.concat(['scripts/xdebug.sh', 'scripts/pcov.sh']);
-          break;
-      }
-      await moveFiles(files);
-      break;
     case 'win32':
-      switch (version) {
-        case '7.4':
-          await moveFiles(['ext/php_pcov.dll']);
-          break;
-      }
-      break;
+      return fs.readFileSync(
+        path.join(__dirname, '../src/scripts/' + filename),
+        'utf8'
+      );
     default:
       return await log(
         'Platform ' + os_version + ' is not supported',
@@ -101,11 +76,6 @@ export async function readScript(
         'error'
       );
   }
-
-  return fs.readFileSync(
-    path.join(__dirname, '../src/scripts/' + filename),
-    'utf8'
-  );
 }
 
 /**
@@ -117,10 +87,12 @@ export async function readScript(
  */
 export async function writeScript(
   filename: string,
-  version: string,
   script: string
-): Promise<any> {
-  fs.writeFileSync(version + filename, script, {mode: 0o755});
+): Promise<string> {
+  let runner_dir: string = await getInput('RUNNER_TOOL_CACHE', false);
+  let script_path: string = path.join(runner_dir, filename);
+  fs.writeFileSync(script_path, script, {mode: 0o755});
+  return script_path;
 }
 
 /**


### PR DESCRIPTION
- Fix custom extension scripts to not clone in working directory. Fixes #65 
- Use files from this action instead of copying. Fixes #65 
- Use `tool-cache` directory to store script for the action. Fixes #65 
- Fix race condition in `linux.sh` to get correct `php.ini`
- Update `node-version` to `12.x` for testing.
- Update action branding.
- Update PHP 7.4 versions in `README.md`
- Add support for PHP 7.4 for `phalcon4`
- Bump version to `1.4.5`