### PR TITLE
1.5.7

### DIFF
--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -3,14 +3,13 @@ import * as extensions from '../src/extensions';
 describe('Extension tests', () => {
   it('checking addExtensionOnWindows', async () => {
     let win32: string = await extensions.addExtension(
-      'xdebug, pcov',
-      '7.2',
+      'xdebug, pcov, redis',
+      '7.4',
       'win32'
     );
     expect(win32).toContain('Add-Extension xdebug');
     expect(win32).toContain('Add-Extension pcov');
-    win32 = await extensions.addExtension('xdebug, pcov', '7.4', 'win32');
-    expect(win32).toContain('Add-Extension xdebug');
+    expect(win32).toContain('Add-Extension redis beta');
 
     win32 = await extensions.addExtension(
       'does_not_exist',
@@ -26,18 +25,21 @@ describe('Extension tests', () => {
 
   it('checking addExtensionOnLinux', async () => {
     let linux: string = await extensions.addExtension(
-      'xdebug, pcov',
-      '7.2',
+      'xdebug, pcov, redis',
+      '7.4',
       'linux'
     );
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.2-xdebug'
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-xdebug'
     );
     expect(linux).toContain('pecl install xdebug');
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.2-pcov'
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-pcov'
     );
     expect(linux).toContain('pecl install pcov');
+    expect(linux).toContain(
+      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-igbinary php7.4-redis'
+    );
 
     linux = await extensions.addExtension('phalcon3, phalcon4', '7.2', 'linux');
     expect(linux).toContain('phalcon.sh master 7.2');
@@ -46,6 +48,9 @@ describe('Extension tests', () => {
     linux = await extensions.addExtension('phalcon3, phalcon4', '7.3', 'linux');
     expect(linux).toContain('phalcon.sh master 7.3');
     expect(linux).toContain('phalcon.sh 4.0.x 7.3');
+
+    linux = await extensions.addExtension('phalcon4', '7.4', 'linux');
+    expect(linux).toContain('phalcon.sh 4.0.x 7.4');
 
     linux = await extensions.addExtension('xdebug', '7.2', 'fedora');
     expect(linux).toContain('Platform fedora is not supported');
@@ -71,6 +76,12 @@ describe('Extension tests', () => {
 
     darwin = await extensions.addExtension('xdebug', '7.2', 'darwin');
     expect(darwin).toContain('sudo pecl install xdebug');
+
+    darwin = await extensions.addExtension('redis', '5.6', 'darwin');
+    expect(darwin).toContain('sudo pecl install redis-2.2.8');
+
+    darwin = await extensions.addExtension('redis', '7.2', 'darwin');
+    expect(darwin).toContain('sudo pecl install redis');
 
     darwin = await extensions.addExtension(
       'does_not_exist',

--- a/action.yml
+++ b/action.yml
@@ -5,19 +5,20 @@ branding:
   color: 'purple'
 inputs:
   php-version:
-    description: 'PHP version you want to install.'
+    description: 'Setup PHP version.'
+    default: '7.4'
     required: true
   extension-csv:
-    description: '(Optional) PHP extensions you want to install.'
+    description: 'Setup PHP extensions.'
     required: false
   ini-values-csv: 
-    description: '(Optional) Custom values you want to set in php.ini.'
+    description: 'Add values to php.ini.'
     required: false
   coverage: 
-    description: '(Optional) Code coverage driver you want to install. (Accepts: xdebug, pcov and none)'
+    description: 'Setup code coverage driver.'
     required: false
   pecl:
-    description: '(Optional) Setup PECL on ubuntu'
+    description: 'Setup PECL on ubuntu'
     required: false
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1607,6 +1607,9 @@ function addExtensionDarwin(extension_csv, version) {
                     case '5.6xdebug':
                         install_command = 'sudo pecl install xdebug-2.5.5 >/dev/null 2>&1';
                         break;
+                    case '5.6redis':
+                        install_command = 'sudo pecl install redis-2.2.8 >/dev/null 2>&1';
+                        break;
                     default:
                         install_command = 'sudo pecl install ' + extension + ' >/dev/null 2>&1';
                         break;
@@ -1637,7 +1640,14 @@ function addExtensionWindows(extension_csv, version) {
         yield utils.asyncForEach(extensions, function (extension) {
             return __awaiter(this, void 0, void 0, function* () {
                 // add script to enable extension is already installed along with php
-                script += '\nAdd-Extension ' + extension;
+                switch (version + extension) {
+                    case '7.4redis':
+                        script += '\nAdd-Extension ' + extension + ' beta';
+                        break;
+                    default:
+                        script += '\nAdd-Extension ' + extension;
+                        break;
+                }
             });
         });
         return script;
@@ -1660,6 +1670,10 @@ function addExtensionLinux(extension_csv, version) {
                 // add script to enable extension is already installed along with php
                 let install_command = '';
                 switch (version + extension) {
+                    case '7.4redis':
+                        install_command =
+                            'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-igbinary php7.4-redis >/dev/null 2>&1';
+                        break;
                     case '7.2phalcon3':
                     case '7.3phalcon3':
                         install_command =

--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,12 +2249,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2269,17 +2271,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2396,7 +2401,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2408,6 +2414,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2422,6 +2429,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2429,12 +2437,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2453,6 +2463,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2533,7 +2544,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2545,6 +2557,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2666,6 +2679,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1614,9 +1614,9 @@
       }
     },
     "eslint": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.1.tgz",
-      "integrity": "sha512-UWzBS79pNcsDSxgxbdjkmzn/B6BhsXMfUaOHnNwyE8nD+Q6pyT96ow2MccVayUTV4yMid4qLhMiQaywctRkBLA==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.2.tgz",
+      "integrity": "sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2249,14 +2249,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2271,20 +2269,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2401,8 +2396,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2414,7 +2408,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2429,7 +2422,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2437,14 +2429,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2463,7 +2453,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2544,8 +2533,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2557,7 +2545,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2679,7 +2666,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5974,9 +5960,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
-      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
+      "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -553,44 +553,16 @@
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
-          "integrity": "sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.10.0",
-            "eslint-scope": "^5.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
-          "integrity": "sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "eslint-visitor-keys": "^1.1.0",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash.unescape": "4.0.1",
-            "semver": "^6.3.0",
-            "tsutils": "^3.17.1"
-          }
-        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.9.0.tgz",
-      "integrity": "sha512-0lOLFdpdJsCMqMSZT7l7W2ta0+GX8A3iefG3FovJjrX+QR8y6htFlFdU7aOVPL6pDvt6XcsOb8fxk5sq+girTw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
+      "integrity": "sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.9.0",
+        "@typescript-eslint/typescript-estree": "2.10.0",
         "eslint-scope": "^5.0.0"
       }
     },
@@ -604,40 +576,12 @@
         "@typescript-eslint/experimental-utils": "2.10.0",
         "@typescript-eslint/typescript-estree": "2.10.0",
         "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
-          "integrity": "sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.10.0",
-            "eslint-scope": "^5.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
-          "integrity": "sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "eslint-visitor-keys": "^1.1.0",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash.unescape": "4.0.1",
-            "semver": "^6.3.0",
-            "tsutils": "^3.17.1"
-          }
-        }
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.9.0.tgz",
-      "integrity": "sha512-v6btSPXEWCP594eZbM+JCXuFoXWXyF/z8kaSBSdCb83DF+Y7+xItW29SsKtSULgLemqJBT+LpT+0ZqdfH7QVmA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
+      "integrity": "sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -2284,8 +2228,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2306,14 +2249,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2328,20 +2269,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2458,8 +2396,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2471,7 +2408,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2486,7 +2422,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2494,14 +2429,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2520,7 +2453,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2601,8 +2533,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2614,7 +2545,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2700,8 +2630,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2737,7 +2666,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2757,7 +2685,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2801,14 +2728,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint **/*.ts --cache",
-    "format": "prettier --write **/*.ts",
+    "format": "prettier --write **/*.ts && git add .",
     "format-check": "prettier --check **/*.ts",
     "release": "ncc build src/install.ts -o dist && git add -f dist/",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -21,6 +21,9 @@ export async function addExtensionDarwin(
       case '5.6xdebug':
         install_command = 'sudo pecl install xdebug-2.5.5 >/dev/null 2>&1';
         break;
+      case '5.6redis':
+        install_command = 'sudo pecl install redis-2.2.8 >/dev/null 2>&1';
+        break;
       default:
         install_command = 'sudo pecl install ' + extension + ' >/dev/null 2>&1';
         break;
@@ -50,7 +53,14 @@ export async function addExtensionWindows(
   let script = '\n';
   await utils.asyncForEach(extensions, async function(extension: string) {
     // add script to enable extension is already installed along with php
-    script += '\nAdd-Extension ' + extension;
+    switch (version + extension) {
+      case '7.4redis':
+        script += '\nAdd-Extension ' + extension + ' beta';
+        break;
+      default:
+        script += '\nAdd-Extension ' + extension;
+        break;
+    }
   });
   return script;
 }
@@ -73,6 +83,10 @@ export async function addExtensionLinux(
 
     let install_command = '';
     switch (version + extension) {
+      case '7.4redis':
+        install_command =
+          'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-igbinary php7.4-redis >/dev/null 2>&1';
+        break;
       case '7.2phalcon3':
       case '7.3phalcon3':
         install_command =

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -20,13 +20,8 @@ add_log() {
 step_log "Setup PHP and Composer"
 version=$1
 export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
-if [ "$1" = "5.6" ] || [ "$1" = "7.0" ]; then
-  brew tap exolnet/homebrew-deprecated >/dev/null 2>&1
-fi
-if [ "$1" = "7.4" ]; then
-  brew update >/dev/null 2>&1
-fi
-brew install php@"$1" composer >/dev/null 2>&1
+brew tap shivammathur/homebrew-php >/dev/null 2>&1
+brew install shivammathur/php/php@"$1" composer >/dev/null 2>&1
 brew link --force --overwrite php@"$1" >/dev/null 2>&1
 ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
 echo "date.timezone=UTC" >> "$ini_file"


### PR DESCRIPTION
- Improve `action.yml` 
- Update pre-commit hook
- Use [`shivammathur/homebrew-php`](https://github.com/shivammathur/homebrew-php) for `macOS`.
- Fix `ext-redis`. Fixes #96 
- Update dependencies
- Bump version to `1.5.7`