### PR TITLE
Revert to apt for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,14 +186,14 @@ You can persist composer's internal cache directory using the [`action/cache`](h
   run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 - name: Cache on linux and macOS
   if: matrix.operating-system != 'windows-latest'
-  uses: actions/cache@v1        
+  uses: actions/cache@v1
   with:
     path: ${{ steps.composer-cache.outputs.dir }}
     key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
     restore-keys: ${{ runner.os }}-composer-
 - name: Cache on windows
   if: matrix.operating-system == 'windows-latest'
-  uses: actions/cache@v1        
+  uses: actions/cache@v1
   with:
     path: ${{ steps.composer-cache.outputs.dir }}
     key: ${{ runner.os }}-composer-${{ hashFiles('**composer.lock') }}

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -40,10 +40,10 @@ describe('Extension tests', () => {
       'linux'
     );
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php7.2-xdebug'
+      'sudo DEBIAN_FRONTEND=noninteractive apt install -y php7.2-xdebug'
     );
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php7.2-pcov'
+      'sudo DEBIAN_FRONTEND=noninteractive apt install -y php7.2-pcov'
     );
 
     linux = await extensions.addExtension('xdebug, pcov', '7.4', 'linux');

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -192,7 +192,7 @@ function addExtensionLinux(extension_csv, version) {
                         break;
                     default:
                         install_command =
-                            'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php' +
+                            'sudo DEBIAN_FRONTEND=noninteractive apt install -y php' +
                                 version +
                                 '-' +
                                 extension +

--- a/package-lock.json
+++ b/package-lock.json
@@ -1744,7 +1744,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2159,7 +2160,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2215,6 +2217,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2258,12 +2261,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -185,7 +185,7 @@ export async function addExtensionLinux(
         break;
       default:
         install_command =
-          'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php' +
+          'sudo DEBIAN_FRONTEND=noninteractive apt install -y php' +
           version +
           '-' +
           extension +


### PR DESCRIPTION
Revert to `apt` for extensions as `apt-fast` gives exit-code as 0(success) even for errors.
Fixes wrong success messages for extensions which failed to install #71 