### PR TITLE
1.5.6

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -61,13 +61,22 @@ jobs:
           ini-values-csv: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
 
       - name: Testing PHP version
-        run: php -v
+        run: |
+          php -v
+          php -r "if(strpos(phpversion(), '${{ matrix.php-versions }}') === false) {throw new Exception('Wrong PHP version Installed');}"
+
       - name: Testing Composer version
-        run: composer -V
+        run: |
+          composer -V
+          php -r "if(strpos(@exec('composer -V'), 'Composer version') === false) {throw new Exception('Composer not found');}"
       - name: Testing Extensions
-        run: php -m
+        run: |
+          php -m
+          php -r "if(! extension_loaded('mbstring')) {throw new Exception('mbstring not found');}"
+          php -r "if(! extension_loaded('Xdebug')) {throw new Exception('Xdebug not found');}"
+          php -r "if(phpversion()>=7.1 && ! extension_loaded('pcov')) {throw new Exception('PCOV not found');}"
       - name: Testing ini values
         run: |
-          printf "post_max_size: %s\n" $(php -r "echo ini_get('post_max_size');")
-          printf "short_open_tag: %s\n" $(php -r "echo ini_get('short_open_tag');")
-          printf "date.timezone: %s\n" $(php -r "echo ini_get('date.timezone');")
+          php -r "if(ini_get('post_max_size')!='256M') {throw new Exception('post_max_size not added');}"
+          php -r "if(ini_get('short_open_tag')!=1) {throw new Exception('short_open_tag not added');}"
+          php -r "if(ini_get('date.timezone')!='Asia/Kolkata') {throw new Exception('date.timezone not added');}"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Runs on all [PHP versions supported](#tada-php-support "List of PHP versions sup
 ```yaml
 uses: shivammathur/setup-php@v1
 with:
-  php-version: '7.3'  
+  php-version: '7.4'  
   coverage: xdebug
 ```
 
@@ -87,7 +87,7 @@ If your source code directory is other than `src`, `lib` or, `app`, specify `pco
 ```yaml
 uses: shivammathur/setup-php@v1
 with:
-  php-version: '7.3'
+  php-version: '7.4'
   ini-values-csv: pcov.directory=api #optional, see above for usage.
   coverage: pcov
 ```
@@ -104,7 +104,7 @@ Consider disabling the coverage using this PHP action for these reasons.
 ```yaml
 uses: shivammathur/setup-php@v1
 with:
-  php-version: '7.3'
+  php-version: '7.4'
   coverage: none
 ```
 
@@ -130,7 +130,7 @@ steps:
 - name: Setup PHP
   uses: shivammathur/setup-php@v1
   with:
-    php-version: '7.3'
+    php-version: '7.4'
     extension-csv: mbstring, intl #optional, setup extensions
     ini-values-csv: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
     coverage: xdebug #optional, setup coverage driver
@@ -155,7 +155,7 @@ jobs:
     strategy:      
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout
@@ -250,7 +250,6 @@ If this action helped you.
 - [Homebrew](https://brew.sh/ "MacOS package manager")
 - [ppa:ondrej/php](https://launchpad.net/~ondrej/+archive/ubuntu/php "Pre-compiled ubuntu packages")
 - [exolnet/homebrew-deprecated](https://github.com/eXolnet/homebrew-deprecated "Pre-compiled deprecated PHP for macOS")
-- [phpbrew](https://github.com/phpbrew/phpbrew "PHP packages manager")
 
 ## :bookmark_tabs: Further Reading
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -60,10 +60,6 @@ describe('Utils tests', () => {
   });
 
   it('checking readScripts', async () => {
-    const rc: string = fs.readFileSync(
-      path.join(__dirname, '../src/scripts/7.4.sh'),
-      'utf8'
-    );
     const darwin: string = fs.readFileSync(
       path.join(__dirname, '../src/scripts/darwin.sh'),
       'utf8'
@@ -76,15 +72,12 @@ describe('Utils tests', () => {
       path.join(__dirname, '../src/scripts/win32.ps1'),
       'utf8'
     );
-    expect(await utils.readScript('darwin.sh', '7.4', 'darwin')).toBe(rc);
+    expect(await utils.readScript('darwin.sh', '7.4', 'darwin')).toBe(darwin);
     expect(await utils.readScript('darwin.sh', '7.3', 'darwin')).toBe(darwin);
     expect(await utils.readScript('linux.sh', '7.4', 'linux')).toBe(linux);
     expect(await utils.readScript('linux.sh', '7.3', 'linux')).toBe(linux);
     expect(await utils.readScript('win32.ps1', '7.4', 'win32')).toBe(win32);
     expect(await utils.readScript('win32.ps1', '7.3', 'win32')).toBe(win32);
-    expect(await utils.readScript('fedora.sh', '7.3', 'fedora')).toContain(
-      'Platform fedora is not supported'
-    );
   });
 
   it('checking writeScripts', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -810,19 +810,7 @@ exports.addLog = addLog;
  */
 function readScript(filename, version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
-        switch (os_version) {
-            case 'darwin':
-                switch (version) {
-                    case '7.4':
-                        return fs.readFileSync(path.join(__dirname, '../src/scripts/7.4.sh'), 'utf8');
-                }
-                return fs.readFileSync(path.join(__dirname, '../src/scripts/' + filename), 'utf8');
-            case 'linux':
-            case 'win32':
-                return fs.readFileSync(path.join(__dirname, '../src/scripts/' + filename), 'utf8');
-            default:
-                return yield log('Platform ' + os_version + ' is not supported', os_version, 'error');
-        }
+        return fs.readFileSync(path.join(__dirname, '../src/scripts/' + filename), 'utf8');
     });
 }
 exports.readScript = readScript;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,12 +2249,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2269,17 +2271,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2396,7 +2401,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2408,6 +2414,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2422,6 +2429,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2429,12 +2437,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2453,6 +2463,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2533,7 +2544,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2545,6 +2557,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2666,6 +2679,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1776,9 +1776,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.0.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.0.5.tgz",
-      "integrity": "sha512-etxXrWsFWzxsrxKwJnFC38uppH/vlJ3oF7Wmp/cxedqxRIxVhXup8e5y5MmtVXelevgxrgA1QS1vo8j889iK5Q==",
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.1.0.tgz",
+      "integrity": "sha512-KHy1K0647bn86NTcWhWGoEIF9VgQ8YxR9hHZf/wQ4OvDwjRx27uk+mqvyZakWnRvIWFS/L25JNs4rnhsiE0adg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^2.5.0"
@@ -2249,14 +2249,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2271,20 +2269,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2401,8 +2396,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2414,7 +2408,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2429,7 +2422,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2437,14 +2429,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2463,7 +2453,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2544,8 +2533,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2557,7 +2545,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2679,7 +2666,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4833,9 +4819,9 @@
       }
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
+      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==",
       "dev": true
     },
     "pump": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -17,12 +17,15 @@ add_log() {
   fi
 }
 
+step_log "Setup PHP and Composer"
 version=$1
 export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
 if [ "$1" = "5.6" ] || [ "$1" = "7.0" ]; then
   brew tap exolnet/homebrew-deprecated >/dev/null 2>&1
 fi
-step_log "Setup PHP and Composer"
+if [ "$1" = "7.4" ]; then
+  brew update >/dev/null 2>&1
+fi
 brew install php@"$1" composer >/dev/null 2>&1
 brew link --force --overwrite php@"$1" >/dev/null 2>&1
 ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -34,7 +34,7 @@ ext_dir=$(php -i | grep "extension_dir => /usr" | sed -e "s|.*=> s*||")
 sudo chmod 777 "$ini_file"
 mkdir -p "$(pecl config-get ext_dir)"
 composer global require hirak/prestissimo >/dev/null 2>&1
-add_log "$tick" "PHP" "Installed PHP$version"
+add_log "$tick" "PHP" "Installed PHP $(php -v | head -n 1 | cut -c 5-10)"
 add_log "$tick" "Composer" "Installed"
 
 add_extension() {

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -18,7 +18,6 @@ add_log() {
 }
 existing_version=$(php-config --version | cut -c 1-3)
 version=$1
-status="Switched to PHP$version"
 step_log "Setup PHP and Composer"
 sudo mkdir -p /var/run
 sudo mkdir -p /run/php
@@ -30,7 +29,9 @@ if [ "$existing_version" != "$1" ]; then
 		else
 		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" php"$1"-phpdbg php"$1"-xml curl php"$1"-curl >/dev/null 2>&1
 		fi
-		status="Installed PHP$version"
+		status="installed"
+	else
+	  status="switched"
 	fi
 
 	for tool in php phar phar.phar php-cgi php-config phpize phpdbg; do
@@ -38,6 +39,13 @@ if [ "$existing_version" != "$1" ]; then
 			sudo update-alternatives --set $tool /usr/bin/"$tool$1" >/dev/null 2>&1
 		fi
 	done
+	if [ "$status" != "switched" ]; then
+	  status="Installed PHP $(php -v | head -n 1 | cut -c 5-10)"
+	else
+	  status="Switched to PHP $(php -v | head -n 1 | cut -c 5-10)"
+	fi
+else
+  status="PHP $(php -v | head -n 1 | cut -c 5-10) Found"
 fi
 
 ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -39,7 +39,7 @@ if ($null -eq $installed -or -not("$($installed.Version).".StartsWith(($version 
   $status = "Installed PHP $($installed.FullVersion)"
 }
 else {
-  $status = "Switched to PHP $($installed.FullVersion)"
+  $status = "PHP $($installed.FullVersion) Found"
 }
 
 Set-PhpIniKey -Key 'date.timezone' -Value 'UTC' -Path $php_dir

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,32 +173,10 @@ export async function readScript(
   version: string,
   os_version: string
 ): Promise<string> {
-  switch (os_version) {
-    case 'darwin':
-      switch (version) {
-        case '7.4':
-          return fs.readFileSync(
-            path.join(__dirname, '../src/scripts/7.4.sh'),
-            'utf8'
-          );
-      }
-      return fs.readFileSync(
-        path.join(__dirname, '../src/scripts/' + filename),
-        'utf8'
-      );
-    case 'linux':
-    case 'win32':
-      return fs.readFileSync(
-        path.join(__dirname, '../src/scripts/' + filename),
-        'utf8'
-      );
-    default:
-      return await log(
-        'Platform ' + os_version + ' is not supported',
-        os_version,
-        'error'
-      );
-  }
+  return fs.readFileSync(
+    path.join(__dirname, '../src/scripts/' + filename),
+    'utf8'
+  );
 }
 
 /**


### PR DESCRIPTION
- Switch to `Homebrew` for PHP 7.4 after Homebrew/homebrew-core#47289.
- Add 7.4 to `README` and `workflow`.
- Improve checks in workflow.
- Show semantic versions on PHP install and correct logs.
- Bump version to `1.5.6`