### PR TITLE
Fix coverage log for Xdebug on PHP 8.0

### DIFF
--- a/.github/workflows/experimental-workflow.yml
+++ b/.github/workflows/experimental-workflow.yml
@@ -61,6 +61,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, xdebug, pcov #optional
           ini-values: post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata #optional
+          coverage: xdebug
 
       - name: Testing PHP version
         run: |

--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -34,13 +34,23 @@ describe('Config tests', () => {
   });
 
   it('checking addCoverage with Xdebug on windows', async () => {
-    const win32: string = await coverage.addCoverage('xdebug', '7.3', 'win32');
+    const win32: string = await coverage.addCoverage('xdebug', '7.4', 'win32');
     expect(win32).toContain('addExtension xdebug');
+  });
+
+  it('checking addCoverage with Xdebug on windows', async () => {
+    const win32: string = await coverage.addCoverage('xdebug', '8.0', 'win32');
+    expect(win32).toContain('Xdebug currently only supports PHP 7.4 or lower');
   });
 
   it('checking addCoverage with Xdebug on linux', async () => {
     const linux: string = await coverage.addCoverage('xdebug', '7.4', 'linux');
     expect(linux).toContain('addExtension xdebug');
+  });
+
+  it('checking addCoverage with Xdebug on linux', async () => {
+    const linux: string = await coverage.addCoverage('xdebug', '8.0', 'linux');
+    expect(linux).toContain('Xdebug currently only supports PHP 7.4 or lower');
   });
 
   it('checking addCoverage with Xdebug on darwin', async () => {
@@ -50,6 +60,15 @@ describe('Config tests', () => {
       'darwin'
     );
     expect(darwin).toContain('addExtension xdebug');
+  });
+
+  it('checking addCoverage with Xdebug on darwin', async () => {
+    const darwin: string = await coverage.addCoverage(
+      'xdebug',
+      '8.0',
+      'darwin'
+    );
+    expect(darwin).toContain('Xdebug currently only supports PHP 7.4 or lower');
   });
 
   it('checking disableCoverage windows', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1216,10 +1216,17 @@ const config = __importStar(__webpack_require__(641));
  */
 function addCoverageXdebug(version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
-        return ((yield extensions.addExtension('xdebug', version, os_version, true)) +
-            (yield utils.suppressOutput(os_version)) +
-            '\n' +
-            (yield utils.addLog('$tick', 'xdebug', 'Xdebug enabled as coverage driver', os_version)));
+        switch (version) {
+            case '8.0':
+                return ('\n' +
+                    (yield utils.addLog('$cross', 'xdebug', 'Xdebug currently only supports PHP 7.4 or lower', os_version)));
+            case '7.4':
+            default:
+                return ((yield extensions.addExtension('xdebug', version, os_version, true)) +
+                    (yield utils.suppressOutput(os_version)) +
+                    '\n' +
+                    (yield utils.addLog('$tick', 'xdebug', 'Xdebug enabled as coverage driver', os_version)));
+        }
     });
 }
 exports.addCoverageXdebug = addCoverageXdebug;

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -12,17 +12,31 @@ export async function addCoverageXdebug(
   version: string,
   os_version: string
 ): Promise<string> {
-  return (
-    (await extensions.addExtension('xdebug', version, os_version, true)) +
-    (await utils.suppressOutput(os_version)) +
-    '\n' +
-    (await utils.addLog(
-      '$tick',
-      'xdebug',
-      'Xdebug enabled as coverage driver',
-      os_version
-    ))
-  );
+  switch (version) {
+    case '8.0':
+      return (
+        '\n' +
+        (await utils.addLog(
+          '$cross',
+          'xdebug',
+          'Xdebug currently only supports PHP 7.4 or lower',
+          os_version
+        ))
+      );
+    case '7.4':
+    default:
+      return (
+        (await extensions.addExtension('xdebug', version, os_version, true)) +
+        (await utils.suppressOutput(os_version)) +
+        '\n' +
+        (await utils.addLog(
+          '$tick',
+          'xdebug',
+          'Xdebug enabled as coverage driver',
+          os_version
+        ))
+      );
+  }
 }
 
 /**


### PR DESCRIPTION
- Fix coverage log for `Xdebug` on PHP 8.0