### PR TITLE
1.6.0

### DIFF
--- a/.github/workflows/experimental-workflow.yml
+++ b/.github/workflows/experimental-workflow.yml
@@ -59,8 +59,8 @@ jobs:
         run: node dist/index.js
         env:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, xdebug, pcov #optional
-          ini-values-csv: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
+          extensions: mbstring, xdebug, pcov #optional
+          ini-values: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
 
       - name: Testing PHP version
         run: |

--- a/.github/workflows/experimental-workflow.yml
+++ b/.github/workflows/experimental-workflow.yml
@@ -1,0 +1,91 @@
+name: Experimental workflow
+on:
+  pull_request:
+    branches:
+      - nightly
+      - master
+      - develop
+      - verbose
+    paths-ignore:
+      - '**.md'
+      - 'examples/**'
+  push:
+    branches:
+      - nightly
+      - master
+      - develop
+      - verbose
+    paths-ignore:
+      - '**.md'
+      - 'examples/**'
+jobs:
+  run:
+    name: Run
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, ubuntu-16.04, macOS-latest]
+        php-versions: ['8.0']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Prettier Format Check
+        run: npm run format-check
+
+      - name: ESLint Check
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Send Coverage
+        continue-on-error: true
+        timeout-minutes: 1
+        run: curl -s https://codecov.io/bash | bash -s -- -t ${{secrets.CODECOV_TOKEN}} -f coverage/clover.xml -n github-actions-codecov-${{ matrix.operating-system }}-php${{ matrix.php-versions }}
+
+      - name: Setup PHP with extensions and custom config
+        run: node dist/index.js
+        env:
+          php-version: ${{ matrix.php-versions }}
+          extension-csv: mbstring, xdebug, pcov #optional
+          ini-values-csv: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
+
+      - name: Testing PHP version
+        run: |
+          php -v
+          php -r "if(strpos(phpversion(), '${{ matrix.php-versions }}') === false) {throw new Exception('Wrong PHP version Installed');}"
+
+      - name: Testing Composer version
+        run: |
+          composer -V
+          php -r "if(strpos(@exec('composer -V'), 'Composer version') === false) {throw new Exception('Composer not found');}"
+      - name: Testing Extensions
+        run: |
+          php -m
+          php -r "if(! extension_loaded('mbstring')) {throw new Exception('mbstring not found');}"
+          # php -r "if(! extension_loaded('Xdebug')) {throw new Exception('Xdebug not found');}"
+          php -r "if(! extension_loaded('pcov')) {throw new Exception('PCOV not found');}"
+      - name: Testing ini values
+        run: |
+          php -r "if(ini_get('post_max_size')!='256M') {throw new Exception('post_max_size not added');}"
+          php -r "if(ini_get('short_open_tag')!=1) {throw new Exception('short_open_tag not added');}"
+          php -r "if(ini_get('date.timezone')!='Asia/Kolkata') {throw new Exception('date.timezone not added');}"
+      - name: Test and Benchmark JIT
+        run: |
+          php -r "if(! extension_loaded('Zend OPcache')) {throw new Exception('Zend OPcache not found');}"
+          php -r "if(ini_get('opcache.jit_buffer_size')!='256M') {throw new Exception('opcache.jit_buffer_size not set');}"
+          php -r "if(ini_get('opcache.jit')!=1235) {throw new Exception('opcache.jit not set');}"
+          php -r "if(ini_get('pcre.jit')!=1) {throw new Exception('pcre.jit not set');}"
+          curl https://raw.githubusercontent.com/php/php-src/master/Zend/bench.php | php

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,8 +57,8 @@ jobs:
         run: node dist/index.js
         env:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, xdebug, pcov #optional
-          ini-values-csv: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
+          extensions: mbstring, xdebug, pcov #optional
+          ini-values: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
 
       - name: Testing PHP version
         run: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="#tada-php-support" title="PHP Versions Supported"><img alt="PHP Versions Supported" src="https://img.shields.io/badge/php-%3E%3D%205.6-8892BF.svg"></a>  
 </p>
 
-Setup PHP with required extensions, php.ini configuration and composer in [GitHub Actions](https://github.com/features/actions "GitHub Actions"). This action can be added as a step in your action workflow and it will setup the PHP environment you need to test your application. Refer to [Usage](#memo-usage "How to use this") section and [examples](#examples "Examples of use") to see how to use this.
+Setup PHP with required extensions, php.ini configuration, code-coverage support and composer in [GitHub Actions](https://github.com/features/actions "GitHub Actions"). This action gives you a cross platform interface to setup the PHP environment you need to test your application. Refer to [Usage](#memo-usage "How to use this") section and [examples](#examples "Examples of use") to see how to use this.
 
 ## Contents
 
@@ -123,7 +123,9 @@ Inputs supported by this GitHub Action.
 
 See [action.yml](action.yml "Metadata for this GitHub Action") and usage below for more info.
 
-### Setup a particular PHP version
+### Basic Usage 
+
+> Setup a particular PHP version
 
 ```yaml
 steps:
@@ -140,7 +142,9 @@ steps:
     pecl: false #optional, setup PECL
 ```
 
-### Setup multiple PHP versions
+### Matrix Testing
+
+> Setup multiple PHP versions
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Setup PHP with required extensions, php.ini configuration and composer in [GitHu
 |7.2|`Stable`|`Security fixes only`|
 |7.3|`Stable`|`Active`|
 |7.4|`Stable`|`Active`|
+|8.0|`Experimental`|`In development`|
+
+**Note:** Specifying `8.0` in `php-version` input installs `PHP 8.0.0-dev`. This is an experimental feature on this action available on `ubuntu` and `macOS`. Currently some extensions might not be available for this version.   
 
 ## :cloud: OS/Platform Support
 
@@ -120,7 +123,7 @@ Inputs supported by this GitHub Action.
 
 See [action.yml](action.yml "Metadata for this GitHub Action") and usage below for more info.
 
-### Basic Usage
+### Setup a particular PHP version
 
 ```yaml
 steps:
@@ -135,18 +138,9 @@ steps:
     ini-values-csv: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
     coverage: xdebug #optional, setup coverage driver
     pecl: false #optional, setup PECL
-
-- name: Check PHP Version
-  run: php -v
-
-- name: Check Composer Version
-  run: composer -V
-
-- name: Check PHP Extensions
-  run: php -m
 ```
 
-### Matrix Testing
+### Setup multiple PHP versions
 
 ```yaml
 jobs:
@@ -169,15 +163,6 @@ jobs:
         ini-values-csv: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
         coverage: xdebug #optional, setup coverage driver
         pecl: false #optional, setup PECL
-
-    - name: Check PHP Version
-      run: php -v
-
-    - name: Check Composer Version
-      run: composer -V
-
-    - name: Check PHP Extensions
-      run: php -m
 ```
 
 ### Cache dependencies
@@ -246,10 +231,10 @@ If this action helped you.
 
 ## :bookmark: This action uses the following works
 
-- [powershell-phpmanager](https://github.com/mlocati/powershell-phpmanager "Package to handle PHP on windows")
-- [Homebrew](https://brew.sh/ "MacOS package manager")
 - [ppa:ondrej/php](https://launchpad.net/~ondrej/+archive/ubuntu/php "Pre-compiled ubuntu packages")
-- [exolnet/homebrew-deprecated](https://github.com/eXolnet/homebrew-deprecated "Pre-compiled deprecated PHP for macOS")
+- [shivammathur/php-builder](https://github.com/shivammathur/php-builder "Pre-compiled nightly PHP builds")
+- [mlocati/powershell-phpmanager](https://github.com/mlocati/powershell-phpmanager "Package to handle PHP on windows")
+- [shivammathur/homebrew-php](https://github.com/shivammathur/homebrew-php "Tap for PHP builds for MacOS")
 
 ## :bookmark_tabs: Further Reading
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ with:
 Specify `coverage: pcov` to use `PCOV`.  
 It is much faster than `Xdebug`.  
 `PCOV` needs `PHP >= 7.1`.  
-If your source code directory is other than `src`, `lib` or, `app`, specify `pcov.directory` using the `ini-values-csv` input.  
+If your source code directory is other than `src`, `lib` or, `app`, specify `pcov.directory` using the `ini-values` input.  
 
 
 ```yaml
 uses: shivammathur/setup-php@v1
 with:
   php-version: '7.4'
-  ini-values-csv: pcov.directory=api #optional, see above for usage.
+  ini-values: pcov.directory=api #optional, see above for usage.
   coverage: pcov
 ```
 
@@ -116,8 +116,8 @@ with:
 Inputs supported by this GitHub Action.
 
 - php-version `required`
-- extension-csv `optional`
-- ini-values-csv `optional`
+- extension `optional`
+- ini-values `optional`
 - coverage `optional`
 - pecl `optional`
 
@@ -134,8 +134,8 @@ steps:
   uses: shivammathur/setup-php@v1
   with:
     php-version: '7.4'
-    extension-csv: mbstring, intl #optional, setup extensions
-    ini-values-csv: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
+    extensions: mbstring, intl #optional, setup extensions
+    ini-values: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
     coverage: xdebug #optional, setup coverage driver
     pecl: false #optional, setup PECL
 ```
@@ -159,8 +159,8 @@ jobs:
       uses: shivammathur/setup-php@v1
       with:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring, intl #optional, setup extensions
-        ini-values-csv: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
+        extensions: mbstring, intl #optional, setup extensions
+        ini-values: post_max_size=256M, short_open_tag=On #optional, setup php.ini configuration
         coverage: xdebug #optional, setup coverage driver
         pecl: false #optional, setup PECL
 ```

--- a/__tests__/install.test.ts
+++ b/__tests__/install.test.ts
@@ -10,8 +10,8 @@ jest.mock('../src/install', () => ({
       version: string,
       os_version: string
     ): Promise<string> => {
-      const extension_csv: string = process.env['extension-csv'] || '';
-      const ini_values_csv: string = process.env['ini-values-csv'] || '';
+      const extension_csv: string = process.env['extensions'] || '';
+      const ini_values_csv: string = process.env['ini-values'] || '';
       const coverage_driver: string = process.env['coverage'] || '';
 
       let script = 'initial script ' + filename + version + os_version;
@@ -77,8 +77,8 @@ function setEnv(
 ): void {
   process.env['php-version'] = version;
   process.env['RUNNER_OS'] = os;
-  process.env['extension-csv'] = extension_csv;
-  process.env['ini-values-csv'] = ini_values_csv;
+  process.env['extensions'] = extension_csv;
+  process.env['ini-values'] = ini_values_csv;
   process.env['coverage'] = coverage_driver;
   process.env['pecl'] = pecl;
 }

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -26,23 +26,6 @@ describe('Utils tests', () => {
     expect(await utils.getInput('DoesNotExist', false)).toBe('');
   });
 
-  it('checking getVersion', async () => {
-    process.env['php-version'] = '7.3';
-    expect(await utils.getVersion()).toBe('7.3');
-    process.env['php-version'] = '7.4';
-    expect(await utils.getVersion()).toBe('7.4');
-    process.env['php-version'] = '8.0';
-    expect(await utils.getVersion()).toBe('7.4');
-    process.env['php-version'] = '8.0-dev';
-    expect(await utils.getVersion()).toBe('7.4');
-    process.env['php-version'] = '7.4nightly';
-    expect(await utils.getVersion()).toBe('7.4');
-    process.env['php-version'] = '7.4snapshot';
-    expect(await utils.getVersion()).toBe('7.4');
-    process.env['php-version'] = 'nightly';
-    expect(await utils.getVersion()).toBe('7.4');
-  });
-
   it('checking asyncForEach', async () => {
     const array: Array<string> = ['a', 'b', 'c'];
     let concat = '';

--- a/action.yml
+++ b/action.yml
@@ -23,11 +23,11 @@ inputs:
   # Deprecated options, do not use. Will not be supported after February 1, 2019.
   extension-csv:
     description: 'Deprecated! Use extensions instead.'
-    deprecationMessage: 'The extensions property will not be supported after February 1, 2020. Use extensions instead.'
+    deprecationMessage: 'The extension-csv property will not be supported after February 1, 2020. Use extensions instead.'
     required: false
   ini-values-csv:
     description: 'Deprecated! Use ini-values instead.'
-    deprecationMessage: 'The ini-values property will not be supported after February 1, 2020. Use ini-values instead.'
+    deprecationMessage: 'The ini-values-csv property will not be supported after February 1, 2020. Use ini-values instead.'
     required: false
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ inputs:
     description: 'Setup PHP version.'
     default: '7.4'
     required: true
-  extension-csv:
+  extensions:
     description: 'Setup PHP extensions.'
     required: false
-  ini-values-csv: 
+  ini-values:
     description: 'Add values to php.ini.'
     required: false
   coverage: 
@@ -19,6 +19,15 @@ inputs:
     required: false
   pecl:
     description: 'Setup PECL on ubuntu'
+    required: false
+  # Deprecated options, do not use. Will not be supported after February 1, 2019.
+  extension-csv:
+    description: 'Deprecated! Use extensions instead.'
+    deprecationMessage: 'The extensions property will not be supported after February 1, 2020. Use extensions instead.'
+    required: false
+  ini-values-csv:
+    description: 'Deprecated! Use ini-values instead.'
+    deprecationMessage: 'The ini-values property will not be supported after February 1, 2020. Use ini-values instead.'
     required: false
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -683,26 +683,6 @@ function getInput(name, mandatory) {
 }
 exports.getInput = getInput;
 /**
- * Function to read the PHP version.
- */
-function getVersion() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const version = yield getInput('php-version', true);
-        switch (version) {
-            case '8.0':
-            case '8.0-dev':
-            case '7.4':
-            case '7.4snapshot':
-            case '7.4nightly':
-            case 'nightly':
-                return '7.4';
-            default:
-                return version;
-        }
-    });
-}
-exports.getVersion = getVersion;
-/**
  * Async foreach loop
  *
  * @author https://github.com/Atinux
@@ -1525,7 +1505,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const os_version = process.platform;
-            const version = yield utils.getVersion();
+            const version = yield utils.getInput('php-version', true);
             // check the os version and run the respective script
             let script_path = '';
             switch (os_version) {
@@ -1541,7 +1521,7 @@ function run() {
                 }
                 case 'win32':
                     script_path = yield build('win32.ps1', version, os_version);
-                    yield exec_1.exec('pwsh ' + script_path + ' -version ' + version + ' -dir ' + __dirname);
+                    yield exec_1.exec('pwsh ' + script_path + ' -version ' + version);
                     break;
             }
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1481,8 +1481,10 @@ const utils = __importStar(__webpack_require__(163));
 function build(filename, version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
         // taking inputs
-        const extension_csv = yield utils.getInput('extension-csv', false);
-        const ini_values_csv = yield utils.getInput('ini-values-csv', false);
+        const extension_csv = (yield utils.getInput('extensions', false)) ||
+            (yield utils.getInput('extension-csv', false));
+        const ini_values_csv = (yield utils.getInput('ini-values', false)) ||
+            (yield utils.getInput('ini-values-csv', false));
         const coverage_driver = yield utils.getInput('coverage', false);
         let script = yield utils.readScript(filename, version, os_version);
         if (extension_csv) {

--- a/examples/codeigniter.yml
+++ b/examples/codeigniter.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/examples/codeigniter.yml
+++ b/examples/codeigniter.yml
@@ -15,7 +15,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, intl, curl, dom
+          extensions: mbstring, intl, curl, dom
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/laravel-mysql.yml
+++ b/examples/laravel-mysql.yml
@@ -39,7 +39,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, dom, fileinfo, mysql
+          extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/laravel-postgres.yml
+++ b/examples/laravel-postgres.yml
@@ -41,7 +41,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, dom, fileinfo, pgsql
+          extensions: mbstring, dom, fileinfo, pgsql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/laravel.yml
+++ b/examples/laravel.yml
@@ -17,7 +17,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, dom, fileinfo
+          extensions: mbstring, dom, fileinfo
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/laravel.yml
+++ b/examples/laravel.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/examples/lumen-mysql.yml
+++ b/examples/lumen-mysql.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/examples/lumen-mysql.yml
+++ b/examples/lumen-mysql.yml
@@ -39,7 +39,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, dom, fileinfo, mysql
+          extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/lumen-postgres.yml
+++ b/examples/lumen-postgres.yml
@@ -41,7 +41,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, dom, fileinfo, pgsql
+          extensions: mbstring, dom, fileinfo, pgsql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/lumen-postgres.yml
+++ b/examples/lumen-postgres.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/examples/lumen.yml
+++ b/examples/lumen.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/examples/lumen.yml
+++ b/examples/lumen.yml
@@ -17,7 +17,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, dom, fileinfo, mysql
+          extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/phalcon-mysql.yml
+++ b/examples/phalcon-mysql.yml
@@ -37,7 +37,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, dom, zip, phalcon4, mysql #use phalcon3 for the phalcon 3.x.
+          extensions: mbstring, dom, zip, phalcon4, mysql #use phalcon3 for the phalcon 3.x.
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/phalcon-postgres.yml
+++ b/examples/phalcon-postgres.yml
@@ -38,7 +38,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, dom, zip, phalcon4, pgsql #use phalcon3 for the phalcon 3.x
+          extensions: mbstring, dom, zip, phalcon4, pgsql #use phalcon3 for the phalcon 3.x
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/sage.yml
+++ b/examples/sage.yml
@@ -21,7 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring
+          extensions: mbstring
       - name: Check node versions
         run: node -v
       - name: Get yarn cache

--- a/examples/slim-framework.yml
+++ b/examples/slim-framework.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/examples/slim-framework.yml
+++ b/examples/slim-framework.yml
@@ -15,7 +15,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, simplexml, dom
+          extensions: mbstring, simplexml, dom
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/symfony-mysql.yml
+++ b/examples/symfony-mysql.yml
@@ -26,7 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, xml, ctype, iconv, mysql
+          extensions: mbstring, xml, ctype, iconv, mysql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/symfony-mysql.yml
+++ b/examples/symfony-mysql.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3']
+        php-versions: ['7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/examples/symfony-postgres.yml
+++ b/examples/symfony-postgres.yml
@@ -26,7 +26,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, xml, ctype, iconv, pgsql
+          extensions: mbstring, xml, ctype, iconv, pgsql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/symfony-postgres.yml
+++ b/examples/symfony-postgres.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3']
+        php-versions: ['7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/examples/symfony.yml
+++ b/examples/symfony.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.3']
+        php-versions: ['7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/examples/symfony.yml
+++ b/examples/symfony.yml
@@ -17,7 +17,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, xml, ctype, iconv
+          extensions: mbstring, xml, ctype, iconv
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/yii2-mysql.yml
+++ b/examples/yii2-mysql.yml
@@ -36,7 +36,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, intl, gd, imagick, zip, dom, mysql
+          extensions: mbstring, intl, gd, imagick, zip, dom, mysql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/yii2-postgres.yml
+++ b/examples/yii2-postgres.yml
@@ -36,7 +36,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, intl, gd, imagick, zip, dom, pgsql
+          extensions: mbstring, intl, gd, imagick, zip, dom, pgsql
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/examples/zend-framework.yml
+++ b/examples/zend-framework.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4']
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/examples/zend-framework.yml
+++ b/examples/zend-framework.yml
@@ -15,7 +15,7 @@ jobs:
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extension-csv: mbstring, bcmath, curl, intl
+          extensions: mbstring, bcmath, curl, intl
           coverage: xdebug #optional
       - name: Get composer cache directory
         id: composer-cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.5.8",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2249,12 +2249,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2269,17 +2271,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2396,7 +2401,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2408,6 +2414,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2422,6 +2429,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2429,12 +2437,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2453,6 +2463,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2533,7 +2544,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2545,6 +2557,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2666,6 +2679,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.5.8",
+  "version": "1.6.0",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",

--- a/src/install.ts
+++ b/src/install.ts
@@ -42,7 +42,7 @@ export async function build(
 export async function run(): Promise<void> {
   try {
     const os_version: string = process.platform;
-    const version: string = await utils.getVersion();
+    const version: string = await utils.getInput('php-version', true);
     // check the os version and run the respective script
     let script_path = '';
     switch (os_version) {
@@ -58,9 +58,7 @@ export async function run(): Promise<void> {
       }
       case 'win32':
         script_path = await build('win32.ps1', version, os_version);
-        await exec(
-          'pwsh ' + script_path + ' -version ' + version + ' -dir ' + __dirname
-        );
+        await exec('pwsh ' + script_path + ' -version ' + version);
         break;
     }
   } catch (error) {

--- a/src/install.ts
+++ b/src/install.ts
@@ -18,8 +18,12 @@ export async function build(
   os_version: string
 ): Promise<string> {
   // taking inputs
-  const extension_csv: string = await utils.getInput('extension-csv', false);
-  const ini_values_csv: string = await utils.getInput('ini-values-csv', false);
+  const extension_csv: string =
+    (await utils.getInput('extensions', false)) ||
+    (await utils.getInput('extension-csv', false));
+  const ini_values_csv: string =
+    (await utils.getInput('ini-values', false)) ||
+    (await utils.getInput('ini-values-csv', false));
   const coverage_driver: string = await utils.getInput('coverage', false);
 
   let script: string = await utils.readScript(filename, version, os_version);

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -29,7 +29,8 @@ ext_dir=$(php -i | grep "extension_dir => /usr" | sed -e "s|.*=> s*||")
 sudo chmod 777 "$ini_file"
 mkdir -p "$(pecl config-get ext_dir)"
 composer global require hirak/prestissimo >/dev/null 2>&1
-add_log "$tick" "PHP" "Installed PHP $(php -v | head -n 1 | cut -c 5-10)"
+semver=$(php -v | head -n 1 | cut -f 2 -d ' ')
+add_log "$tick" "PHP" "Installed PHP $semver"
 add_log "$tick" "Composer" "Installed"
 
 add_extension() {
@@ -46,10 +47,10 @@ add_extension() {
       (
         eval "$install_command" && \
         add_log "$tick" "$extension" "Installed and enabled"
-      ) || add_log "$cross" "$extension" "Could not install $extension on PHP$version"
+      ) || add_log "$cross" "$extension" "Could not install $extension on PHP $semver"
     else
       if ! php -m | grep -i -q "$extension"; then
-        add_log "$cross" "$extension" "Could not find $extension for PHP$version on PECL"
+        add_log "$cross" "$extension" "Could not find $extension for PHP $semver on PECL"
       fi
     fi
   fi

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -26,7 +26,6 @@ if [ "$existing_version" != "$1" ]; then
 	if [ ! -e "/usr/bin/php$1" ]; then
 		if [ "$1" = "7.4" ]; then
 		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" php"$1"-phpdbg php"$1"-xml curl php"$1"-curl >/dev/null 2>&1
-		  semver=$(php -v | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '-')
 		elif [ "$1" = "8.0" ]; then
       tar_file=php_"$1"%2Bubuntu"$(lsb_release -r -s)".tar.xz
       install_dir=~/php/"$1"
@@ -35,10 +34,8 @@ if [ "$existing_version" != "$1" ]; then
       sudo mkdir -m 777 -p ~/php
       sudo tar xf "$tar_file" -C ~/php  >/dev/null 2>&1 && rm -rf "$tar_file"
       sudo ln -sf -S "$1" "$install_dir"/bin/* /usr/bin/ && sudo ln -sf "$install_dir"/etc/php.ini /etc/php.ini
-      semver=$(php -v | head -n 1 | cut -f 2 -d ' ')
 		else
 		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" curl php"$1"-curl >/dev/null 2>&1
-		  semver=$(php -v | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '-')
 		fi
 		status="installed"
 	else
@@ -50,6 +47,12 @@ if [ "$existing_version" != "$1" ]; then
 			sudo update-alternatives --set $tool /usr/bin/"$tool$1" >/dev/null 2>&1
 		fi
 	done
+
+	semver=$(php -v | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '-')
+	if [ "$1" = "8.0" ]; then
+	  semver=$(php -v | head -n 1 | cut -f 2 -d ' ')
+	fi
+
 	if [ "$status" != "switched" ]; then
 	  status="Installed PHP $semver"
 	else

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -17,35 +17,46 @@ add_log() {
   fi
 }
 existing_version=$(php-config --version | cut -c 1-3)
-version=$1
+semver=$(php -v | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '-')
 step_log "Setup PHP and Composer"
 sudo mkdir -p /var/run
 sudo mkdir -p /run/php
 find /etc/apt/sources.list.d -type f -name 'ondrej-ubuntu-php*.list' -exec sudo DEBIAN_FRONTEND=noninteractive apt-fast update -o Dir::Etc::sourcelist="{}" ';' >/dev/null 2>&1
 if [ "$existing_version" != "$1" ]; then
 	if [ ! -e "/usr/bin/php$1" ]; then
-		if [ "$1" != "7.4" ]; then
-		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" curl php"$1"-curl >/dev/null 2>&1
-		else
+		if [ "$1" = "7.4" ]; then
 		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" php"$1"-phpdbg php"$1"-xml curl php"$1"-curl >/dev/null 2>&1
+		  semver=$(php -v | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '-')
+		elif [ "$1" = "8.0" ]; then
+      tar_file=php_"$1"%2Bubuntu"$(lsb_release -r -s)".tar.xz
+      install_dir=~/php/"$1"
+      sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libicu-dev >/dev/null 2>&1
+      curl -o "$tar_file" -L https://bintray.com/shivammathur/php/download_file?file_path="$tar_file" >/dev/null 2>&1
+      sudo mkdir -m 777 -p ~/php
+      sudo tar xf "$tar_file" -C ~/php  >/dev/null 2>&1 && rm -rf "$tar_file"
+      sudo ln -sf -S "$1" "$install_dir"/bin/* /usr/bin/ && sudo ln -sf "$install_dir"/etc/php.ini /etc/php.ini
+      semver=$(php -v | head -n 1 | cut -f 2 -d ' ')
+		else
+		  sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php"$1" curl php"$1"-curl >/dev/null 2>&1
+		  semver=$(php -v | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '-')
 		fi
 		status="installed"
 	else
 	  status="switched"
 	fi
 
-	for tool in php phar phar.phar php-cgi php-config phpize phpdbg; do
+	for tool in pear pecl php phar phar.phar php-cgi php-config phpize phpdbg; do
 		if [ -e "/usr/bin/$tool$1" ]; then
 			sudo update-alternatives --set $tool /usr/bin/"$tool$1" >/dev/null 2>&1
 		fi
 	done
 	if [ "$status" != "switched" ]; then
-	  status="Installed PHP $(php -v | head -n 1 | cut -c 5-10)"
+	  status="Installed PHP $semver"
 	else
-	  status="Switched to PHP $(php -v | head -n 1 | cut -c 5-10)"
+	  status="Switched to PHP $semver"
 	fi
 else
-  status="PHP $(php -v | head -n 1 | cut -c 5-10) Found"
+  status="PHP $semver Found"
 fi
 
 ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
@@ -88,6 +99,6 @@ add_extension()
       (
         eval "$install_command" && \
         add_log "$tick" "$extension" "Installed and enabled"
-      ) || add_log "$cross" "$extension" "Could not install $extension on php$version"
+      ) || add_log "$cross" "$extension" "Could not install $extension on PHP $semver"
   fi
 }

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -1,6 +1,5 @@
 param (
-  [Parameter(Mandatory = $true)][string]$version = "7.3",
-  [Parameter(Mandatory = $true)][string]$dir
+  [Parameter(Mandatory = $true)][string]$version = "7.3"
 )
 
 $tick = ([char]8730)
@@ -14,6 +13,10 @@ Function Step-Log($message) {
 Function Add-Log($mark, $subject, $message) {
   $code = if ($mark -eq $cross) { "31" } else { "32" }
   printf "\033[%s;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s \033[0m\n" $code $mark $subject $message
+}
+
+if ($version -eq '8.0') {
+  $version = '7.4'
 }
 
 Step-Log "Setup PhpManager"
@@ -85,6 +88,6 @@ Function Add-Extension {
     }
   }
   catch {
-    Add-Log $cross $extension "Could not enable"
+    Add-Log $cross $extension "Could not install $extension on PHP $($installed.FullVersion)"
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,24 +23,6 @@ export async function getInput(
 }
 
 /**
- * Function to read the PHP version.
- */
-export async function getVersion(): Promise<string> {
-  const version: string = await getInput('php-version', true);
-  switch (version) {
-    case '8.0':
-    case '8.0-dev':
-    case '7.4':
-    case '7.4snapshot':
-    case '7.4nightly':
-    case 'nightly':
-      return '7.4';
-    default:
-      return version;
-  }
-}
-
-/**
  * Async foreach loop
  *
  * @author https://github.com/Atinux


### PR DESCRIPTION
- Add support for `PHP 8.0.0-dev` Fixes #104.
- Deprecate `extension-csv` and `ini-values-csv` inputs in favour of `extensions` and `ini-values`.
- Update example to use `PHP 7.4`.
- Fix PHP versions in logs.
- Improve `README`
- Bump version to `1.6.0`
