### PR TITLE
1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ Setup PHP with required extensions, php.ini configuration, code-coverage support
 - On `windows` extensions which have `windows` binary on `PECL` can be installed.
 - On `macOS` extensions which are on `PECL` can be installed.
 - Extensions which are installed along with PHP if specified are enabled.
+- Extensions on `PECL` which do not have a latest stable version, their pre-release versions can be installed by suffixing the extension with its state i.e `alpha`, `beta`, `devel` or `snapshot` separated by a `-` like `msgpack-beta`.
 - Extensions which cannot be installed gracefully leave an error message in the logs, the action is not interrupted.
 
 ## :wrench: Tools Support
 
 These tools can be setup globally using the `tools` input.
 
-`codeception`, `composer`, `composer-prefetcher`, `deployer`, `pecl`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `psalm`
+`codeception`, `composer`, `composer-prefetcher`, `deployer`, `pecl`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `psalm`, `symfony`
 
 ```yaml
 uses: shivammathur/setup-php@v1
@@ -280,7 +281,7 @@ key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
 
 ### Problem Matchers
 
-You can setup problem matchers for your `PHPUnit` output. This will scan the errors in your tests and surface that information prominently in the GitHub Actions UI by creating annotations and log file decorations.
+You can setup problem matchers for your `PHPUnit` output by adding this step after the `setup-php` step. This will scan the logs for failing tests and surface that information prominently in the GitHub Actions UI by creating annotations and log file decorations.
 
 ```yaml
 - name: Setup Problem Matchers for PHPUnit
@@ -327,10 +328,10 @@ Contributions are welcome! See [Contributor's Guide](.github/CONTRIBUTING.md "sh
 
 If this action helped you.
 
-- Please star the project and share it, this helps reach more people.
-- If you blog, write about your experience using this.
-- Support this project on <a href="https://www.patreon.com/shivammathur"><img alt="Patreon" src="https://shivammathur.com/badges/patreon.svg"></a> or using <a href="https://www.paypal.me/shivammathur"><img alt="Paypal" src="https://shivammathur.com/badges/paypal.svg"></a>.
-- If you need any help using this, reach out here <a href="https://www.codementor.io/shivammathur?utm_source=github&utm_medium=button&utm_term=shivammathur&utm_campaign=github" title="Contact Shivam Mathur on Codementor"><img alt="Contact me on Codementor" src="https://cdn.codementor.io/badges/contact_me_github.svg"></a>
+- Please star the project and share it with the community.
+- If you blog, write about your experience while using this action.
+- I maintain this in my free time, please support me with a [Patreon](https://www.patreon.com/shivammathur "Shivam Mathur Patreon") subscription or a one time contribution using [Paypal](https://www.paypal.me/shivammathur "Shivam Mathur PayPal").
+- If you need any help using this, please contact me using [Codementor](https://www.codementor.io/shivammathur "Shivam Mathur Codementor")
 
 ## :bookmark: This action uses the following works
 

--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -8,7 +8,7 @@ jest.mock('../src/extensions', () => ({
 
 describe('Config tests', () => {
   it('checking addCoverage with PCOV on windows', async () => {
-    let win32: string = await coverage.addCoverage('pcov', '7.4', 'win32');
+    let win32: string = await coverage.addCoverage('PCOV', '7.4', 'win32');
     expect(win32).toContain('add_extension pcov');
     expect(win32).toContain('Remove-Extension xdebug');
 

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -3,13 +3,14 @@ import * as extensions from '../src/extensions';
 describe('Extension tests', () => {
   it('checking addExtensionOnWindows', async () => {
     let win32: string = await extensions.addExtension(
-      'xdebug, pcov, phalcon4',
+      'xdebug, pcov, phalcon4, ast-beta',
       '7.4',
       'win32'
     );
     expect(win32).toContain('Add-Extension xdebug');
     expect(win32).toContain('Add-Extension pcov');
     expect(win32).toContain('phalcon.ps1 phalcon4');
+    expect(win32).toContain('Add-Extension ast beta');
 
     win32 = await extensions.addExtension(
       'phalcon3, does_not_exist',
@@ -26,7 +27,7 @@ describe('Extension tests', () => {
 
   it('checking addExtensionOnLinux', async () => {
     let linux: string = await extensions.addExtension(
-      'xdebug, pcov',
+      'xdebug, pcov, ast-beta',
       '7.4',
       'linux'
     );
@@ -34,7 +35,8 @@ describe('Extension tests', () => {
     expect(linux).toContain(
       'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-pcov'
     );
-    expect(linux).toContain('pecl install pcov');
+    expect(linux).toContain('pecl install -f pcov');
+    expect(linux).toContain('install_extension ast-beta');
 
     linux = await extensions.addExtension('gearman', '7.0', 'linux');
     expect(linux).toContain('gearman.sh 7.0');
@@ -60,12 +62,13 @@ describe('Extension tests', () => {
 
   it('checking addExtensionOnDarwin', async () => {
     let darwin: string = await extensions.addExtension(
-      'xdebug, pcov',
+      'xdebug, pcov, ast-beta',
       '7.2',
       'darwin'
     );
-    expect(darwin).toContain('sudo pecl install xdebug');
-    expect(darwin).toContain('sudo pecl install pcov');
+    expect(darwin).toContain('sudo pecl install -f xdebug');
+    expect(darwin).toContain('sudo pecl install -f pcov');
+    expect(darwin).toContain('install_extension ast-beta');
 
     darwin = await extensions.addExtension('phalcon3', '7.0', 'darwin');
     expect(darwin).toContain('phalcon_darwin.sh phalcon3 7.0');
@@ -74,33 +77,33 @@ describe('Extension tests', () => {
     expect(darwin).toContain('phalcon_darwin.sh phalcon4 7.3');
 
     darwin = await extensions.addExtension('pcov', '5.6', 'darwin');
-    expect(darwin).toContain('sudo pecl install pcov');
+    expect(darwin).toContain('sudo pecl install -f pcov');
 
     darwin = await extensions.addExtension('pcov', '7.2', 'darwin');
-    expect(darwin).toContain('sudo pecl install pcov');
+    expect(darwin).toContain('sudo pecl install -f pcov');
 
     darwin = await extensions.addExtension('xdebug', '5.6', 'darwin');
-    expect(darwin).toContain('sudo pecl install xdebug-2.5.5');
+    expect(darwin).toContain('sudo pecl install -f xdebug-2.5.5');
 
     darwin = await extensions.addExtension('xdebug', '7.0', 'darwin');
-    expect(darwin).toContain('sudo pecl install xdebug-2.9.0');
+    expect(darwin).toContain('sudo pecl install -f xdebug-2.9.0');
 
     darwin = await extensions.addExtension('xdebug', '7.2', 'darwin');
-    expect(darwin).toContain('sudo pecl install xdebug');
+    expect(darwin).toContain('sudo pecl install -f xdebug');
 
     darwin = await extensions.addExtension('redis', '5.6', 'darwin');
-    expect(darwin).toContain('sudo pecl install redis-2.2.8');
+    expect(darwin).toContain('sudo pecl install -f redis-2.2.8');
 
     darwin = await extensions.addExtension('redis', '7.2', 'darwin');
-    expect(darwin).toContain('sudo pecl install redis');
+    expect(darwin).toContain('sudo pecl install -f redis');
 
     darwin = await extensions.addExtension('imagick', '5.6', 'darwin');
     expect(darwin).toContain('brew install pkg-config imagemagick');
-    expect(darwin).toContain('sudo pecl install imagick');
+    expect(darwin).toContain('sudo pecl install -f imagick');
 
     darwin = await extensions.addExtension('imagick', '7.4', 'darwin');
     expect(darwin).toContain('brew install pkg-config imagemagick');
-    expect(darwin).toContain('sudo pecl install imagick');
+    expect(darwin).toContain('sudo pecl install -f imagick');
 
     darwin = await extensions.addExtension(
       'does_not_exist',

--- a/__tests__/matchers.test.ts
+++ b/__tests__/matchers.test.ts
@@ -23,7 +23,7 @@ describe('Matchers', () => {
 
   it('Test Regex', async () => {
     const regex1 = /^\d+\)\s.*$/;
-    const regex2 = /^(.*)$/;
+    const regex2 = /^(.*Failed\sasserting\sthat.*)$/;
     const regex3 = /^\s*$/;
     const regex4 = /^(.*):(\d+)$/;
     expect(regex1.test('1) Tests\\Test::it_tests')).toBe(true);

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -206,6 +206,30 @@ describe('Tools tests', () => {
     ).toStrictEqual(['composer', 'a', 'b']);
   });
 
+  it('checking getSymfonyUri', async () => {
+    expect(await tools.getSymfonyUri('latest', 'linux')).toContain(
+      'releases/latest/download/symfony_linux_amd64'
+    );
+    expect(await tools.getSymfonyUri('1.2.3', 'linux')).toContain(
+      'releases/download/v1.2.3/symfony_linux_amd64'
+    );
+    expect(await tools.getSymfonyUri('latest', 'darwin')).toContain(
+      'releases/latest/download/symfony_darwin_amd64'
+    );
+    expect(await tools.getSymfonyUri('1.2.3', 'darwin')).toContain(
+      'releases/download/v1.2.3/symfony_darwin_amd64'
+    );
+    expect(await tools.getSymfonyUri('latest', 'win32')).toContain(
+      'releases/latest/download/symfony_windows_amd64'
+    );
+    expect(await tools.getSymfonyUri('1.2.3', 'win32')).toContain(
+      'releases/download/v1.2.3/symfony_windows_amd64'
+    );
+    expect(await tools.getSymfonyUri('1.2.3', 'fedora')).toContain(
+      'Platform fedora is not supported'
+    );
+  });
+
   it('checking getCleanedToolsList', async () => {
     const tools_list: string[] = await tools.getCleanedToolsList(
       'tool, composer:1.2.3, robmorgan/phinx, hirak/prestissimo, narrowspark/automatic-composer-prefetcher'
@@ -301,7 +325,7 @@ describe('Tools tests', () => {
 
   it('checking addTools on linux', async () => {
     const script: string = await tools.addTools(
-      'php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize',
+      'php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize, symfony',
       '7.4',
       'linux'
     );
@@ -320,6 +344,9 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'add_tool https://phar.phpunit.de/phpunit.phar phpunit'
     );
+    expect(script).toContain(
+      'add_tool https://github.com/symfony/cli/releases/latest/download/symfony_linux_amd64 symfony'
+    );
     expect(script).toContain('add_pecl');
     expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
     expect(script).toContain('add_composer_tool phinx phinx:1.2.3 robmorgan/');
@@ -329,7 +356,7 @@ describe('Tools tests', () => {
   });
   it('checking addTools on darwin', async () => {
     const script: string = await tools.addTools(
-      'phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, phive:1.2.3, composer-prefetcher:1.2.3, phpize, php-config',
+      'phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, phive:1.2.3, composer-prefetcher:1.2.3, phpize, php-config, symfony, symfony:1.2.3',
       '7.4',
       'darwin'
     );
@@ -358,12 +385,18 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'add_composer_tool composer-prefetcher composer-prefetcher:1.2.3 narrowspark/automatic-'
     );
+    expect(script).toContain(
+      'add_tool https://github.com/symfony/cli/releases/latest/download/symfony_darwin_amd64 symfony'
+    );
+    expect(script).toContain(
+      'add_tool https://github.com/symfony/cli/releases/download/v1.2.3/symfony_darwin_amd64 symfony'
+    );
     expect(script).toContain('add_log "$tick" "phpize" "Added"');
     expect(script).toContain('add_log "$tick" "php-config" "Added"');
   });
   it('checking addTools on windows', async () => {
     const script: string = await tools.addTools(
-      'codeception, deployer, prestissimo, phpmd, phinx, phive:0.13.2, php-config, phpize, does_not_exit',
+      'codeception, deployer, prestissimo, phpmd, phinx, phive:0.13.2, php-config, phpize, symfony, does_not_exit',
       '7.4',
       'win32'
     );
@@ -382,6 +415,9 @@ describe('Tools tests', () => {
     expect(script).toContain('Add-Composer-Tool phinx phinx robmorgan/');
     expect(script).toContain(
       'Add-Tool https://github.com/phar-io/phive/releases/download/0.13.2/phive-0.13.2.phar phive'
+    );
+    expect(script).toContain(
+      'Add-Tool https://github.com/symfony/cli/releases/latest/download/symfony_windows_amd64.exe symfony'
     );
     expect(script).toContain('phpize is not a windows tool');
     expect(script).toContain('php-config is not a windows tool');

--- a/dist/index.js
+++ b/dist/index.js
@@ -1791,6 +1791,35 @@ function getDeployerUrl(version) {
 }
 exports.getDeployerUrl = getDeployerUrl;
 /**
+ * Function to get the Deployer url
+ *
+ * @param version
+ * @param os_version
+ */
+function getSymfonyUri(version, os_version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let filename = '';
+        switch (os_version) {
+            case 'linux':
+            case 'darwin':
+                filename = 'symfony_' + os_version + '_amd64';
+                break;
+            case 'win32':
+                filename = 'symfony_windows_amd64.exe';
+                break;
+            default:
+                return yield utils.log('Platform ' + os_version + ' is not supported', os_version, 'error');
+        }
+        switch (version) {
+            case 'latest':
+                return 'releases/latest/download/' + filename;
+            default:
+                return 'releases/download/v' + version + '/' + filename;
+        }
+    });
+}
+exports.getSymfonyUri = getSymfonyUri;
+/**
  * Function to add/move composer in the tools list
  *
  * @param tools
@@ -1963,6 +1992,12 @@ function addTools(tools_csv, php_version, os_version) {
                     case 'php-config':
                     case 'phpize':
                         script += yield addDevTools(tool, os_version);
+                        break;
+                    case 'symfony':
+                    case 'symfony-cli':
+                        uri = yield getSymfonyUri(version, os_version);
+                        url = github + 'symfony/cli/' + uri;
+                        script += yield addArchive('symfony', version, url, os_version);
                         break;
                     default:
                         script += yield utils.addLog('$cross', tool, 'Tool ' + tool + ' is not supported', os_version);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2151,7 +2151,7 @@ exports.disableCoverage = disableCoverage;
  */
 function addCoverage(coverage_driver, version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
-        coverage_driver.toLowerCase();
+        coverage_driver = coverage_driver.toLowerCase();
         const script = '\n' + (yield utils.stepLog('Setup Coverage', os_version));
         const pipe = yield utils.suppressOutput(os_version);
         switch (coverage_driver) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1262,17 +1262,24 @@ module.exports = require("assert");
 
 "use strict";
 
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-const os = __webpack_require__(87);
+const os = __importStar(__webpack_require__(87));
 /**
  * Commands
  *
  * Command Format:
- *   ##[name key=value;key=value]message
+ *   ::name key=value,key=value::message
  *
  * Examples:
- *   ##[warning]This is the user warning message
- *   ##[set-secret name=mypassword]definitelyNotAPassword!
+ *   ::warning::This is the message
+ *   ::set-env name=MY_VAR::some value
  */
 function issueCommand(command, properties, message) {
     const cmd = new Command(command, properties, message);
@@ -1308,30 +1315,28 @@ class Command {
                         else {
                             cmdStr += ',';
                         }
-                        // safely append the val - avoid blowing up when attempting to
-                        // call .replace() if message is not a string for some reason
-                        cmdStr += `${key}=${escape(`${val || ''}`)}`;
+                        cmdStr += `${key}=${escapeProperty(val)}`;
                     }
                 }
             }
         }
-        cmdStr += CMD_STRING;
-        // safely append the message - avoid blowing up when attempting to
-        // call .replace() if message is not a string for some reason
-        const message = `${this.message || ''}`;
-        cmdStr += escapeData(message);
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
         return cmdStr;
     }
 }
 function escapeData(s) {
-    return s.replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+    return (s || '')
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
 }
-function escape(s) {
-    return s
+function escapeProperty(s) {
+    return (s || '')
+        .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
-        .replace(/]/g, '%5D')
-        .replace(/;/g, '%3B');
+        .replace(/:/g, '%3A')
+        .replace(/,/g, '%2C');
 }
 //# sourceMappingURL=command.js.map
 
@@ -1351,10 +1356,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const command_1 = __webpack_require__(431);
-const os = __webpack_require__(87);
-const path = __webpack_require__(622);
+const os = __importStar(__webpack_require__(87));
+const path = __importStar(__webpack_require__(622));
 /**
  * The code to exit an action
  */

--- a/dist/index.js
+++ b/dist/index.js
@@ -2325,6 +2325,7 @@ function build(filename, version, os_version) {
     return __awaiter(this, void 0, void 0, function* () {
         // taking inputs
         const extension_csv = (yield utils.getInput('extensions', false)) ||
+            (yield utils.getInput('extension', false)) ||
             (yield utils.getInput('extension-csv', false));
         const ini_values_csv = (yield utils.getInput('ini-values', false)) ||
             (yield utils.getInput('ini-values-csv', false));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "setup-php",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-xD+CQd9p4lU7ZfRqmUcbJpqR+Ss51rJRVeXMyOLrZQImN9/8Sy/BEUBnHO/UKD3z03R686PVTLfEPmkropGuLw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-IbCx7oefq+Gi6FWbSs2Fnw8VkEI6Y4gvjrYprY3RV//ksq/KPMlClOerJ4jRosyal6zkUIc8R9fS/cpRMlGClg=="
     },
     "@actions/exec": {
       "version": "1.0.3",
@@ -710,9 +710,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.0.tgz",
-      "integrity": "sha512-dXvuABY9nM1xgsXlOtLQXJKdacxZJd7AtvLsKZ/0b57ruMXDKCOXAC/M75GbllQX6o1pcZ5hAG4JzYy7Z/wM2w==",
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
+      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
       "dev": true,
       "requires": {
         "jest-diff": "^24.3.0"
@@ -743,9 +743,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.5.tgz",
-      "integrity": "sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.6.tgz",
+      "integrity": "sha512-IkltIncDQWv6fcAvnHtJ6KtkmY/vtR3bViOaCzpj/A3yNhlfZAgxNe6AEQD1cQrkYD+YsKVo08DSxvNKEsD7BA==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -3514,9 +3514,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
-      "integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
+      "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -5636,9 +5636,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+      "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "husky": {
     "skipCI": true,
     "hooks": {
-      "pre-commit": "npm run build && npm run format && npm run release"
+      "pre-commit": "npm run format && npm run lint && npm run build && npm run release"
     }
   }
 }

--- a/src/configs/phpunit.json
+++ b/src/configs/phpunit.json
@@ -7,7 +7,7 @@
           "regexp": "^\\d+\\)\\s.*$"
         },
         {
-          "regexp": "^(.*)$",
+          "regexp": "^(.*Failed\\sasserting\\sthat.*)$",
           "message": 1
         },
         {

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -143,7 +143,7 @@ export async function addCoverage(
   version: string,
   os_version: string
 ): Promise<string> {
-  coverage_driver.toLowerCase();
+  coverage_driver = coverage_driver.toLowerCase();
   const script: string =
     '\n' + (await utils.stepLog('Setup Coverage', os_version));
   const pipe: string = await utils.suppressOutput(os_version);

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -18,23 +18,26 @@ export async function addExtensionDarwin(
   await utils.asyncForEach(extensions, async function(extension: string) {
     extension = extension.toLowerCase();
     const version_extension: string = version + extension;
-    // add script to enable extension is already installed along with php
     let install_command = '';
     switch (true) {
+      // match pre-release versions
+      case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
+        install_command = 'install_extension ' + extension + pipe;
+        break;
       case /5\.6xdebug/.test(version_extension):
-        install_command = 'sudo pecl install xdebug-2.5.5' + pipe;
+        install_command = 'sudo pecl install -f xdebug-2.5.5' + pipe;
         break;
       case /7\.0xdebug/.test(version_extension):
-        install_command = 'sudo pecl install xdebug-2.9.0' + pipe;
+        install_command = 'sudo pecl install -f xdebug-2.9.0' + pipe;
         break;
       case /5\.6redis/.test(version_extension):
-        install_command = 'sudo pecl install redis-2.2.8' + pipe;
+        install_command = 'sudo pecl install -f redis-2.2.8' + pipe;
         break;
       case /[5-9]\.\dimagick/.test(version_extension):
         install_command =
           'brew install pkg-config imagemagick' +
           pipe +
-          ' && sudo pecl install imagick' +
+          ' && sudo pecl install -f imagick' +
           pipe;
         break;
       case /^7\.[0-3]phalcon3$|^7\.[2-4]phalcon4$/.test(version_extension):
@@ -48,7 +51,7 @@ export async function addExtensionDarwin(
           pipe;
         break;
       default:
-        install_command = 'sudo pecl install ' + extension + pipe;
+        install_command = 'sudo pecl install -f ' + extension + pipe;
         break;
     }
     script +=
@@ -77,9 +80,14 @@ export async function addExtensionWindows(
   const extensions: Array<string> = await utils.extensionArray(extension_csv);
   let script = '\n';
   await utils.asyncForEach(extensions, async function(extension: string) {
-    // add script to enable extension is already installed along with php
+    extension = extension.toLowerCase();
+    const [extension_name, stability]: string[] = extension.split('-');
     const version_extension: string = version + extension;
     switch (true) {
+      // match pre-release versions
+      case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
+        script += '\nAdd-Extension ' + extension_name + ' ' + stability;
+        break;
       // match 7.0phalcon3...7.3phalcon3 and 7.2phalcon4...7.4phalcon4
       case /^7\.[0-3]phalcon3$|^7\.[2-4]phalcon4$/.test(version_extension):
         script +=
@@ -115,10 +123,13 @@ export async function addExtensionLinux(
   let script = '\n';
   await utils.asyncForEach(extensions, async function(extension: string) {
     extension = extension.toLowerCase();
-    // add script to enable extension is already installed along with php
     const version_extension: string = version + extension;
     let install_command = '';
     switch (true) {
+      // match pre-release versions
+      case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
+        install_command = 'install_extension ' + extension + pipe;
+        break;
       // match 5.6gearman..7.4gearman
       case /^((5\.6)|(7\.[0-4]))gearman$/.test(version_extension):
         install_command =
@@ -153,7 +164,7 @@ export async function addExtensionLinux(
           '-' +
           extension.replace('pdo_', '').replace('pdo-', '') +
           pipe +
-          ' || sudo pecl install ' +
+          ' || sudo pecl install -f ' +
           extension +
           pipe;
         break;

--- a/src/install.ts
+++ b/src/install.ts
@@ -29,7 +29,10 @@ export async function build(
   const coverage_driver: string = await utils.getInput('coverage', false);
   const pecl: string = await utils.getInput('pecl', false);
   let tools_csv: string = await utils.getInput('tools', false);
-  if (pecl == 'true') {
+  if (
+    pecl == 'true' ||
+    /.*-(beta|alpha|devel|snapshot).*/.test(extension_csv)
+  ) {
     tools_csv = 'pecl, ' + tools_csv;
   }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -22,6 +22,7 @@ export async function build(
   // taking inputs
   const extension_csv: string =
     (await utils.getInput('extensions', false)) ||
+    (await utils.getInput('extension', false)) ||
     (await utils.getInput('extension-csv', false));
   const ini_values_csv: string =
     (await utils.getInput('ini-values', false)) ||

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -40,6 +40,16 @@ add_extension() {
   fi
 }
 
+# Function to force install extensions using PECL
+install_extension() {
+  extension=$1
+  extension_name="$(echo "$extension" | cut -d'-' -f 1)"
+  sudo sed -i "/$extension_name/d" "$ini_file"
+  sudo rm -rf /etc/php/"$version"/cli/conf.d/*"$extension_name"* >/dev/null 2>&1
+  sudo rm -rf "$ext_dir"/"$extension_name".so >/dev/null 2>&1
+  sudo pecl install -f "$extension" >/dev/null 2>&1
+}
+
 # Function to remove extensions
 remove_extension() {
   extension=$1
@@ -125,14 +135,12 @@ setup_master() {
 
 # Function to setup PECL
 add_pecl() {
-  update_ppa
   add_devtools
-  wget https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar >/dev/null 2>&1
-  sudo php install-pear-nozlib.phar >/dev/null 2>&1
-  sudo rm -rf install-pear-nozlib.phar >/dev/null 2>&1
+  $apt_install php-pear >/dev/null 2>&1
   sudo pear config-set php_ini "$ini_file" >/dev/null 2>&1
   sudo pear config-set auto_discover 1 >/dev/null 2>&1
   sudo pear channel-update pear.php.net >/dev/null 2>&1
+  sudo pecl channel-update pecl.php.net >/dev/null 2>&1
   add_log "$tick" "PECL" "Added"
 }
 

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -38,6 +38,7 @@ add_extension() {
     (update_ppa && eval "$install_command" && add_log "$tick" "$extension" "Installed and enabled") ||
     add_log "$cross" "$extension" "Could not install $extension on PHP $semver"
   fi
+  sudo chmod 777 "$ini_file"
 }
 
 # Function to force install extensions using PECL

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -118,7 +118,7 @@ Function Add-Tool() {
     Add-Extension mbstring >$null 2>&1
     Add-Extension xml >$null 2>&1
   }
-  if (Test-Path $php_dir\$tool) {
+  if (((Get-ChildItem -Path $php_dir/* | Where-Object Name -Match "^$tool(.exe|.phar)*$").Count -gt 0)) {
     Add-Log $tick $tool "Added"
   } else {
     Add-Log $cross $tool "Could not add $tool"

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -35,7 +35,7 @@ Function Add-Extension {
   )
   try {
     $extension_info = Get-PhpExtension -Path $php_dir | Where-Object { $_.Name -eq $extension -or $_.Handle -eq $extension }
-    if ($null -ne $extension_info) {
+    if ($null -ne $extension_info -and $mininum_stability -eq 'stable') {
       switch ($extension_info.State) {
         'Builtin' {
           Add-Log $tick $extension "Enabled"
@@ -51,7 +51,11 @@ Function Add-Extension {
     }
     else {
       Install-PhpExtension -Extension $extension -MinimumStability $mininum_stability -Path $php_dir
-      Add-Log $tick $extension "Installed and enabled"
+      if($mininum_stability -ne 'stable') {
+        Add-Log $tick "$extension-$mininum_stability" "Installed and enabled"
+      } else {
+        Add-Log $tick $extension "Installed and enabled"
+      }
     }
   }
   catch {
@@ -151,7 +155,7 @@ Function Add-Composer-Tool() {
 }
 
 Function Add-PECL() {
-  Add-Log $tick "PECL" "Use extensions input or Install-PhpExtension to setup PECL extensions on windows"
+  Add-Log $tick "PECL" "Use extensions input to setup PECL extensions on windows"
 }
 
 # Variables

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -244,6 +244,40 @@ export async function getDeployerUrl(version: string): Promise<string> {
 }
 
 /**
+ * Function to get the Deployer url
+ *
+ * @param version
+ * @param os_version
+ */
+export async function getSymfonyUri(
+  version: string,
+  os_version: string
+): Promise<string> {
+  let filename = '';
+  switch (os_version) {
+    case 'linux':
+    case 'darwin':
+      filename = 'symfony_' + os_version + '_amd64';
+      break;
+    case 'win32':
+      filename = 'symfony_windows_amd64.exe';
+      break;
+    default:
+      return await utils.log(
+        'Platform ' + os_version + ' is not supported',
+        os_version,
+        'error'
+      );
+  }
+  switch (version) {
+    case 'latest':
+      return 'releases/latest/download/' + filename;
+    default:
+      return 'releases/download/v' + version + '/' + filename;
+  }
+}
+
+/**
  * Function to add/move composer in the tools list
  *
  * @param tools
@@ -439,6 +473,12 @@ export async function addTools(
       case 'php-config':
       case 'phpize':
         script += await addDevTools(tool, os_version);
+        break;
+      case 'symfony':
+      case 'symfony-cli':
+        uri = await getSymfonyUri(version, os_version);
+        url = github + 'symfony/cli/' + uri;
+        script += await addArchive('symfony', version, url, os_version);
         break;
       default:
         script += await utils.addLog(


### PR DESCRIPTION
- Add support for pre-release `PECL` extensions. Fixes #159 
- Fix `php.ini` permissions after extension setup. Fixes #164 
- Fix `PHPUnit` problem matchers. Fixes #163 
- Add support for `symfony` in tools input. Fixes #158 
- Fix lower-casing of coverage driver.
- Add lint to pre-commit hook.
- Fix check for testing tools setup.
- Bump version to 1.8.0.
