### PR TITLE
narrowspark/automatic-composer-prefetcher as a alternative to prestissimo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Setup PHP with required extensions, php.ini configuration, code-coverage support
 
 The latest version of the following tools can be setup globally using the `tools` input.
 
-`composer`, `codeception`, `deployer`, `pecl`, `phinx`, `phpcbf`, `phpcpd`, `php-cs-fixer`, `phpcs`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `psalm`
+`composer`, `codeception`, `deployer`, `pecl`, `phinx`, `phpcbf`, `phpcpd`, `php-cs-fixer`, `phpcs`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `composer-prefetcher`, `psalm`
 
 ```yaml
 uses: shivammathur/setup-php@v1

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -106,5 +106,13 @@ describe('Tools tests', () => {
       'Add-Content -Path $PsHome\\profile.ps1 -Value "New-Alias phinx $composer_dir\\vendor\\bin\\phinx.bat"'
     );
     expect(script).toContain('Tool does_not_exit is not supported');
+
+    script = await tools.addTools('phpstan, composer-prefetcher', 'darwin');
+    expect(script).toContain(
+      'add_tool https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar phpstan'
+    );
+    expect(script).toContain(
+      'composer global require narrowspark/automatic-composer-prefetcher'
+    );
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -1715,6 +1715,13 @@ function addTools(tools_csv, os_version) {
                                 '\n' +
                                 (yield utils.addLog('$tick', 'hirak/prestissimo', 'Added', os_version));
                         break;
+                    case 'composer-prefetcher':
+                        script +=
+                            'composer global require narrowspark/automatic-composer-prefetcher' +
+                                (yield utils.suppressOutput(os_version)) +
+                                '\n' +
+                                (yield utils.addLog('$tick', 'narrowspark/automatic-composer-prefetcher', 'Added', os_version));
+                        break;
                     case 'pecl':
                         script += yield getPECLCommand(os_version);
                         break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2267,7 +2267,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2288,12 +2289,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2308,17 +2311,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2435,7 +2441,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2447,6 +2454,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2461,6 +2469,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2468,12 +2477,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2492,6 +2503,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2581,7 +2593,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2593,6 +2606,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2678,7 +2692,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2714,6 +2729,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2733,6 +2749,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2776,12 +2793,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -179,6 +179,18 @@ export async function addTools(
             os_version
           ));
         break;
+      case 'composer-prefetcher':
+        script +=
+          'composer global require narrowspark/automatic-composer-prefetcher' +
+          (await utils.suppressOutput(os_version)) +
+          '\n' +
+          (await utils.addLog(
+            '$tick',
+            'narrowspark/automatic-composer-prefetcher',
+            'Added',
+            os_version
+          ));
+        break;
       case 'pecl':
         script += await getPECLCommand(os_version);
         break;


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Adding narrowspark/automatic-composer-prefetcher as a alternative to prestissimo
labels: enhancement

---

## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: 

> Further notes in [Contribution Guidelines](.github/CONTRIBUTING.md)
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

This PR #137

> In case this PR introduced TypeScript/JavaScript code changes:

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors.