### PR TITLE
1.7.1

### DIFF
--- a/.github/workflows/experimental-workflow.yml
+++ b/.github/workflows/experimental-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         php-versions: ['8.0']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
         php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2019 shivammathur and contributors
+Copyright (c) 2019-2020 shivammathur and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Examples for setting up this GitHub Action with different PHP Frameworks/Package
 
 |Framework/Package|Runs on|Workflow|
 |--- |--- |--- |
+|CakePHP|`macOS`, `ubuntu` and `windows`|[cakephp.yml](./examples/cakephp.yml "GitHub Action for CakePHP")|
 |CodeIgniter|`macOS`, `ubuntu` and `windows`|[codeigniter.yml](./examples/codeigniter.yml "GitHub Action for CodeIgniter")|
 |Laravel with `MySQL` and `Redis`|`ubuntu`|[laravel-mysql.yml](./examples/laravel-mysql.yml "GitHub Action for Laravel with MySQL and Redis")|
 |Laravel with `PostgreSQL` and `Redis`|`ubuntu`|[laravel-postgres.yml](./examples/laravel-postgres.yml "GitHub Action for Laravel with PostgreSQL and Redis")|

--- a/README.md
+++ b/README.md
@@ -269,7 +269,9 @@ Examples for setting up this GitHub Action with different PHP Frameworks/Package
 
 |Framework/Package|Runs on|Workflow|
 |--- |--- |--- |
-|CakePHP|`macOS`, `ubuntu` and `windows`|[cakephp.yml](./examples/cakephp.yml "GitHub Action for CakePHP")|
+|CakePHP with `MySQL` and `Redis`|`ubuntu`|[cakephp-mysql.yml](./examples/cakephp-mysql.yml "GitHub Action for CakePHP with MySQL and Redis")|
+|CakePHP with `PostgreSQL` and `Redis`|`ubuntu`|[cakephp-postgres.yml](./examples/cakephp-postgres.yml "GitHub Action for CakePHP with Postgres and Redis")|
+|CakePHP without services|`macOS`, `ubuntu` and `windows`|[cakephp.yml](./examples/cakephp.yml "GitHub Action for CakePHP without services")|
 |CodeIgniter|`macOS`, `ubuntu` and `windows`|[codeigniter.yml](./examples/codeigniter.yml "GitHub Action for CodeIgniter")|
 |Laravel with `MySQL` and `Redis`|`ubuntu`|[laravel-mysql.yml](./examples/laravel-mysql.yml "GitHub Action for Laravel with MySQL and Redis")|
 |Laravel with `PostgreSQL` and `Redis`|`ubuntu`|[laravel-postgres.yml](./examples/laravel-postgres.yml "GitHub Action for Laravel with PostgreSQL and Redis")|

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Setup PHP with required extensions, php.ini configuration, code-coverage support
 
 ## :wrench: Tools Support
 
-The latest version of the following tools can be setup globally using the `tools` input.
+These tools can be setup globally using the `tools` input.
 
 `composer`, `codeception`, `deployer`, `pecl`, `phinx`, `phpcbf`, `phpcpd`, `php-cs-fixer`, `phpcs`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `composer-prefetcher`, `psalm`
 
@@ -81,7 +81,21 @@ with:
   tools: php-cs-fixer, phpunit
 ```
 
-**Note:** `composer` is setup by default, so that is not required to be specified. 
+To setup a particular version of a tool, specify it in the form `tool:version`.  
+Version should be in semver format and a valid release of the tool.
+
+```yaml
+uses: shivammathur/setup-php@v1
+with:
+  php-version: '7.4'
+  tools: php-cs-fixer:2.15.5, phpunit:8.5.1
+``` 
+
+**Note**
+- `composer` is setup by default.
+- Specifying version for `composer` and `pecl` has no effect, latest version of both tools will be setup.
+- If the version specified for the tool is not in semver format, latest version of the tool will be setup.
+- Tools which cannot be installed gracefully leave an error message in the logs, the action is not interrupted.
 
 ## :signal_strength: Coverage support
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Setup PHP with required extensions, php.ini configuration, code-coverage support
 
 These tools can be setup globally using the `tools` input.
 
-`composer`, `codeception`, `deployer`, `pecl`, `phinx`, `phpcbf`, `phpcpd`, `php-cs-fixer`, `phpcs`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `composer-prefetcher`, `psalm`
+`codeception`, `composer`, `composer-prefetcher`, `deployer`, `pecl`, `phinx`, `phpcbf`, `phpcpd`, `php-cs-fixer`, `phpcs`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `psalm`
 
 ```yaml
 uses: shivammathur/setup-php@v1

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ See [action.yml](action.yml "Metadata for this GitHub Action") and usage below f
 ```yaml
 steps:
 - name: Checkout
-  uses: actions/checkout@v1
+  uses: actions/checkout@v2
 
 - name: Setup PHP
   uses: shivammathur/setup-php@v1
@@ -175,7 +175,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v1
@@ -200,7 +200,7 @@ jobs:
 ```yaml
 steps:
 - name: Checkout
-  uses: actions/checkout@v1
+  uses: actions/checkout@v2
 
 - name: Setup PHP
   uses: shivammathur/setup-php@v1

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -1,11 +1,20 @@
 import * as tools from '../src/tools';
 
 describe('Tools tests', () => {
-  it('checking getToolCommand', async () => {
-    expect(await tools.getToolCommand('linux')).toBe('add_tool ');
-    expect(await tools.getToolCommand('darwin')).toBe('add_tool ');
-    expect(await tools.getToolCommand('win32')).toBe('Add-Tool ');
-    expect(await tools.getToolCommand('fedora')).toContain(
+  it('checking getCommand', async () => {
+    expect(await tools.getArchiveCommand('linux')).toBe('add_tool ');
+    expect(await tools.getArchiveCommand('darwin')).toBe('add_tool ');
+    expect(await tools.getArchiveCommand('win32')).toBe('Add-Tool ');
+    expect(await tools.getArchiveCommand('fedora')).toContain(
+      'Platform fedora is not supported'
+    );
+  });
+
+  it('checking getCommand', async () => {
+    expect(await tools.getPackageCommand('linux')).toBe('add_composer_tool ');
+    expect(await tools.getPackageCommand('darwin')).toBe('add_composer_tool ');
+    expect(await tools.getPackageCommand('win32')).toBe('Add-Composer-Tool ');
+    expect(await tools.getPackageCommand('fedora')).toContain(
       'Platform fedora is not supported'
     );
   });
@@ -19,27 +28,240 @@ describe('Tools tests', () => {
     );
   });
 
-  it('checking linkTool', async () => {
-    expect(await tools.linkTool('tool', 'linux')).toContain(
-      'sudo ln -s "$(composer -q global config home)"/vendor/bin/tool /usr/local/bin/tool'
+  it('checking parseToolVersion', async () => {
+    expect(await tools.getToolVersion('latest')).toBe('latest');
+    expect(await tools.getToolVersion('1.2.3')).toBe('1.2.3');
+    expect(await tools.getToolVersion('^1.2.3')).toBe('1.2.3');
+    expect(await tools.getToolVersion('>=1.2.3')).toBe('1.2.3');
+    expect(await tools.getToolVersion('>1.2.3')).toBe('1.2.3');
+    expect(await tools.getToolVersion('1.2.3-ALPHA')).toBe('1.2.3-ALPHA');
+    expect(await tools.getToolVersion('1.2.3-alpha')).toBe('1.2.3-alpha');
+    expect(await tools.getToolVersion('1.2.3-beta')).toBe('1.2.3-beta');
+    expect(await tools.getToolVersion('1.2.3-rc')).toBe('1.2.3-rc');
+    expect(await tools.getToolVersion('1.2.3-dev')).toBe('1.2.3-dev');
+    expect(await tools.getToolVersion('1.2.3-alpha1')).toBe('1.2.3-alpha1');
+    expect(await tools.getToolVersion('1.2.3-alpha.1')).toBe('1.2.3-alpha.1');
+  });
+
+  it('checking parseToolVersion', async () => {
+    expect(await tools.parseTool('phpunit')).toStrictEqual({
+      name: 'phpunit',
+      version: 'latest'
+    });
+    expect(await tools.parseTool('phpunit:1.2.3')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3'
+    });
+    expect(await tools.parseTool('phpunit:^1.2.3')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3'
+    });
+    expect(await tools.parseTool('phpunit:>=1.2.3')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3'
+    });
+    expect(await tools.parseTool('phpunit:>1.2.3')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3'
+    });
+    expect(await tools.parseTool('phpunit:1.2.3-ALPHA')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3-ALPHA'
+    });
+    expect(await tools.parseTool('phpunit:1.2.3-alpha')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3-alpha'
+    });
+    expect(await tools.parseTool('phpunit:1.2.3-beta')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3-beta'
+    });
+    expect(await tools.parseTool('phpunit:1.2.3-rc')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3-rc'
+    });
+    expect(await tools.parseTool('phpunit:1.2.3-dev')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3-dev'
+    });
+    expect(await tools.parseTool('phpunit:1.2.3-alpha1')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3-alpha1'
+    });
+    expect(await tools.parseTool('phpunit:1.2.3-alpha.1')).toStrictEqual({
+      name: 'phpunit',
+      version: '1.2.3-alpha.1'
+    });
+  });
+
+  it('checking getUri', async () => {
+    expect(
+      await tools.getUri('tool', 'latest', 'releases', '', 'download')
+    ).toBe('releases/latest/download/tool.phar');
+    expect(
+      await tools.getUri('tool', '1.2.3', 'releases', '', 'download')
+    ).toBe('releases/download/1.2.3/tool.phar');
+    expect(
+      await tools.getUri('tool', '1.2.3', 'releases', 'v', 'download')
+    ).toBe('releases/download/v1.2.3/tool.phar');
+  });
+
+  it('checking getCodeceptionUriBuilder', async () => {
+    expect(await tools.getCodeceptionUriBuilder('3.2.1', '5.6', 'php56')).toBe(
+      'releases/3.2.1/php56/codecept.phar'
     );
-    expect(await tools.linkTool('tool', 'darwin')).toContain(
-      'sudo ln -s "$(composer -q global config home)"/vendor/bin/tool /usr/local/bin/tool'
+    expect(await tools.getCodeceptionUriBuilder('3.2.1', '7.0', 'php54')).toBe(
+      'releases/3.2.1/php54/codecept.phar'
     );
-    expect(await tools.linkTool('tool', 'win32')).toContain(
-      '$composer_dir = composer -q global config home | % {$_ -replace "/", "\\"}'
+    expect(await tools.getCodeceptionUriBuilder('3.2.1', '7.1', 'php56')).toBe(
+      'releases/3.2.1/php56/codecept.phar'
     );
-    expect(await tools.linkTool('tool', 'win32')).toContain(
-      'Add-Content -Path $PsHome\\profile.ps1 -Value "New-Alias tool $composer_dir\\vendor\\bin\\tool.bat"'
+    expect(await tools.getCodeceptionUriBuilder('3.2.1', '7.2', 'php56')).toBe(
+      'releases/3.2.1/codecept.phar'
     );
-    expect(await tools.linkTool('tool', 'fedora')).toContain(
-      'Platform fedora is not supported'
+    expect(await tools.getCodeceptionUriBuilder('3.2.1', '7.3', 'php56')).toBe(
+      'releases/3.2.1/codecept.phar'
+    );
+    expect(await tools.getCodeceptionUriBuilder('3.2.1', '7.4', 'php56')).toBe(
+      'releases/3.2.1/codecept.phar'
     );
   });
 
-  it('checking addTools', async () => {
-    let script: string = await tools.addTools(
-      'php-cs-fixer, phpstan, phpunit, pecl, phinx',
+  it('checking getCodeceptionUri', async () => {
+    expect(await tools.getCodeceptionUri('latest', '5.6')).toBe(
+      'php56/codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('latest', '7.0')).toBe(
+      'php56/codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('latest', '7.1')).toBe(
+      'php56/codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('latest', '7.2')).toBe(
+      'codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('latest', '7.3')).toBe(
+      'codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('latest', '7.4')).toBe(
+      'codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('3.2.1', '5.6')).toBe(
+      'releases/3.2.1/php54/codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('4.3.2', '5.6')).toBe(
+      'releases/4.3.2/php56/codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('3.2.1', '7.4')).toBe(
+      'releases/3.2.1/codecept.phar'
+    );
+    expect(await tools.getCodeceptionUri('4.3.2', '7.4')).toBe(
+      'releases/4.3.2/codecept.phar'
+    );
+  });
+
+  it('checking getPhpunitUri', async () => {
+    expect(await tools.getPhpunitUrl('tool', 'latest')).toBe(
+      'https://phar.phpunit.de/tool.phar'
+    );
+    expect(await tools.getPhpunitUrl('tool', '1.2.3')).toBe(
+      'https://phar.phpunit.de/tool-1.2.3.phar'
+    );
+  });
+
+  it('checking getDeployerUri', async () => {
+    expect(await tools.getDeployerUrl('latest')).toBe(
+      'https://deployer.org/deployer.phar'
+    );
+    expect(await tools.getDeployerUrl('1.2.3')).toBe(
+      'https://deployer.org/releases/v1.2.3/deployer.phar'
+    );
+  });
+
+  it('checking getDeployerUri', async () => {
+    expect(await tools.addComposer(['a', 'b'])).toStrictEqual([
+      'composer',
+      'a',
+      'b'
+    ]);
+    expect(await tools.addComposer(['a', 'b', 'composer'])).toStrictEqual([
+      'composer',
+      'a',
+      'b'
+    ]);
+    expect(
+      await tools.addComposer(['a', 'b', 'composer:1.2.3'])
+    ).toStrictEqual(['composer', 'a', 'b']);
+  });
+
+  it('checking getCleanedToolsList', async () => {
+    const tools_list: string[] = await tools.getCleanedToolsList(
+      'tool, composer:1.2.3, robmorgan/phinx, hirak/prestissimo, narrowspark/automatic-composer-prefetcher'
+    );
+    expect(tools_list).toStrictEqual([
+      'composer',
+      'tool',
+      'phinx',
+      'prestissimo',
+      'composer-prefetcher'
+    ]);
+  });
+
+  it('checking addArchive', async () => {
+    let script: string = await tools.addArchive(
+      'tool',
+      '1.2.3',
+      'https://tool.com/tool.phar',
+      'linux'
+    );
+    expect(script).toContain('add_tool https://tool.com/tool.phar tool');
+    script = await tools.addArchive(
+      'tool',
+      '1.2.3',
+      'https://tool.com/tool.phar',
+      'darwin'
+    );
+    expect(script).toContain('add_tool https://tool.com/tool.phar tool');
+    script = await tools.addArchive(
+      'tool',
+      '1.2.3',
+      'https://tool.com/tool.phar',
+      'win32'
+    );
+    expect(script).toContain('Add-Tool https://tool.com/tool.phar tool');
+
+    script = await tools.addArchive(
+      'tool',
+      '1.2.3',
+      'https://tool.com/tool.phar',
+      'fedora'
+    );
+    expect(script).toContain('Platform fedora is not supported');
+  });
+
+  it('checking addPackage', async () => {
+    let script: string = await tools.addPackage(
+      'tool',
+      'tool:1.2.3',
+      'user/',
+      'linux'
+    );
+    expect(script).toContain('add_composer_tool tool tool:1.2.3 user/');
+
+    script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'darwin');
+    expect(script).toContain('add_composer_tool tool tool:1.2.3 user/');
+
+    script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'win32');
+    expect(script).toContain('Add-Composer-Tool tool tool:1.2.3 user/');
+
+    script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'fedora');
+    expect(script).toContain('Platform fedora is not supported');
+  });
+
+  it('checking addTools on linux', async () => {
+    const script: string = await tools.addTools(
+      'php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3',
+      '7.4',
       'linux'
     );
     expect(script).toContain(
@@ -55,13 +277,13 @@ describe('Tools tests', () => {
       'add_tool https://phar.phpunit.de/phpunit.phar phpunit'
     );
     expect(script).toContain('add_pecl');
-    expect(script).toContain('composer global require robmorgan/phinx');
-    expect(script).toContain(
-      'sudo ln -s "$(composer -q global config home)"/vendor/bin/phinx /usr/local/bin/phinx'
-    );
-
-    script = await tools.addTools(
-      'phpcs, phpcbf, phpcpd, phpmd, psalm, phinx',
+    expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
+    expect(script).toContain('add_composer_tool phinx phinx:1.2.3 robmorgan/');
+  });
+  it('checking addTools on darwin', async () => {
+    const script: string = await tools.addTools(
+      'phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, composer-prefetcher:1.2.3',
+      '7.4',
       'darwin'
     );
     expect(script).toContain(
@@ -74,7 +296,7 @@ describe('Tools tests', () => {
       'add_tool https://github.com/squizlabs/PHP_CodeSniffer/releases/latest/download/phpcbf.phar phpcbf'
     );
     expect(script).toContain(
-      'add_tool https://github.com/sebastianbergmann/phpcpd/releases/latest/download/phpcpd.phar phpcpd'
+      'add_tool https://phar.phpunit.de/phpcpd.phar phpcpd'
     );
     expect(script).toContain(
       'add_tool https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar phpmd'
@@ -82,13 +304,15 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'https://github.com/vimeo/psalm/releases/latest/download/psalm.phar psalm'
     );
-    expect(script).toContain('composer global require robmorgan/phinx');
+    expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
     expect(script).toContain(
-      'sudo ln -s "$(composer -q global config home)"/vendor/bin/phinx /usr/local/bin/phinx'
+      'add_composer_tool composer-prefetcher composer-prefetcher:1.2.3 narrowspark/automatic-'
     );
-
-    script = await tools.addTools(
+  });
+  it('checking addTools on windows', async () => {
+    const script: string = await tools.addTools(
       'codeception, deployer, prestissimo, phpmd, phinx, does_not_exit',
+      '7.4',
       'win32'
     );
     expect(script).toContain(
@@ -97,22 +321,27 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'Add-Tool https://deployer.org/deployer.phar deployer'
     );
-    expect(script).toContain('composer global require hirak/prestissimo');
-    expect(script).toContain('composer global require robmorgan/phinx');
     expect(script).toContain(
-      '$composer_dir = composer -q global config home | % {$_ -replace "/", "\\"}'
+      'Add-Composer-Tool prestissimo prestissimo hirak/'
     );
-    expect(script).toContain(
-      'Add-Content -Path $PsHome\\profile.ps1 -Value "New-Alias phinx $composer_dir\\vendor\\bin\\phinx.bat"'
-    );
+    expect(script).toContain('Add-Composer-Tool phinx phinx robmorgan/');
     expect(script).toContain('Tool does_not_exit is not supported');
-
-    script = await tools.addTools('phpstan, composer-prefetcher', 'darwin');
-    expect(script).toContain(
-      'add_tool https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar phpstan'
+  });
+  it('checking addTools with composer tool using user/tool as input', async () => {
+    const script: string = await tools.addTools(
+      'hirak/prestissimo, narrowspark/automatic-composer-prefetcher, robmorgan/phinx',
+      '7.4',
+      'win32'
     );
     expect(script).toContain(
-      'composer global require narrowspark/automatic-composer-prefetcher'
+      'Add-Tool https://github.com/composer/composer/releases/latest/download/composer.phar composer'
+    );
+    expect(script).toContain(
+      'Add-Composer-Tool prestissimo prestissimo hirak/'
+    );
+    expect(script).toContain('Add-Composer-Tool phinx phinx robmorgan/');
+    expect(script).toContain(
+      'Add-Composer-Tool composer-prefetcher composer-prefetcher narrowspark/automatic-'
     );
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -20,18 +20,18 @@ inputs:
   tools:
     description: 'Setup popular tools globally.'
     required: false
-  # Deprecated options, do not use. Will not be supported after February 1, 2020.
+  # Deprecated options, do not use. Will not be supported in v2 which will be released around February 1, 2020.
   extension-csv:
     description: 'Deprecated! Use extensions instead.'
-    deprecationMessage: 'The extension-csv property will not be supported after February 1, 2020. Use extensions instead.'
+    deprecationMessage: 'The extension-csv property will not be supported in v2. Use extensions instead.'
     required: false
   ini-values-csv:
     description: 'Deprecated! Use ini-values instead.'
-    deprecationMessage: 'The ini-values-csv property will not be supported after February 1, 2020. Use ini-values instead.'
+    deprecationMessage: 'The ini-values-csv property will not be supported in v2. Use ini-values instead.'
     required: false
   pecl:
     description: 'Deprecated! Use tools instead to setup PECL.'
-    deprecationMessage: 'The pecl property will not be supported after February 1, 2020. Specify pecl in tools instead.'
+    deprecationMessage: 'The pecl property will not be supported in v2. Specify pecl in tools instead.'
     required: false
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1555,7 +1555,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils = __importStar(__webpack_require__(163));
-function getToolCommand(os_version) {
+/**
+ * Function to get command to setup tool
+ *
+ * @param os_version
+ */
+function getArchiveCommand(os_version) {
     return __awaiter(this, void 0, void 0, function* () {
         switch (os_version) {
             case 'linux':
@@ -1568,7 +1573,32 @@ function getToolCommand(os_version) {
         }
     });
 }
-exports.getToolCommand = getToolCommand;
+exports.getArchiveCommand = getArchiveCommand;
+/**
+ * Function to get command to setup tools using composer
+ *
+ * @param os_version
+ */
+function getPackageCommand(os_version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        switch (os_version) {
+            case 'linux':
+            case 'darwin':
+                return 'add_composer_tool ';
+            case 'win32':
+                return 'Add-Composer-Tool ';
+            default:
+                return yield utils.log('Platform ' + os_version + ' is not supported', os_version, 'error');
+        }
+    });
+}
+exports.getPackageCommand = getPackageCommand;
+/**
+ *
+ * Function to get command to setup PECL
+ *
+ * @param os_version
+ */
 function getPECLCommand(os_version) {
     return __awaiter(this, void 0, void 0, function* () {
         switch (os_version) {
@@ -1583,150 +1613,297 @@ function getPECLCommand(os_version) {
     });
 }
 exports.getPECLCommand = getPECLCommand;
-function linkTool(tool, os_version) {
+/**
+ * Function to get tool version
+ *
+ * @param version
+ */
+function getToolVersion(version) {
     return __awaiter(this, void 0, void 0, function* () {
-        switch (os_version) {
-            case 'linux':
-            case 'darwin':
-                return ('sudo ln -s "$(composer -q global config home)"/vendor/bin/' +
-                    tool +
-                    ' /usr/local/bin/' +
-                    tool);
-            case 'win32':
-                return ('$composer_dir = composer -q global config home | % {$_ -replace "/", "\\"}' +
-                    '\n' +
-                    'Add-Content -Path $PsHome\\profile.ps1 -Value "New-Alias ' +
-                    tool +
-                    ' $composer_dir\\vendor\\bin\\' +
-                    tool +
-                    '.bat"');
+        // semver_regex - https://semver.org/
+        const semver_regex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+        version = version.replace(/[><=^]*/, '');
+        switch (true) {
+            case semver_regex.test(version):
+                return version;
             default:
-                return yield utils.log('Platform ' + os_version + ' is not supported', os_version, 'error');
+                return 'latest';
         }
     });
 }
-exports.linkTool = linkTool;
+exports.getToolVersion = getToolVersion;
+/**
+ * Function to parse tool:version
+ *
+ * @param release
+ */
+function parseTool(release) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const parts = release.split(':');
+        const tool = parts[0];
+        const version = parts[1];
+        switch (version) {
+            case undefined:
+                return {
+                    name: tool,
+                    version: 'latest'
+                };
+            default:
+                return {
+                    name: tool,
+                    version: yield getToolVersion(parts[1])
+                };
+        }
+    });
+}
+exports.parseTool = parseTool;
+/**
+ * Function to get the url of tool with the given version
+ *
+ * @param version
+ * @param prefix
+ * @param version_prefix
+ * @param verb
+ */
+function getUri(tool, version, prefix, version_prefix, verb) {
+    return __awaiter(this, void 0, void 0, function* () {
+        switch (version) {
+            case 'latest':
+                return [prefix, version, verb, tool + '.phar'].filter(Boolean).join('/');
+            default:
+                return [prefix, verb, version_prefix + version, tool + '.phar']
+                    .filter(Boolean)
+                    .join('/');
+        }
+    });
+}
+exports.getUri = getUri;
+/**
+ * Helper function to get the codeception url
+ *
+ * @param version
+ * @param php_version
+ * @param suffix
+ */
+function getCodeceptionUriBuilder(version, php_version, suffix) {
+    return __awaiter(this, void 0, void 0, function* () {
+        switch (true) {
+            case /^5\.6$|^7\.[0|1]$/.test(php_version):
+                return ['releases', version, suffix, 'codecept.phar']
+                    .filter(Boolean)
+                    .join('/');
+            case /^7\.[2-4]$/.test(php_version):
+            default:
+                return ['releases', version, 'codecept.phar'].filter(Boolean).join('/');
+        }
+    });
+}
+exports.getCodeceptionUriBuilder = getCodeceptionUriBuilder;
+/**
+ * Function to get the codeception url
+ *
+ * @param version
+ * @param php_version
+ */
+function getCodeceptionUri(version, php_version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        switch (true) {
+            case /latest/.test(version):
+                switch (true) {
+                    case /^5\.6$|^7\.[0|1]$/.test(php_version):
+                        return 'php56/codecept.phar';
+                    case /^7\.[2-4]$/.test(php_version):
+                    default:
+                        return 'codecept.phar';
+                }
+            case /([4-9]|\d{2,})\..*/.test(version):
+                return yield getCodeceptionUriBuilder(version, php_version, 'php56');
+            default:
+                return yield getCodeceptionUriBuilder(version, php_version, 'php54');
+        }
+    });
+}
+exports.getCodeceptionUri = getCodeceptionUri;
+/**
+ * Function to get the PHPUnit url
+ *
+ * @param version
+ */
+function getPhpunitUrl(tool, version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const phpunit = 'https://phar.phpunit.de';
+        switch (version) {
+            case 'latest':
+                return phpunit + '/' + tool + '.phar';
+            default:
+                return phpunit + '/' + tool + '-' + version + '.phar';
+        }
+    });
+}
+exports.getPhpunitUrl = getPhpunitUrl;
+/**
+ * Function to get the Deployer url
+ *
+ * @param version
+ */
+function getDeployerUrl(version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const deployer = 'https://deployer.org';
+        switch (version) {
+            case 'latest':
+                return deployer + '/deployer.phar';
+            default:
+                return deployer + '/releases/v' + version + '/deployer.phar';
+        }
+    });
+}
+exports.getDeployerUrl = getDeployerUrl;
+/**
+ * Function to add/move composer in the tools list
+ *
+ * @param tools
+ */
+function addComposer(tools_list) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const regex = /^composer($|:.*)/;
+        const composer = tools_list.filter(tool => regex.test(tool))[0];
+        switch (composer) {
+            case undefined:
+                break;
+            default:
+                tools_list = tools_list.filter(tool => !regex.test(tool));
+                break;
+        }
+        tools_list.unshift('composer');
+        return tools_list;
+    });
+}
+exports.addComposer = addComposer;
+/**
+ * Function to get Tools list after cleanup
+ *
+ * @param tools_csv
+ */
+function getCleanedToolsList(tools_csv) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let tools_list = yield utils.CSVArray(tools_csv);
+        tools_list = yield addComposer(tools_list);
+        tools_list = tools_list
+            .map(function (extension) {
+            return extension
+                .trim()
+                .replace(/robmorgan\/|hirak\/|narrowspark\/automatic-/, '');
+        })
+            .filter(Boolean);
+        return [...new Set(tools_list)];
+    });
+}
+exports.getCleanedToolsList = getCleanedToolsList;
+/**
+ * Helper function to get script to setup a tool using a phar url
+ *
+ * @param tool
+ * @param version
+ * @param url
+ * @param os_version
+ */
+function addArchive(tool, version, url, os_version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return (yield getArchiveCommand(os_version)) + url + ' ' + tool;
+    });
+}
+exports.addArchive = addArchive;
+/**
+ * Helper function to get script to setup a tool using composer
+ *
+ * @param tool
+ * @param release
+ * @param prefix
+ * @param os_version
+ */
+function addPackage(tool, release, prefix, os_version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const tool_command = yield getPackageCommand(os_version);
+        return tool_command + tool + ' ' + release + ' ' + prefix;
+    });
+}
+exports.addPackage = addPackage;
 /**
  * Setup tools
  *
  * @param tool_csv
  * @param os_version
  */
-function addTools(tools_csv, os_version) {
+function addTools(tools_csv, php_version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
         let script = '\n' + (yield utils.stepLog('Setup Tools', os_version));
-        let tools = yield utils.CSVArray(tools_csv);
-        tools = tools.filter(tool => tool !== 'composer');
-        tools.unshift('composer');
-        yield utils.asyncForEach(tools, function (tool) {
+        const tools_list = yield getCleanedToolsList(tools_csv);
+        yield utils.asyncForEach(tools_list, function (release) {
             return __awaiter(this, void 0, void 0, function* () {
+                const tool_data = yield parseTool(release);
+                const tool = tool_data.name;
+                const version = tool_data.version;
+                const github = 'https://github.com/';
+                let uri = yield getUri(tool, version, 'releases', '', 'download');
                 script += '\n';
+                let url = '';
                 switch (tool) {
                     case 'php-cs-fixer':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/latest/download/php-cs-fixer.phar' +
-                                ' ' +
-                                'php-cs-fixer';
+                        uri = yield getUri(tool, version, 'releases', 'v', 'download');
+                        url = github + 'FriendsOfPHP/PHP-CS-Fixer/' + uri;
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'phpcs':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://github.com/squizlabs/PHP_CodeSniffer/releases/latest/download/phpcs.phar' +
-                                ' ' +
-                                'phpcs';
-                        break;
                     case 'phpcbf':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://github.com/squizlabs/PHP_CodeSniffer/releases/latest/download/phpcbf.phar' +
-                                ' ' +
-                                'phpcbf';
-                        break;
-                    case 'phpcpd':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://github.com/sebastianbergmann/phpcpd/releases/latest/download/phpcpd.phar' +
-                                ' ' +
-                                'phpcpd';
+                        url = github + 'squizlabs/PHP_CodeSniffer/' + uri;
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'phpstan':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar' +
-                                ' ' +
-                                'phpstan';
+                        url = github + 'phpstan/phpstan/' + uri;
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'phpmd':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar' +
-                                ' ' +
-                                'phpmd';
+                        url = github + 'phpmd/phpmd/' + uri;
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'psalm':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://github.com/vimeo/psalm/releases/latest/download/psalm.phar' +
-                                ' ' +
-                                'psalm';
-                        break;
-                    case 'phinx':
-                        script +=
-                            'composer global require robmorgan/phinx' +
-                                (yield utils.suppressOutput(os_version)) +
-                                '\n' +
-                                (yield linkTool('phinx', os_version)) +
-                                '\n' +
-                                (yield utils.addLog('$tick', 'phinx', 'Added', os_version));
+                        url = github + 'vimeo/psalm/' + uri;
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'composer':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://github.com/composer/composer/releases/latest/download/composer.phar' +
-                                ' ' +
-                                'composer';
+                        url =
+                            github + 'composer/composer/releases/latest/download/composer.phar';
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'codeception':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://codeception.com/codecept.phar' +
-                                ' ' +
-                                'codeception';
+                        url =
+                            'https://codeception.com/' +
+                                (yield getCodeceptionUri(version, php_version));
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
+                    case 'phpcpd':
                     case 'phpunit':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://phar.phpunit.de/phpunit.phar' +
-                                ' ' +
-                                'phpunit';
+                        url = yield getPhpunitUrl(tool, version);
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'deployer':
-                        script +=
-                            (yield getToolCommand(os_version)) +
-                                'https://deployer.org/deployer.phar' +
-                                ' ' +
-                                'deployer';
+                        url = yield getDeployerUrl(version);
+                        script += yield addArchive(tool, version, url, os_version);
+                        break;
+                    case 'phinx':
+                        script += yield addPackage(tool, release, 'robmorgan/', os_version);
                         break;
                     case 'prestissimo':
-                        script +=
-                            'composer global require hirak/prestissimo' +
-                                (yield utils.suppressOutput(os_version)) +
-                                '\n' +
-                                (yield utils.addLog('$tick', 'hirak/prestissimo', 'Added', os_version));
+                        script += yield addPackage(tool, release, 'hirak/', os_version);
                         break;
                     case 'composer-prefetcher':
-                        script +=
-                            'composer global require narrowspark/automatic-composer-prefetcher' +
-                                (yield utils.suppressOutput(os_version)) +
-                                '\n' +
-                                (yield utils.addLog('$tick', 'narrowspark/automatic-composer-prefetcher', 'Added', os_version));
+                        script += yield addPackage(tool, release, 'narrowspark/automatic-', os_version);
                         break;
                     case 'pecl':
                         script += yield getPECLCommand(os_version);
                         break;
                     default:
-                        script += yield utils.log('Tool ' + tool + ' is not supported', os_version, 'error');
+                        script += yield utils.addLog('$cross', tool, 'Tool ' + tool + ' is not supported', os_version);
                         break;
                 }
             });
@@ -2049,7 +2226,7 @@ function build(filename, version, os_version) {
             tools_csv = 'pecl, ' + tools_csv;
         }
         let script = yield utils.readScript(filename, version, os_version);
-        script += yield tools.addTools(tools_csv, os_version);
+        script += yield tools.addTools(tools_csv, version, os_version);
         if (extension_csv) {
             script += yield extensions.addExtension(extension_csv, version, os_version);
         }

--- a/examples/bedrock.yml
+++ b/examples/bedrock.yml
@@ -11,7 +11,7 @@ jobs:
         php-versions: ['7.1', '7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/cakephp-mysql.yml
+++ b/examples/cakephp-mysql.yml
@@ -1,23 +1,39 @@
-# GitHub Action for CakePHP
+# GitHub Action for CakePHP with MySQL and Redis
 # Tested with https://github.com/cakephp/app
-name: Testing CakePHP
+name: Testing CakePHP with MySQL
 on: [push, pull_request]
 jobs:
   tests:
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
         php-versions: ['7.2', '7.3', '7.4']
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: false
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: cakephp
+        ports:
+          - 3306/tcp
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      redis:
+        image: redis
+        ports:
+          - 6379/tcp
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
+        uses: shivammathur/setup-php@v1
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, pdo_sqlite, pdo_mysql
-          coverage: pcov #optional
+          # You can also use ext-apcu or ext-memcached instead of ext-redis
+          # Install memcached if using ext-memcached
+          extensions: mbstring, intl, redis, pdo_mysql
+          coverage: pcov
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -33,8 +49,12 @@ jobs:
         run: |
           composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
           composer run-script post-install-cmd --no-interaction
+      # Add a step to run migrations if required
       - name: Test with phpunit
         run: vendor/bin/phpunit --coverage-text
+        env:
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+          DB_DSN: "mysql://root:password@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/cakephp?init[]=SET sql_mode = \"STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION\""
 
   coding-standard:
     name: Coding Standard

--- a/examples/cakephp-postgres.yml
+++ b/examples/cakephp-postgres.yml
@@ -1,23 +1,39 @@
-# GitHub Action for CakePHP
+# GitHub Action for CakePHP with PostgreSQL and Redis
 # Tested with https://github.com/cakephp/app
-name: Testing CakePHP
+name: Testing CakePHP with PostgreSQL
 on: [push, pull_request]
 jobs:
   tests:
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
         php-versions: ['7.2', '7.3', '7.4']
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432/tcp
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      redis:
+        image: redis
+        ports:
+          - 6379/tcp
+        options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
+        uses: shivammathur/setup-php@v1
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, pdo_sqlite, pdo_mysql
-          coverage: pcov #optional
+          # You can also use ext-apcu or ext-memcached instead of ext-redis
+          # Install memcached if using ext-memcached
+          extensions: mbstring, intl, redis, pdo_pgsql
+          coverage: pcov
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -33,8 +49,12 @@ jobs:
         run: |
           composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
           composer run-script post-install-cmd --no-interaction
+      # Add a step to run migrations if required
       - name: Test with phpunit
         run: vendor/bin/phpunit --coverage-text
+        env:
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+          DB_DSN: postgres://postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres
 
   coding-standard:
     name: Coding Standard

--- a/examples/cakephp.yml
+++ b/examples/cakephp.yml
@@ -1,0 +1,91 @@
+# GitHub Action for CakePHP
+name: Testing CakePHP
+on: [push, pull_request]
+jobs:
+  tests:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+        php-versions: ['7.2', '7.3', '7.4']
+    runs-on: ${{ matrix.operating-system }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pdo_sqlite, pdo_mysql
+          coverage: pcov #optional
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          # Use composer.json for key, if composer.lock is not committed.
+          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: |
+          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+          composer run-script post-install-cmd --no-interaction
+      - name: Test with phpunit
+        run: vendor/bin/phpunit --coverage-text
+
+  coding-standard:
+    name: Coding Standard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: '7.3'
+          extensions: mbstring, intl
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          # Use composer.json for key, if composer.lock is not committed.
+          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+      - name: PHP CodeSniffer
+        run: composer cs-check
+
+  static-analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: '7.3'
+          extensions: mbstring, intl
+          tools: phpstan
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          # Use composer.json for key, if composer.lock is not committed.
+          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+      - name: Static Analysis using PHPStan
+        run: phpstan analyse --no-progress src/

--- a/examples/codeigniter.yml
+++ b/examples/codeigniter.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/laravel-mysql.yml
+++ b/examples/laravel-mysql.yml
@@ -34,7 +34,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/laravel-mysql.yml
+++ b/examples/laravel-mysql.yml
@@ -21,7 +21,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: laravel
         ports:
-          - 3306
+          - 3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       redis:
         image: redis
@@ -64,7 +64,9 @@ jobs:
         run: php artisan migrate -v
         env:
           DB_PORT: ${{ job.services.mysql.ports['3306'] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       - name: Test with phpunit
         run: vendor/bin/phpunit --coverage-text
         env:
           DB_PORT: ${{ job.services.mysql.ports['3306'] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}

--- a/examples/laravel-postgres.yml
+++ b/examples/laravel-postgres.yml
@@ -66,7 +66,9 @@ jobs:
         run: php artisan migrate -v
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       - name: Test with phpunit
         run: vendor/bin/phpunit --coverage-text
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}

--- a/examples/laravel-postgres.yml
+++ b/examples/laravel-postgres.yml
@@ -36,7 +36,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/laravel.yml
+++ b/examples/laravel.yml
@@ -12,7 +12,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/lumen-mysql.yml
+++ b/examples/lumen-mysql.yml
@@ -34,7 +34,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/lumen-mysql.yml
+++ b/examples/lumen-mysql.yml
@@ -21,7 +21,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: lumen
         ports:
-          - 3306
+          - 3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       redis:
         image: redis
@@ -64,7 +64,9 @@ jobs:
         run: php artisan migrate -v
         env:
           DB_PORT: ${{ job.services.mysql.ports['3306'] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       - name: Test with phpunit
         run: vendor/bin/phpunit --coverage-text
         env:
           DB_PORT: ${{ job.services.mysql.ports['3306'] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}

--- a/examples/lumen-postgres.yml
+++ b/examples/lumen-postgres.yml
@@ -66,7 +66,9 @@ jobs:
         run: php artisan migrate -v
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
       - name: Test with phpunit
         run: vendor/bin/phpunit --coverage-text
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}
+          REDIS_PORT: ${{ job.services.redis.ports['6379'] }}

--- a/examples/lumen-postgres.yml
+++ b/examples/lumen-postgres.yml
@@ -36,7 +36,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/lumen.yml
+++ b/examples/lumen.yml
@@ -12,7 +12,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/phalcon-mysql.yml
+++ b/examples/phalcon-mysql.yml
@@ -34,7 +34,7 @@ jobs:
       # php-versions: ['7.0', '7.1', '7.2', '7.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/phalcon-mysql.yml
+++ b/examples/phalcon-mysql.yml
@@ -24,7 +24,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: phalcon
         ports:
-          - 3306
+          - 3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       fail-fast: false

--- a/examples/phalcon-postgres.yml
+++ b/examples/phalcon-postgres.yml
@@ -35,7 +35,7 @@ jobs:
       # php-versions: ['7.0', '7.1', '7.2', '7.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/sage.yml
+++ b/examples/sage.yml
@@ -12,7 +12,7 @@ jobs:
         node-versions: ['8', '10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:

--- a/examples/slim-framework.yml
+++ b/examples/slim-framework.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/symfony-mysql.yml
+++ b/examples/symfony-mysql.yml
@@ -13,7 +13,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: symfony
           MYSQL_DATABASE: symfony
         ports:
-          - 3306
+          - 3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       fail-fast: false

--- a/examples/symfony-mysql.yml
+++ b/examples/symfony-mysql.yml
@@ -21,7 +21,7 @@ jobs:
         php-versions: ['7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/symfony-postgres.yml
+++ b/examples/symfony-postgres.yml
@@ -21,7 +21,7 @@ jobs:
         php-versions: ['7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/symfony.yml
+++ b/examples/symfony.yml
@@ -12,7 +12,7 @@ jobs:
         php-versions: ['7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/examples/yii2-mysql.yml
+++ b/examples/yii2-mysql.yml
@@ -19,7 +19,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: yii
           MYSQL_DATABASE: yii
         ports:
-          - 3306
+          - 3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       fail-fast: false

--- a/examples/yii2-mysql.yml
+++ b/examples/yii2-mysql.yml
@@ -27,7 +27,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set Node.js 10.x
         uses: actions/setup-node@v1
         with:

--- a/examples/yii2-postgres.yml
+++ b/examples/yii2-postgres.yml
@@ -27,7 +27,7 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set Node.js 10.x
         uses: actions/setup-node@v1
         with:

--- a/examples/zend-framework.yml
+++ b/examples/zend-framework.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -536,9 +536,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
-      "integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
+      "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -2267,7 +2267,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2288,12 +2289,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2308,17 +2311,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2435,7 +2441,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2447,6 +2454,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2461,6 +2469,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2468,12 +2477,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2492,6 +2503,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2581,7 +2593,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2593,6 +2606,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2678,7 +2692,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2714,6 +2729,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2733,6 +2749,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2776,12 +2793,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,9 +518,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.22.tgz",
-      "integrity": "sha512-r5i93jqbPWGXYXxianGATOxTelkp6ih/U0WVnvaqAvTqM+0U6J3kw6Xk6uq/dWNRkEVw/0SLcO5ORXbVNz4FMQ==",
+      "version": "12.12.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz",
+      "integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -551,12 +551,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.14.0.tgz",
-      "integrity": "sha512-sneOJ3Hu0m5whJiVIxGBZZZMxMJ7c0LhAJzeMJgHo+n5wFs+/6rSR/gl7crkdR2kNwfOOSdzdc0gMvatG4dX2Q==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.15.0.tgz",
+      "integrity": "sha512-XRJFznI5v4K1WvIrWmjFjBAdQWaUTz4xJEdqR7+wAFsv6Q9dP3mOlE6BMNT3pdlp9eF1+bC5m5LZTmLMqffCVw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.14.0",
+        "@typescript-eslint/experimental-utils": "2.15.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -564,32 +564,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.14.0.tgz",
-      "integrity": "sha512-KcyKS7G6IWnIgl3ZpyxyBCxhkBPV+0a5Jjy2g5HxlrbG2ZLQNFeneIBVXdaBCYOVjvGmGGFKom1kgiAY75SDeQ==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.15.0.tgz",
+      "integrity": "sha512-Qkxu5zndY5hqlcQkmA88gfLvqQulMpX/TN91XC7OuXsRf4XG5xLGie0sbpX97o/oeccjeZYRMipIsjKk/tjDHA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.14.0",
+        "@typescript-eslint/typescript-estree": "2.15.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.14.0.tgz",
-      "integrity": "sha512-haS+8D35fUydIs+zdSf4BxpOartb/DjrZ2IxQ5sR8zyGfd77uT9ZJZYF8+I0WPhzqHmfafUBx8MYpcp8pfaoSA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.15.0.tgz",
+      "integrity": "sha512-6iSgQsqAYTaHw59t0tdjzZJluRAjswdGltzKEdLtcJOxR2UVTPHYvZRqkAVGCkaMVb6Fpa60NnuozNCvsSpA9g==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.14.0",
-        "@typescript-eslint/typescript-estree": "2.14.0",
+        "@typescript-eslint/experimental-utils": "2.15.0",
+        "@typescript-eslint/typescript-estree": "2.15.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.14.0.tgz",
-      "integrity": "sha512-pnLpUcMNG7GfFFfNQbEX6f1aPa5fMnH2G9By+A1yovYI4VIOK2DzkaRuUlIkbagpAcrxQHLqovI1YWqEcXyRnA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.15.0.tgz",
+      "integrity": "sha512-L6Pog+w3VZzXkAdyqA0VlwybF8WcwZX+mufso86CMxSdWmcizJ38lgBdpqTbc9bo92iyi0rOvmATKiwl+amjxg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -602,9 +602,9 @@
       }
     },
     "@zeit/ncc": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.20.5.tgz",
-      "integrity": "sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.21.0.tgz",
+      "integrity": "sha512-RUMdvVK/w78oo+yBjruZltt0kJXYar2un/1bYQ2LuHG7GmFVm+QjxzEmySwREctaJdEnBvlMdUNWd9hXHxEI3g==",
       "dev": true
     },
     "abab": {
@@ -867,9 +867,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -1623,9 +1623,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.1.tgz",
+      "integrity": "sha512-Q8t2YZ+0e0pc7NRVj3B4tSQ9rim1oi4Fh46k2xhJ2qOiEwhQfdjyEQddWdj7ZFaKmU+5104vn1qrcjEPWq+bgQ==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -1807,9 +1807,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.2.0.tgz",
-      "integrity": "sha512-/jbCUW+g0jejXAvsytgcNhii6uEgolt0RO2e4+mhmXybfkcram5V3XIyrHCnUsb0vCmDKgHhJ1lYSm7F3VCEDA==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.3.0.tgz",
+      "integrity": "sha512-GE6CR4ESJeu6Huw7vfZfaXHmX2R2kCFvf2X9OMcOxfP158yLKgLWz7PqLYTwRDACi84IhpmRxO8lK7GGwG05UQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^2.5.0"
@@ -2267,8 +2267,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2289,14 +2288,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2311,20 +2308,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2441,8 +2435,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2454,7 +2447,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2469,7 +2461,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2477,14 +2468,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2503,7 +2492,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2593,8 +2581,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2606,7 +2593,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2692,8 +2678,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2729,7 +2714,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2749,7 +2733,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2793,14 +2776,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3048,9 +3029,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3173,9 +3154,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3230,9 +3211,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
-      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
+      "integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -4342,18 +4323,18 @@
       }
     },
     "mime-db": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
@@ -5080,9 +5061,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
-      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -5781,9 +5762,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -5953,9 +5934,9 @@
       }
     },
     "ts-jest": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.2.0.tgz",
-      "integrity": "sha512-Yc+HLyldlIC9iIK8xEN7tV960Or56N49MDP7hubCZUeI7EbIOTsas6rXCMB4kQjLACJ7eDOF4xWEO5qumpKsag==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",
+      "integrity": "sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -6045,9 +6026,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
-      "integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+      "integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6381,9 +6362,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^12.12.16",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",
-    "@zeit/ncc": "^0.20.5",
+    "@zeit/ncc": "^0.21.0",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-import": "^2.19.1",

--- a/src/install.ts
+++ b/src/install.ts
@@ -34,7 +34,7 @@ export async function build(
   }
 
   let script: string = await utils.readScript(filename, version, os_version);
-  script += await tools.addTools(tools_csv, os_version);
+  script += await tools.addTools(tools_csv, version, os_version);
 
   if (extension_csv) {
     script += await extensions.addExtension(extension_csv, version, os_version);

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -57,10 +57,25 @@ add_tool() {
     if [ ! -e /usr/local/bin/"$tool" ]; then
       rm -rf /usr/local/bin/"${tool:?}"
     fi
-    sudo curl -o /usr/local/bin/"$tool" -L "$url" >/dev/null 2>&1
-    sudo chmod a+x /usr/local/bin/"$tool"
+    status_code=$(sudo curl -s -w "%{http_code}" -o /usr/local/bin/"$tool" -L "$url")
+    if [ "$status_code" = "200" ]; then
+      sudo chmod a+x /usr/local/bin/"$tool"
+      add_log "$tick" "$tool" "Added"
+    else
+      add_log "$cross" "$tool" "Could not setup $tool"
+    fi
   fi
+}
+
+add_composer_tool() {
+  tool=$1
+  release=$2
+  prefix=$3
+  (
+  composer global require "$prefix$release" >/dev/null 2>&1 && \
+  sudo ln -sf "$(composer -q global config home)"/vendor/bin/"$tool" /usr/local/bin/"$tool" && \
   add_log "$tick" "$tool" "Added"
+  ) || add_log "$cross" "$tool" "Could not setup $tool"
 }
 
 add_pecl() {

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -57,9 +57,24 @@ add_tool() {
   if [ ! -e /usr/local/bin/"$tool" ]; then
     rm -rf /usr/local/bin/"${tool:?}"
   fi
-  sudo curl -o /usr/local/bin/"$tool" -L "$url" >/dev/null 2>&1
-  sudo chmod a+x /usr/local/bin/"$tool"
+  status_code=$(sudo curl -s -w "%{http_code}" -o /usr/local/bin/"$tool" -L "$url")
+  if [ "$status_code" = "200" ]; then
+    sudo chmod a+x /usr/local/bin/"$tool"
+    add_log "$tick" "$tool" "Added"
+  else
+    add_log "$cross" "$tool" "Could not setup $tool"
+  fi
+}
+
+add_composer_tool() {
+  tool=$1
+  release=$2
+  prefix=$3
+  (
+  composer global require "$prefix$release" >/dev/null 2>&1 && \
+  sudo ln -sf "$(composer -q global config home)"/vendor/bin/"$tool" /usr/local/bin/"$tool" && \
   add_log "$tick" "$tool" "Added"
+  ) || add_log "$cross" "$tool" "Could not setup $tool"
 }
 
 # Function to setup the nightly build from master branch

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -133,11 +133,11 @@ if [ "$existing_version" != "$version" ]; then
     update_ppa
     ppa_updated=1
     if [ "$version" = "7.4" ]; then
-      $apt_install php"$version" php"$version"-phpdbg php"$version"-xml curl php"$version"-curl >/dev/null 2>&1
+      $apt_install php"$version" php"$version"-curl php"$version"-mbstring php"$version"-xml php"$version"-phpdbg >/dev/null 2>&1
     elif [ "$version" = "8.0" ]; then
       setup_master
     else
-      $apt_install php"$version" curl php"$version"-curl >/dev/null 2>&1
+      $apt_install php"$version" php"$version"-curl php"$version"-mbstring php"$version"-xml >/dev/null 2>&1
     fi
     status="installed"
   else

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,6 +1,11 @@
 import * as utils from './utils';
 
-export async function getToolCommand(os_version: string): Promise<string> {
+/**
+ * Function to get command to setup tool
+ *
+ * @param os_version
+ */
+export async function getArchiveCommand(os_version: string): Promise<string> {
   switch (os_version) {
     case 'linux':
     case 'darwin':
@@ -16,6 +21,33 @@ export async function getToolCommand(os_version: string): Promise<string> {
   }
 }
 
+/**
+ * Function to get command to setup tools using composer
+ *
+ * @param os_version
+ */
+export async function getPackageCommand(os_version: string): Promise<string> {
+  switch (os_version) {
+    case 'linux':
+    case 'darwin':
+      return 'add_composer_tool ';
+    case 'win32':
+      return 'Add-Composer-Tool ';
+    default:
+      return await utils.log(
+        'Platform ' + os_version + ' is not supported',
+        os_version,
+        'error'
+      );
+  }
+}
+
+/**
+ *
+ * Function to get command to setup PECL
+ *
+ * @param os_version
+ */
 export async function getPECLCommand(os_version: string): Promise<string> {
   switch (os_version) {
     case 'linux':
@@ -32,36 +64,227 @@ export async function getPECLCommand(os_version: string): Promise<string> {
   }
 }
 
-export async function linkTool(
+/**
+ * Function to get tool version
+ *
+ * @param version
+ */
+export async function getToolVersion(version: string): Promise<string> {
+  // semver_regex - https://semver.org/
+  const semver_regex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+  version = version.replace(/[><=^]*/, '');
+  switch (true) {
+    case semver_regex.test(version):
+      return version;
+    default:
+      return 'latest';
+  }
+}
+
+/**
+ * Function to parse tool:version
+ *
+ * @param release
+ */
+export async function parseTool(
+  release: string
+): Promise<{name: string; version: string}> {
+  const parts: string[] = release.split(':');
+  const tool: string = parts[0];
+  const version: string | undefined = parts[1];
+  switch (version) {
+    case undefined:
+      return {
+        name: tool,
+        version: 'latest'
+      };
+    default:
+      return {
+        name: tool,
+        version: await getToolVersion(parts[1])
+      };
+  }
+}
+
+/**
+ * Function to get the url of tool with the given version
+ *
+ * @param version
+ * @param prefix
+ * @param version_prefix
+ * @param verb
+ */
+export async function getUri(
   tool: string,
+  version: string,
+  prefix: string,
+  version_prefix: string,
+  verb: string
+): Promise<string> {
+  switch (version) {
+    case 'latest':
+      return [prefix, version, verb, tool + '.phar'].filter(Boolean).join('/');
+    default:
+      return [prefix, verb, version_prefix + version, tool + '.phar']
+        .filter(Boolean)
+        .join('/');
+  }
+}
+
+/**
+ * Helper function to get the codeception url
+ *
+ * @param version
+ * @param php_version
+ * @param suffix
+ */
+export async function getCodeceptionUriBuilder(
+  version: string,
+  php_version: string,
+  suffix: string
+): Promise<string> {
+  switch (true) {
+    case /^5\.6$|^7\.[0|1]$/.test(php_version):
+      return ['releases', version, suffix, 'codecept.phar']
+        .filter(Boolean)
+        .join('/');
+    case /^7\.[2-4]$/.test(php_version):
+    default:
+      return ['releases', version, 'codecept.phar'].filter(Boolean).join('/');
+  }
+}
+
+/**
+ * Function to get the codeception url
+ *
+ * @param version
+ * @param php_version
+ */
+export async function getCodeceptionUri(
+  version: string,
+  php_version: string
+): Promise<string> {
+  switch (true) {
+    case /latest/.test(version):
+      switch (true) {
+        case /^5\.6$|^7\.[0|1]$/.test(php_version):
+          return 'php56/codecept.phar';
+        case /^7\.[2-4]$/.test(php_version):
+        default:
+          return 'codecept.phar';
+      }
+    case /([4-9]|\d{2,})\..*/.test(version):
+      return await getCodeceptionUriBuilder(version, php_version, 'php56');
+    default:
+      return await getCodeceptionUriBuilder(version, php_version, 'php54');
+  }
+}
+
+/**
+ * Function to get the PHPUnit url
+ *
+ * @param version
+ */
+export async function getPhpunitUrl(
+  tool: string,
+  version: string
+): Promise<string> {
+  const phpunit = 'https://phar.phpunit.de';
+  switch (version) {
+    case 'latest':
+      return phpunit + '/' + tool + '.phar';
+    default:
+      return phpunit + '/' + tool + '-' + version + '.phar';
+  }
+}
+
+/**
+ * Function to get the Deployer url
+ *
+ * @param version
+ */
+export async function getDeployerUrl(version: string): Promise<string> {
+  const deployer = 'https://deployer.org';
+  switch (version) {
+    case 'latest':
+      return deployer + '/deployer.phar';
+    default:
+      return deployer + '/releases/v' + version + '/deployer.phar';
+  }
+}
+
+/**
+ * Function to add/move composer in the tools list
+ *
+ * @param tools
+ */
+export async function addComposer(tools_list: string[]): Promise<string[]> {
+  const regex = /^composer($|:.*)/;
+  const composer: string = tools_list.filter(tool => regex.test(tool))[0];
+  switch (composer) {
+    case undefined:
+      break;
+    default:
+      tools_list = tools_list.filter(tool => !regex.test(tool));
+      break;
+  }
+  tools_list.unshift('composer');
+  return tools_list;
+}
+
+/**
+ * Function to get Tools list after cleanup
+ *
+ * @param tools_csv
+ */
+export async function getCleanedToolsList(
+  tools_csv: string
+): Promise<string[]> {
+  let tools_list: string[] = await utils.CSVArray(tools_csv);
+  tools_list = await addComposer(tools_list);
+  tools_list = tools_list
+    .map(function(extension: string) {
+      return extension
+        .trim()
+        .replace(/robmorgan\/|hirak\/|narrowspark\/automatic-/, '');
+    })
+    .filter(Boolean);
+  return [...new Set(tools_list)];
+}
+
+/**
+ * Helper function to get script to setup a tool using a phar url
+ *
+ * @param tool
+ * @param version
+ * @param url
+ * @param os_version
+ */
+export async function addArchive(
+  tool: string,
+  version: string,
+  url: string,
   os_version: string
 ): Promise<string> {
-  switch (os_version) {
-    case 'linux':
-    case 'darwin':
-      return (
-        'sudo ln -s "$(composer -q global config home)"/vendor/bin/' +
-        tool +
-        ' /usr/local/bin/' +
-        tool
-      );
-    case 'win32':
-      return (
-        '$composer_dir = composer -q global config home | % {$_ -replace "/", "\\"}' +
-        '\n' +
-        'Add-Content -Path $PsHome\\profile.ps1 -Value "New-Alias ' +
-        tool +
-        ' $composer_dir\\vendor\\bin\\' +
-        tool +
-        '.bat"'
-      );
-    default:
-      return await utils.log(
-        'Platform ' + os_version + ' is not supported',
-        os_version,
-        'error'
-      );
-  }
+  return (await getArchiveCommand(os_version)) + url + ' ' + tool;
+}
+
+/**
+ * Helper function to get script to setup a tool using composer
+ *
+ * @param tool
+ * @param release
+ * @param prefix
+ * @param os_version
+ */
+export async function addPackage(
+  tool: string,
+  release: string,
+  prefix: string,
+  os_version: string
+): Promise<string> {
+  const tool_command = await getPackageCommand(os_version);
+  return tool_command + tool + ' ' + release + ' ' + prefix;
 }
 
 /**
@@ -72,133 +295,85 @@ export async function linkTool(
  */
 export async function addTools(
   tools_csv: string,
+  php_version: string,
   os_version: string
 ): Promise<string> {
   let script = '\n' + (await utils.stepLog('Setup Tools', os_version));
-  let tools: Array<string> = await utils.CSVArray(tools_csv);
-  tools = tools.filter(tool => tool !== 'composer');
-  tools.unshift('composer');
-  await utils.asyncForEach(tools, async function(tool: string) {
+  const tools_list: Array<string> = await getCleanedToolsList(tools_csv);
+  await utils.asyncForEach(tools_list, async function(release: string) {
+    const tool_data: {name: string; version: string} = await parseTool(release);
+    const tool: string = tool_data.name;
+    const version: string = tool_data.version;
+    const github = 'https://github.com/';
+    let uri: string = await getUri(tool, version, 'releases', '', 'download');
     script += '\n';
+    let url = '';
     switch (tool) {
       case 'php-cs-fixer':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/latest/download/php-cs-fixer.phar' +
-          ' ' +
-          'php-cs-fixer';
+        uri = await getUri(tool, version, 'releases', 'v', 'download');
+        url = github + 'FriendsOfPHP/PHP-CS-Fixer/' + uri;
+        script += await addArchive(tool, version, url, os_version);
         break;
       case 'phpcs':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://github.com/squizlabs/PHP_CodeSniffer/releases/latest/download/phpcs.phar' +
-          ' ' +
-          'phpcs';
-        break;
       case 'phpcbf':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://github.com/squizlabs/PHP_CodeSniffer/releases/latest/download/phpcbf.phar' +
-          ' ' +
-          'phpcbf';
-        break;
-      case 'phpcpd':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://github.com/sebastianbergmann/phpcpd/releases/latest/download/phpcpd.phar' +
-          ' ' +
-          'phpcpd';
+        url = github + 'squizlabs/PHP_CodeSniffer/' + uri;
+        script += await addArchive(tool, version, url, os_version);
         break;
       case 'phpstan':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar' +
-          ' ' +
-          'phpstan';
+        url = github + 'phpstan/phpstan/' + uri;
+        script += await addArchive(tool, version, url, os_version);
         break;
       case 'phpmd':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar' +
-          ' ' +
-          'phpmd';
+        url = github + 'phpmd/phpmd/' + uri;
+        script += await addArchive(tool, version, url, os_version);
         break;
       case 'psalm':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://github.com/vimeo/psalm/releases/latest/download/psalm.phar' +
-          ' ' +
-          'psalm';
-        break;
-      case 'phinx':
-        script +=
-          'composer global require robmorgan/phinx' +
-          (await utils.suppressOutput(os_version)) +
-          '\n' +
-          (await linkTool('phinx', os_version)) +
-          '\n' +
-          (await utils.addLog('$tick', 'phinx', 'Added', os_version));
+        url = github + 'vimeo/psalm/' + uri;
+        script += await addArchive(tool, version, url, os_version);
         break;
       case 'composer':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://github.com/composer/composer/releases/latest/download/composer.phar' +
-          ' ' +
-          'composer';
+        url =
+          github + 'composer/composer/releases/latest/download/composer.phar';
+        script += await addArchive(tool, version, url, os_version);
         break;
       case 'codeception':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://codeception.com/codecept.phar' +
-          ' ' +
-          'codeception';
+        url =
+          'https://codeception.com/' +
+          (await getCodeceptionUri(version, php_version));
+        script += await addArchive(tool, version, url, os_version);
         break;
+      case 'phpcpd':
       case 'phpunit':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://phar.phpunit.de/phpunit.phar' +
-          ' ' +
-          'phpunit';
+        url = await getPhpunitUrl(tool, version);
+        script += await addArchive(tool, version, url, os_version);
         break;
       case 'deployer':
-        script +=
-          (await getToolCommand(os_version)) +
-          'https://deployer.org/deployer.phar' +
-          ' ' +
-          'deployer';
+        url = await getDeployerUrl(version);
+        script += await addArchive(tool, version, url, os_version);
+        break;
+      case 'phinx':
+        script += await addPackage(tool, release, 'robmorgan/', os_version);
         break;
       case 'prestissimo':
-        script +=
-          'composer global require hirak/prestissimo' +
-          (await utils.suppressOutput(os_version)) +
-          '\n' +
-          (await utils.addLog(
-            '$tick',
-            'hirak/prestissimo',
-            'Added',
-            os_version
-          ));
+        script += await addPackage(tool, release, 'hirak/', os_version);
         break;
       case 'composer-prefetcher':
-        script +=
-          'composer global require narrowspark/automatic-composer-prefetcher' +
-          (await utils.suppressOutput(os_version)) +
-          '\n' +
-          (await utils.addLog(
-            '$tick',
-            'narrowspark/automatic-composer-prefetcher',
-            'Added',
-            os_version
-          ));
+        script += await addPackage(
+          tool,
+          release,
+          'narrowspark/automatic-',
+          os_version
+        );
         break;
       case 'pecl':
         script += await getPECLCommand(os_version);
         break;
       default:
-        script += await utils.log(
+        script += await utils.addLog(
+          '$cross',
+          tool,
           'Tool ' + tool + ' is not supported',
-          os_version,
-          'error'
+          os_version
         );
         break;
     }


### PR DESCRIPTION
- Update `actions/checkout` to `v2`.
- Update year in `LICENSE`.
- Add `CakePHP` examples.
- Add `REDIS_PORT` environment variable in examples that use `Redis` for caching.
- Add `narrowspark/automatic-composer-prefetcher` in tools.
- Add support to specify version of tools. Fixes #139 
- Fix `codeception` for PHP `5.6`, `7.0` and `7.1`.
- Fix warnings in actions.yml. Fixes #141 
- Update default packages in `linux`. Fixes #143 
- Bump version to `1.7.1`.