### PR TITLE
Use apt-fast instead of apt-get

### DIFF
--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -30,15 +30,15 @@ describe('Extension tests', () => {
       'linux'
     );
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-xdebug'
+      'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php7.4-xdebug'
     );
     expect(linux).toContain('pecl install xdebug');
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-pcov'
+      'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php7.4-pcov'
     );
     expect(linux).toContain('pecl install pcov');
     expect(linux).toContain(
-      'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-igbinary php7.4-redis'
+      'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php7.4-igbinary php7.4-redis'
     );
 
     linux = await extensions.addExtension('phalcon3, phalcon4', '7.2', 'linux');

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -64,7 +64,7 @@ describe('Utils tests', () => {
   });
 
   it('checking writeScripts', async () => {
-    const testString = 'sudo apt-get install php';
+    const testString = 'sudo apt-fast install php';
     const runner_dir: string = process.env['RUNNER_TOOL_CACHE'] || '';
     const script_path: string = path.join(runner_dir, 'test.sh');
     await utils.writeScript('test.sh', testString);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2187,7 +2187,7 @@ function addExtensionLinux(extension_csv, version) {
                 switch (version + extension) {
                     case '7.4redis':
                         install_command =
-                            'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-igbinary php7.4-redis >/dev/null 2>&1';
+                            'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php7.4-igbinary php7.4-redis >/dev/null 2>&1';
                         break;
                     case '7.2phalcon3':
                     case '7.3phalcon3':
@@ -2210,7 +2210,7 @@ function addExtensionLinux(extension_csv, version) {
                         break;
                     default:
                         install_command =
-                            'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php' +
+                            'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php' +
                                 version +
                                 '-' +
                                 extension.replace('pdo_', '').replace('pdo-', '') +

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -85,7 +85,7 @@ export async function addExtensionLinux(
     switch (version + extension) {
       case '7.4redis':
         install_command =
-          'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-igbinary php7.4-redis >/dev/null 2>&1';
+          'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php7.4-igbinary php7.4-redis >/dev/null 2>&1';
         break;
       case '7.2phalcon3':
       case '7.3phalcon3':
@@ -108,7 +108,7 @@ export async function addExtensionLinux(
         break;
       default:
         install_command =
-          'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php' +
+          'sudo DEBIAN_FRONTEND=noninteractive apt-fast install -y php' +
           version +
           '-' +
           extension.replace('pdo_', '').replace('pdo-', '') +

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -29,7 +29,7 @@ if [ "$existing_version" != "$1" ]; then
 		elif [ "$1" = "8.0" ]; then
       tar_file=php_"$1"%2Bubuntu"$(lsb_release -r -s)".tar.xz
       install_dir=~/php/"$1"
-      sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libicu-dev >/dev/null 2>&1
+      sudo DEBIAN_FRONTEND=noninteractive apt-fast -y install libicu-dev >/dev/null 2>&1
       curl -o "$tar_file" -L https://bintray.com/shivammathur/php/download_file?file_path="$tar_file" >/dev/null 2>&1
       sudo mkdir -m 777 -p ~/php
       sudo tar xf "$tar_file" -C ~/php  >/dev/null 2>&1 && rm -rf "$tar_file"


### PR DESCRIPTION
---
name: ⚙ Improvement
about: You found a bug, want to improve something or add a new feature
labels: enhancement

---

### Description

This PR replaces the uses of `apt-get` by `apt-fast` to speed up packages installation.

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors.