### PR TITLE
Add PECL support on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Setup PHP with required extensions, php.ini configuration and composer in [GitHu
 |macOS X Catalina 10.15|`macOS-latest` or `macOS-10.15`|
 
 ## :wrench: PHP Extension Support
-- On `ubuntu` extensions which have the package in apt are installed.
-- On `windows` and `macOS` PECL extensions are installed.
+- On `ubuntu` extensions which have the package in `APT` are installed. If extension is not in `APT`, you can use `PECL` to install the extension as fallback by specifying `pecl: true`. 
+- On `windows` extensions which have `windows` binary on `PECL` can be installed.
+- On `macOS` extensions which are on `PECL` can be installed.
 - Extensions which are installed along with PHP if specified are enabled.
 - Extensions which cannot be installed gracefully leave an error message in the logs, the action is not interrupted.
 
@@ -119,6 +120,7 @@ Inputs supported by this GitHub Action.
 - extension-csv `optional`
 - ini-values-csv `optional`
 - coverage `optional`
+- pecl `optional`
 
 See [action.yml](action.yml "Metadata for this GitHub Action") and usage below for more info.
 
@@ -132,9 +134,10 @@ steps:
   uses: shivammathur/setup-php@master
   with:
     php-version: '7.3'
-    extension-csv: mbstring, xdebug #optional
-    ini-values-csv: post_max_size=256M, short_open_tag=On #optional
-    coverage: xdebug #optional
+    extension-csv: mbstring, xdebug #optional, setup extensions
+    ini-values-csv: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
+    coverage: xdebug #optional, setup coverage driver
+    pecl: true #optional, setup PECL
 - name: Check PHP Version
   run: php -v
 - name: Check Composer Version
@@ -161,10 +164,10 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@master
       with:
-        php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring, xdebug #optional
-        ini-values-csv: post_max_size=256M, short_open_tag=On #optional
-        coverage: xdebug #optional
+        extension-csv: mbstring, xdebug #optional, setup extensions
+        ini-values-csv: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
+        coverage: xdebug #optional, setup coverage driver
+        pecl: true #optional, setup PECL
     - name: Check PHP Version
       run: php -v
     - name: Check Composer Version

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -40,11 +40,13 @@ describe('Extension tests', () => {
       'linux'
     );
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt install -y php7.2-xdebug'
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.2-xdebug'
     );
+    expect(linux).toContain('pecl install xdebug');
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt install -y php7.2-pcov'
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.2-pcov'
     );
+    expect(linux).toContain('pecl install pcov');
 
     linux = await extensions.addExtension('xdebug, pcov', '7.4', 'linux');
     expect(linux).toContain('xdebug.sh');

--- a/__tests__/install.test.ts
+++ b/__tests__/install.test.ts
@@ -35,9 +35,13 @@ jest.mock('../src/install', () => ({
       let script: string = '';
       switch (os_version) {
         case 'darwin':
-        case 'linux':
           script = await install.build(os_version + '.sh', version, os_version);
           script += 'sh script.sh ' + version + ' ' + __dirname;
+          break;
+        case 'linux':
+          let pecl: string = process.env['pecl'] || '';
+          script = await install.build(os_version + '.sh', version, os_version);
+          script += 'sh script.sh ' + version + ' ' + pecl + ' ' + __dirname;
           break;
         case 'win32':
           script = await install.build(os_version + '.sh', version, os_version);
@@ -67,24 +71,26 @@ function setEnv(
   os: string,
   extension_csv: string,
   ini_values_csv: string,
-  coverage_driver: string
+  coverage_driver: string,
+  pecl: any
 ): void {
   process.env['php-version'] = version;
   process.env['RUNNER_OS'] = os;
   process.env['extension-csv'] = extension_csv;
   process.env['ini-values-csv'] = ini_values_csv;
   process.env['coverage'] = coverage_driver;
+  process.env['pecl'] = pecl;
 }
 
 describe('Install', () => {
   it('Test install on windows', async () => {
-    setEnv('7.3', 'win32', '', '', '');
+    setEnv('7.3', 'win32', '', '', '', '');
     // @ts-ignore
     let script: string = await install.run();
     expect(script).toContain('initial script');
     expect(script).toContain('pwsh script.ps1 -version 7.3 -dir ' + __dirname);
 
-    setEnv('7.3', 'win32', 'a, b', 'a=b', 'x');
+    setEnv('7.3', 'win32', 'a, b', 'a=b', 'x', '');
     // @ts-ignore
     script = await install.run();
     expect(script).toContain('initial script');
@@ -95,30 +101,39 @@ describe('Install', () => {
   });
 
   it('Test install on linux', async () => {
-    setEnv('7.3', 'linux', '', '', '');
+    setEnv('7.3', 'linux', '', '', '', '');
     // @ts-ignore
     let script: string = await install.run();
     expect(script).toContain('initial script');
-    expect(script).toContain('sh script.sh 7.3 ' + __dirname);
+    expect(script).toContain('sh script.sh 7.3 ');
 
-    setEnv('7.3', 'linux', 'a, b', 'a=b', 'x');
+    setEnv('7.3', 'linux', 'a, b', 'a=b', 'x', 'true');
     // @ts-ignore
     script = await install.run();
     expect(script).toContain('initial script');
     expect(script).toContain('install extensions');
     expect(script).toContain('edit php.ini');
     expect(script).toContain('set coverage driver');
-    expect(script).toContain('sh script.sh 7.3 ' + __dirname);
+    expect(script).toContain('sh script.sh 7.3 true');
+
+    setEnv('7.3', 'linux', 'a, b', 'a=b', 'x', true);
+    // @ts-ignore
+    script = await install.run();
+    expect(script).toContain('initial script');
+    expect(script).toContain('install extensions');
+    expect(script).toContain('edit php.ini');
+    expect(script).toContain('set coverage driver');
+    expect(script).toContain('sh script.sh 7.3 true');
   });
 
   it('Test install on darwin', async () => {
-    setEnv('7.3', 'darwin', '', '', '');
+    setEnv('7.3', 'darwin', '', '', '', '');
     // @ts-ignore
     let script: string = await install.run();
     expect(script).toContain('initial script');
     expect(script).toContain('sh script.sh 7.3 ' + __dirname);
 
-    setEnv('7.3', 'darwin', 'a, b', 'a=b', 'x');
+    setEnv('7.3', 'darwin', 'a, b', 'a=b', 'x', '');
     // @ts-ignore
     script = await install.run();
     expect(script).toContain('initial script');

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   coverage: 
     description: '(Optional) Code coverage driver you want to install. (Accepts: xdebug, pcov and none)'
     required: false
+  pecl:
+    description: '(Optional) Setup PECL on ubuntu'
+    required: false
 runs:
   using: 'node12'
   main: 'lib/install.js'

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -192,9 +192,11 @@ function addExtensionLinux(extension_csv, version) {
                         break;
                     default:
                         install_command =
-                            'sudo DEBIAN_FRONTEND=noninteractive apt install -y php' +
+                            'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php' +
                                 version +
                                 '-' +
+                                extension +
+                                ' >/dev/null 2>&1 || sudo pecl install ' +
                                 extension +
                                 ' >/dev/null 2>&1';
                         break;

--- a/lib/install.js
+++ b/lib/install.js
@@ -61,9 +61,13 @@ function run() {
             let script_path = '';
             switch (os_version) {
                 case 'darwin':
-                case 'linux':
                     script_path = yield build(os_version + '.sh', version, os_version);
                     yield exec_1.exec('sh ' + script_path + ' ' + version + ' ' + __dirname);
+                    break;
+                case 'linux':
+                    let pecl = yield utils.getInput('pecl', false);
+                    script_path = yield build(os_version + '.sh', version, os_version);
+                    yield exec_1.exec('sh ' + script_path + ' ' + version + ' ' + pecl);
                     break;
                 case 'win32':
                     script_path = yield build('win32.ps1', version, os_version);

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -185,9 +185,11 @@ export async function addExtensionLinux(
         break;
       default:
         install_command =
-          'sudo DEBIAN_FRONTEND=noninteractive apt install -y php' +
+          'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php' +
           version +
           '-' +
+          extension +
+          ' >/dev/null 2>&1 || sudo pecl install ' +
           extension +
           ' >/dev/null 2>&1';
         break;

--- a/src/install.ts
+++ b/src/install.ts
@@ -47,9 +47,13 @@ export async function run() {
     let script_path: string = '';
     switch (os_version) {
       case 'darwin':
-      case 'linux':
         script_path = await build(os_version + '.sh', version, os_version);
         await exec('sh ' + script_path + ' ' + version + ' ' + __dirname);
+        break;
+      case 'linux':
+        let pecl: string = await utils.getInput('pecl', false);
+        script_path = await build(os_version + '.sh', version, os_version);
+        await exec('sh ' + script_path + ' ' + version + ' ' + pecl);
         break;
       case 'win32':
         script_path = await build('win32.ps1', version, os_version);

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -26,11 +26,10 @@ if [ "$existing_version" != "$1" ]; then
 		if [ "$1" != "7.4" ]; then
 		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" curl php"$1"-curl >/dev/null 2>&1
 		else
-		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" php"$1"-dev curl php"$1"-curl >/dev/null 2>&1
+		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" php"$1"-dev php"$1"-xml curl php"$1"-curl >/dev/null 2>&1
 		fi
 		status="Installed PHP$version"
 	fi
-
 
 	for tool in php phar phar.phar php-cgi php-config phpize; do
 		if [ -e "/usr/bin/$tool$1" ]; then
@@ -44,6 +43,17 @@ ext_dir=$(php -i | grep "extension_dir => /usr" | sed -e "s|.*=> s*||")
 sudo chmod 777 "$ini_file"
 sudo mkdir -p /run/php
 add_log "$tick" "PHP" "$status"
+if [ "$2" = "true" ]; then
+  if [ "$1" != "7.4" ]; then
+    sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1"-dev php"$1"-xml >/dev/null 2>&1
+  fi
+  sudo update-alternatives --set php-config /usr/bin/php-config"$1" >/dev/null 2>&1
+  sudo update-alternatives --set phpize /usr/bin/phpize"$1" >/dev/null 2>&1
+  wget https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar >/dev/null 2>&1
+  sudo php install-pear-nozlib.phar >/dev/null 2>&1
+  sudo pear config-set php_ini "$ini_file" >/dev/null 2>&1
+  add_log "$tick" "PECL" "Installed"
+fi
 
 if [ ! -e "/usr/bin/composer" ]; then
 	curl -s -L https://getcomposer.org/installer > composer-setup.php
@@ -71,6 +81,6 @@ add_extension()
       (
         eval "$install_command" && \
         add_log "$tick" "$extension" "Installed and enabled"
-      ) || add_log "$cross" "$extension" "Could not find php$version-$extension"
+      ) || add_log "$cross" "$extension" "Could not install $extension on php$version"
   fi
 }


### PR DESCRIPTION
---
name: 🎉 New Feature
about: PECL can now be setup by specifying `pecl: true as an input`
labels: enhancement

---

- Setup PECL when `pecl: true` is specified. #71 
- Use `apt-get` instead of wrapper `apt`.