### PR TITLE
Fix typo in available options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ with:
 Inputs supported by this GitHub Action.
 
 - php-version `required`
-- extension `optional`
+- extensions `optional`
 - ini-values `optional`
 - coverage `optional`
 - pecl `optional`


### PR DESCRIPTION
### Description 

This PR fixes a typo in the README, `extension` should actually be `extensions`.
