### PR TITLE
Add problem matcher for PHPUnit

### DIFF
--- a/.github/matchers/phpunit.json
+++ b/.github/matchers/phpunit.json
@@ -1,0 +1,24 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "phpunit",
+      "pattern": [
+        {
+          "regexp": "^\\d+\\)\\s.*$"
+        },
+        {
+          "regexp": "^(.*)$",
+          "message": 1
+        },
+        {
+          "regexp": "^\\s*$"
+        },
+        {
+          "regexp": "^(.*):(\\d+)$",
+          "file": 1,
+          "line": 2
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/install.test.ts
+++ b/__tests__/install.test.ts
@@ -1,4 +1,6 @@
 import * as install from '../src/install';
+import * as matchers from '../src/matchers';
+import * as path from 'path';
 
 /**
  * Mock install.ts
@@ -142,5 +144,35 @@ describe('Install', () => {
     expect(script).toContain('edit php.ini');
     expect(script).toContain('set coverage driver');
     expect(script).toContain('sh script.sh 7.3 ' + __dirname);
+  });
+
+  describe('Matchers', () => {
+    let originalLogMethod: any;
+    let outputData: any[] = [];
+
+    beforeAll(() => {
+      originalLogMethod = console.log;
+      console['log'] = jest.fn(inputs => outputData.push(inputs));
+    });
+
+    beforeEach(() => {
+      outputData = [];
+    });
+
+    afterAll(() => {
+      console['log'] = originalLogMethod;
+    });
+
+    it('Add matchers', async () => {
+      matchers.addMatchers();
+
+      expect(outputData).toEqual([
+        `##[add-matcher]${path.join(
+          __dirname,
+          '..',
+          '.github/matchers/phpunit.json'
+        )}`
+      ]);
+    });
   });
 });

--- a/src/install.ts
+++ b/src/install.ts
@@ -4,6 +4,7 @@ import * as config from './config';
 import * as coverage from './coverage';
 import * as extensions from './extensions';
 import * as utils from './utils';
+import {addMatchers} from './matchers';
 
 /**
  * Build the script
@@ -63,6 +64,8 @@ export async function run(): Promise<void> {
         );
         break;
     }
+
+    addMatchers();
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -1,0 +1,10 @@
+import * as path from 'path';
+
+/**
+ * Add matches using the Actions Toolkit problem matchers syntax
+ * https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md
+ */
+export function addMatchers(): void {
+  const matchersPath = path.join(__dirname, '..', '.github/matchers');
+  console.log(`##[add-matcher]${path.join(matchersPath, 'phpunit.json')}`);
+}


### PR DESCRIPTION
---
name:  🎉 Add problem matcher for PHPUnit
about: Add support for parsing PHPUnit output using problem matches
labels: enhancement
---

### Description

Adds a problem matcher, which parses output for warnings/errors. Documentation can be found here: https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md


The GitHub provided `setup-*` actions provide, [example](https://github.com/actions/setup-node/tree/7a3ce8362699742a34a1590e93c9b75e4d0d6dff/.github)

Matchers are registered using [toolkit commands](https://github.com/actions/toolkit/blob/master/docs/commands.md#problem-matchers). I've followed the implementation used by [`setup-node`](https://github.com/actions/setup-node/blob/7a3ce8362699742a34a1590e93c9b75e4d0d6dff/src/setup-node.ts#L27-L35)

---

> In case this PR introduced TypeScript/JavaScript code changes:

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] `npm test` returns with no unit test errors.

<!--
- Please target the develop branch when submitting the pull request.
-->