### PR TITLE
2.1.0

### DIFF
--- a/.github/workflows/experimental-workflow.yml
+++ b/.github/workflows/experimental-workflow.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Setup cache environment
         id: cache-env
-        uses: shivammathur/cache-extensions@v1
+        uses: shivammathur/cache-extensions@develop
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: ${{ env.extensions }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Setup cache environment
         id: cache-env
-        uses: shivammathur/cache-extensions@v1
+        uses: shivammathur/cache-extensions@develop
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: ${{ env.extensions }}

--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ Examples for setting up this GitHub Action with different PHP Frameworks/Package
 
 |Framework/Package|Runs on|Workflow|
 |--- |--- |--- |
+|Blackfire|`macOS`, `ubuntu` and `windows`|[blackfire.yml](./examples/blackfire.yml "GitHub Action using Blackfire")|
+|Blackfire Player|`macOS`, `ubuntu` and `windows`|[blackfire-player.yml](./examples/blackfire-player.yml "GitHub Action using Blackfire Player")|
 |CakePHP with `MySQL` and `Redis`|`ubuntu`|[cakephp-mysql.yml](./examples/cakephp-mysql.yml "GitHub Action for CakePHP with MySQL and Redis")|
 |CakePHP with `PostgreSQL` and `Redis`|`ubuntu`|[cakephp-postgres.yml](./examples/cakephp-postgres.yml "GitHub Action for CakePHP with Postgres and Redis")|
 |CakePHP without services|`macOS`, `ubuntu` and `windows`|[cakephp.yml](./examples/cakephp.yml "GitHub Action for CakePHP without services")|
@@ -491,7 +493,6 @@ Examples for setting up this GitHub Action with different PHP Frameworks/Package
 |Yii2 Starter Kit with `MySQL`|`ubuntu`|[yii2-mysql.yml](./examples/yii2-mysql.yml "GitHub Action for Yii2 Starter Kit with MySQL")|
 |Yii2 Starter Kit with `PostgreSQL`|`ubuntu`|[yii2-postgres.yml](./examples/yii2-postgres.yml "GitHub Action for Yii2 Starter Kit with PostgreSQL")|
 |Zend Framework|`macOS`, `ubuntu` and `windows`|[zend-framework.yml](./examples/zend-framework.yml "GitHub Action for Zend Framework")|
-|Blackfire|`macOS`, `ubuntu` and `windows`|[blackfire.yml](./examples/blackfire.yml "GitHub Action using blackfire")|
 
 ## :scroll: License
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Setup PHP with required extensions, php.ini configuration, code-coverage support
 |macOS X Catalina 10.15|`macos-latest` or `macOS-10.15`|
 
 ## :heavy_plus_sign: PHP Extension Support
-- On `ubuntu` by default extensions which are available as a package can be installed. If the extension is not available as a package but it is on `PECL`, it can be installed by specifying `pecl` in the tools input.
+- On `ubuntu` by default extensions which are available as a package can be installed. PECL extensions if not available as a package can be installed by specifying `pecl` in the tools input.
 
 ```yaml
 uses: shivammathur/setup-php@v2
@@ -81,23 +81,23 @@ with:
   extensions: swoole
 ```
 
-- On `windows` extensions which have `windows` binary on `PECL` can be installed.
+- On `windows` PECL extensions which have the `DLL` binary can be installed.
 
-- On `macOS` extensions which are on `PECL` can be installed.
+- On `macOS` PECL extensions can be installed.
 
-- Extensions which are installed along with PHP if specified are enabled.
+- Extensions installed along with PHP if specified are enabled.
 
-- Specific versions of PECL extensions can be installed by suffixing the extension with the version. This is useful for installing old versions of extensions which support end of life PHP versions.
+- Specific versions of PECL extensions can be installed by suffixing the version. This is useful for installing old versions of extensions which support end of life PHP versions.
 
 ```yaml
 uses: shivammathur/setup-php@v2
 with:
-  php-version: '7.4'
+  php-version: '5.4'
   tools: pecl
-  extensions: pcov-1.0.6
+  extensions: swoole-1.9.3
 ```
 
-- Pre-release versions of PECL extensions can be installed by suffixing the extension with its state i.e `alpha`, `beta`, `devel` or `snapshot`.
+- Pre-release versions of PECL extensions can be setup by suffixing the extension with its state i.e `alpha`, `beta`, `devel` or `snapshot`.
 
 ```yaml
 uses: shivammathur/setup-php@v2
@@ -107,15 +107,15 @@ with:
   extensions: xdebug-beta
 ```
 
-- Blackfire PHP extension is available for install.
+- Extensions which cannot be setup gracefully leave an error message in the logs, the action is not interrupted.
 
-- Extensions which cannot be installed gracefully leave an error message in the logs, the action is not interrupted.
+- These extensions have custom support - `gearman` on ubuntu, `blackfire`, `phalcon3` and `phalcon4` on all supported OS.
 
 ## :wrench: Tools Support
 
 These tools can be setup globally using the `tools` input.
 
-`blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-prefetcher`, `cs2pr`, `deployer`, `pecl`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `psalm`, `symfony`
+`blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-prefetcher`, `cs2pr`, `deployer`, `flex`, `pecl`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `psalm`, `symfony`
 
 ```yaml
 uses: shivammathur/setup-php@v2
@@ -124,7 +124,7 @@ with:
   tools: php-cs-fixer, phpunit
 ```
 
-To setup a particular version of a tool, specify it in the form `tool:version`.  
+To setup a particular version of a tool, specify it in this form `tool:version`.  
 Version should be in semver format and a valid release of the tool.
 
 ```yaml
@@ -134,7 +134,7 @@ with:
   tools: php-cs-fixer:2.15.5, phpunit:8.5.1
 ``` 
 
-**Note**
+**Notes**
 - `composer` is setup by default.
 - Specifying version for `composer` and `pecl` has no effect, latest versions of both tools which are compatible with the PHP version will be setup.
 - Both agent and client will be setup when `blackfire` is specified.
@@ -178,6 +178,7 @@ Consider disabling the coverage using this PHP action for these reasons.
 - You are not generating coverage reports while testing.
 - It will remove `Xdebug`, which will have a positive impact on PHP performance.
 - You are using `phpdbg` for running your tests.
+- You are profiling your code using `blackfire`.
 
 ```yaml
 uses: shivammathur/setup-php@v2
@@ -295,7 +296,7 @@ steps:
 ### Thread Safe Setup
 
 - `NTS` versions are setup by default.
-- On `ubuntu` and `macOS` only NTS versions are supported.
+- On `ubuntu` and `macOS` only `NTS` versions are supported.
 - On `windows` both `TS` and `NTS` versions are supported.
 
 ```yaml
@@ -317,7 +318,7 @@ jobs:
 
 ### Force Update
 
-- PHP versions which are pre-installed on the GitHub Actions runner are not updated to their latest patch release by default.
+- Pre-installed PHP versions on the GitHub Actions runner are not updated to their latest patch release by default.
 - You can specify the `update` environment variable to `true` to force update to the latest release.
 
 ```yaml
@@ -331,7 +332,7 @@ jobs:
 
 ### Verbose Setup
 
-- To debug any issues, you can use the `verbose` tag instead of `v2`.
+To debug any issues, you can use the `verbose` tag instead of `v2`.
 
 ```yaml
 - name: Setup PHP
@@ -380,11 +381,11 @@ steps:
     extensions: ${{ env.extensions }}
 ```
 
+**Note:** If you setup both `TS` and `NTS` PHP versions on `windows`, add `${{ env.PHPTS }}` to `key` and `restore-keys` inputs in `actions/cache` step.
+
 ### Cache Composer Dependencies
 
 If your project uses composer, you can persist composer's internal cache directory. Dependencies cached are loaded directly instead of downloading them while installation. The files cached are available across check-runs and will reduce the workflow execution time.
-
-**Note:** Please do not cache `vendor` directory using `action/cache` as that will have side-effects.
 
 ```yaml
 - name: Get composer cache directory
@@ -402,7 +403,9 @@ If your project uses composer, you can persist composer's internal cache directo
   run: composer install --prefer-dist
 ```
 
-In the above example, if you support a range of `composer` dependencies and do not commit `composer.lock`, you can use the hash of `composer.json` as the key for your cache.
+**Notes**
+- Please do not cache `vendor` directory using `action/cache` as that will have side-effects.
+- In the above example, if you support a range of `composer` dependencies and do not commit `composer.lock`, you can use the hash of `composer.json` as the key for your cache.
 
 ```yaml
 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -410,9 +413,7 @@ key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
 
 ### Cache Node.js Dependencies
 
-If you project has node.js dependencies, you can persist npm's or yarn's internal cache directory. Dependencies cached install faster. The files cached are available across check-runs and will reduce the workflow execution time.
-
-**Note:** Please do not cache `node_modules` directory as that will have side-effects.
+If your project has node.js dependencies, you can persist npm's or yarn's cache directory. The cached files are available across check-runs and will reduce the workflow execution time.
 
 ```yaml
 - name: Get node.js cache directory
@@ -426,6 +427,8 @@ If you project has node.js dependencies, you can persist npm's or yarn's interna
     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }} # Use '**/yarn.lock' for yarn
     restore-keys: ${{ runner.os }}-node-
 ```
+
+**Note:** Please do not cache `node_modules` directory as that will have side-effects.
 
 ### Problem Matchers
 
@@ -507,9 +510,9 @@ Contributions are welcome! See [Contributor's Guide](.github/CONTRIBUTING.md "sh
 
 If this action helped you.
 
+- To support this project subscribe on [Patreon](https://www.patreon.com/shivammathur "Shivam Mathur Patreon") or sponsor using [Paypal](https://www.paypal.me/shivammathur "Shivam Mathur PayPal").
 - Please star the project and share it with the community.
 - If you blog, write about your experience of using this action.
-- Please support me with a [Patreon](https://www.patreon.com/shivammathur "Shivam Mathur Patreon") subscription or a contribution using [Paypal](https://www.paypal.me/shivammathur "Shivam Mathur PayPal") so that I'm able to actively maintain this project.
 - If you need any help using this, please contact me using [Codementor](https://www.codementor.io/shivammathur "Shivam Mathur Codementor")
 
 ## :bookmark: Dependencies
@@ -521,8 +524,8 @@ If this action helped you.
 - [shivammathur/cache-extensions](https://github.com/shivammathur/cache-extensions "GitHub action to help with caching PHP extensions")
 - [shivammathur/homebrew-php](https://github.com/shivammathur/homebrew-php "Tap for PHP builds for MacOS")
 - [shivammathur/php-builder](https://github.com/shivammathur/php-builder "Nightly PHP package")
+- [shivammathur/php5-darwin](https://github.com/shivammathur/php5-darwin "Scripts to setup PHP5 versions on darwin")
 - [shivammathur/php5-ubuntu](https://github.com/shivammathur/php5-ubuntu "Scripts to setup PHP5 versions on ubuntu")
-- [shivammathur/php5-darwin](https://github.com/shivammathur/php5-ubuntu "Scripts to setup PHP5 versions on darwin")
 
 ## :bookmark_tabs: Further Reading
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,8 @@ If this action helped you.
 - [shivammathur/cache-extensions](https://github.com/shivammathur/cache-extensions "GitHub action to help with caching PHP extensions")
 - [shivammathur/homebrew-php](https://github.com/shivammathur/homebrew-php "Tap for PHP builds for MacOS")
 - [shivammathur/php-builder](https://github.com/shivammathur/php-builder "Nightly PHP package")
-- [shivammathur/php5-ubuntu](https://github.com/shivammathur/php5-ubuntu "Scripts to setup PHP5 versions")
+- [shivammathur/php5-ubuntu](https://github.com/shivammathur/php5-ubuntu "Scripts to setup PHP5 versions on ubuntu")
+- [shivammathur/php5-darwin](https://github.com/shivammathur/php5-ubuntu "Scripts to setup PHP5 versions on darwin")
 
 ## :bookmark_tabs: Further Reading
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ with:
 
 These tools can be setup globally using the `tools` input.
 
-`codeception`, `composer`, `composer-prefetcher`, `cs2pr`, `deployer`, `pecl`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `psalm`, `symfony`
+`blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-prefetcher`, `cs2pr`, `deployer`, `pecl`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `psalm`, `symfony`
 
 ```yaml
 uses: shivammathur/setup-php@v2
@@ -137,6 +137,7 @@ with:
 **Note**
 - `composer` is setup by default.
 - Specifying version for `composer` and `pecl` has no effect, latest versions of both tools which are compatible with the PHP version will be setup.
+- Both agent and client will be setup when `blackfire` is specified.
 - If the version specified for the tool is not in semver format, latest version of the tool will be setup.
 - Tools which cannot be installed gracefully leave an error message in the logs, the action is not interrupted.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ with:
   extensions: xdebug-beta
 ```
 
+- Blackfire PHP extension is available for install.
+
 - Extensions which cannot be installed gracefully leave an error message in the logs, the action is not interrupted.
 
 ## :wrench: Tools Support
@@ -489,6 +491,7 @@ Examples for setting up this GitHub Action with different PHP Frameworks/Package
 |Yii2 Starter Kit with `MySQL`|`ubuntu`|[yii2-mysql.yml](./examples/yii2-mysql.yml "GitHub Action for Yii2 Starter Kit with MySQL")|
 |Yii2 Starter Kit with `PostgreSQL`|`ubuntu`|[yii2-postgres.yml](./examples/yii2-postgres.yml "GitHub Action for Yii2 Starter Kit with PostgreSQL")|
 |Zend Framework|`macOS`, `ubuntu` and `windows`|[zend-framework.yml](./examples/zend-framework.yml "GitHub Action for Zend Framework")|
+|Blackfire|`macOS`, `ubuntu` and `windows`|[blackfire.yml](./examples/blackfire.yml "GitHub Action using blackfire")|
 
 ## :scroll: License
 

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -27,10 +27,10 @@ describe('Extension tests', () => {
     expect(win32).toContain('Platform fedora is not supported');
 
     win32 = await extensions.addExtension('blackfire', '7.3', 'win32');
-    expect(win32).toContain('blackfire.ps1 73');
+    expect(win32).toContain('blackfire.ps1 7.3 1.31.0');
 
     win32 = await extensions.addExtension('blackfire-1.31.0', '7.3', 'win32');
-    expect(win32).toContain('blackfire.ps1 73 1.31.0');
+    expect(win32).toContain('blackfire.ps1 7.3 1.31.0');
   });
 
   it('checking addExtensionOnLinux', async () => {
@@ -71,10 +71,10 @@ describe('Extension tests', () => {
     expect(linux).toContain('phalcon.sh phalcon4 7.3');
 
     linux = await extensions.addExtension('blackfire', '7.3', 'linux');
-    expect(linux).toContain('blackfire.sh 7.3 73');
+    expect(linux).toContain('blackfire.sh 7.3 1.31.0');
 
     linux = await extensions.addExtension('blackfire-1.31.0', '7.3', 'linux');
-    expect(linux).toContain('blackfire.sh 7.3 73 1.31.0');
+    expect(linux).toContain('blackfire.sh 7.3 1.31.0');
   });
 
   it('checking addExtensionOnDarwin', async () => {
@@ -133,10 +133,10 @@ describe('Extension tests', () => {
     expect(darwin).toContain('sudo pecl install -f imagick');
 
     darwin = await extensions.addExtension('blackfire', '7.3', 'darwin');
-    expect(darwin).toContain('blackfire_darwin.sh 7.3 73');
+    expect(darwin).toContain('blackfire_darwin.sh 7.3 1.31.0');
 
     darwin = await extensions.addExtension('blackfire-1.31.0', '7.3', 'darwin');
-    expect(darwin).toContain('blackfire_darwin.sh 7.3 73 1.31.0');
+    expect(darwin).toContain('blackfire_darwin.sh 7.3 1.31.0');
 
     darwin = await extensions.addExtension(
       'does_not_exist',

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -38,7 +38,7 @@ describe('Extension tests', () => {
       'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y php7.4-pcov'
     );
     expect(linux).toContain('add_unstable_extension ast beta extension');
-    expect(linux).toContain('add_pecl_extension grpc 1.2.3');
+    expect(linux).toContain('add_pecl_extension grpc 1.2.3 extension');
     expect(linux).toContain(
       'add_unstable_extension xdebug alpha zend_extension'
     );
@@ -74,7 +74,7 @@ describe('Extension tests', () => {
     expect(darwin).toContain('sudo pecl install -f xdebug');
     expect(darwin).toContain('sudo pecl install -f pcov');
     expect(darwin).toContain('add_unstable_extension ast beta extension');
-    expect(darwin).toContain('sudo pecl install -f grpc-1.2.3');
+    expect(darwin).toContain('add_pecl_extension grpc 1.2.3 extension');
 
     darwin = await extensions.addExtension('phalcon3', '7.0', 'darwin');
     expect(darwin).toContain('phalcon_darwin.sh phalcon3 7.0');

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -25,6 +25,12 @@ describe('Extension tests', () => {
 
     win32 = await extensions.addExtension('xdebug', '7.2', 'fedora');
     expect(win32).toContain('Platform fedora is not supported');
+
+    win32 = await extensions.addExtension('blackfire', '7.3', 'win32');
+    expect(win32).toContain('blackfire.ps1 73');
+
+    win32 = await extensions.addExtension('blackfire-1.31.0', '7.3', 'win32');
+    expect(win32).toContain('blackfire.ps1 73 1.31.0');
   });
 
   it('checking addExtensionOnLinux', async () => {
@@ -63,6 +69,12 @@ describe('Extension tests', () => {
     linux = await extensions.addExtension('phalcon3, phalcon4', '7.3', 'linux');
     expect(linux).toContain('phalcon.sh phalcon3 7.3');
     expect(linux).toContain('phalcon.sh phalcon4 7.3');
+
+    linux = await extensions.addExtension('blackfire', '7.3', 'linux');
+    expect(linux).toContain('blackfire.sh 7.3 73');
+
+    linux = await extensions.addExtension('blackfire-1.31.0', '7.3', 'linux');
+    expect(linux).toContain('blackfire.sh 7.3 73 1.31.0');
   });
 
   it('checking addExtensionOnDarwin', async () => {
@@ -119,6 +131,12 @@ describe('Extension tests', () => {
     darwin = await extensions.addExtension('imagick', '7.4', 'darwin');
     expect(darwin).toContain('brew install pkg-config imagemagick');
     expect(darwin).toContain('sudo pecl install -f imagick');
+
+    darwin = await extensions.addExtension('blackfire', '7.3', 'darwin');
+    expect(darwin).toContain('blackfire_darwin.sh 7.3 73');
+
+    darwin = await extensions.addExtension('blackfire-1.31.0', '7.3', 'darwin');
+    expect(darwin).toContain('blackfire_darwin.sh 7.3 73 1.31.0');
 
     darwin = await extensions.addExtension(
       'does_not_exist',

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -278,10 +278,10 @@ describe('Tools tests', () => {
 
   it('checking getWpCliUri', async () => {
     expect(await tools.getWpCliUrl('latest')).toBe(
-      'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar'
+      'wp-cli/builds/blob/gh-pages/phar/wp-cli.phar?raw=true'
     );
     expect(await tools.getWpCliUrl('2.4.0')).toBe(
-      'https://github.com/wp-cli/wp-cli/releases/download/v2.4.0/wp-cli-2.4.0.phar'
+      'wp-cli/wp-cli/releases/download/v2.4.0/wp-cli-2.4.0.phar'
     );
   });
 
@@ -393,7 +393,7 @@ describe('Tools tests', () => {
       'add_tool https://github.com/symfony/cli/releases/latest/download/symfony_linux_amd64 symfony'
     );
     expect(script).toContain(
-      'add_tool https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar wp-cli'
+      'add_tool https://github.com/wp-cli/builds/blob/gh-pages/phar/wp-cli.phar?raw=true wp-cli'
     );
     expect(script).toContain('add_pecl');
     expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
@@ -443,7 +443,7 @@ describe('Tools tests', () => {
       'add_tool https://github.com/symfony/cli/releases/download/v1.2.3/symfony_darwin_amd64 symfony'
     );
     expect(script).toContain(
-      'add_tool https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar wp-cli'
+      'add_tool https://github.com/wp-cli/builds/blob/gh-pages/phar/wp-cli.phar?raw=true wp-cli'
     );
     expect(script).toContain('add_log "$tick" "phpize" "Added"');
     expect(script).toContain('add_log "$tick" "php-config" "Added"');
@@ -477,7 +477,7 @@ describe('Tools tests', () => {
       'Add-Tool https://github.com/symfony/cli/releases/latest/download/symfony_windows_amd64.exe symfony'
     );
     expect(script).toContain(
-      'Add-Tool https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar wp-cli'
+      'Add-Tool https://github.com/wp-cli/builds/blob/gh-pages/phar/wp-cli.phar?raw=true wp-cli'
     );
     expect(script).toContain('phpize is not a windows tool');
     expect(script).toContain('php-config is not a windows tool');

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -2,28 +2,10 @@ import * as tools from '../src/tools';
 
 describe('Tools tests', () => {
   it('checking getCommand', async () => {
-    expect(await tools.getArchiveCommand('linux')).toBe('add_tool ');
-    expect(await tools.getArchiveCommand('darwin')).toBe('add_tool ');
-    expect(await tools.getArchiveCommand('win32')).toBe('Add-Tool ');
-    expect(await tools.getArchiveCommand('fedora')).toContain(
-      'Platform fedora is not supported'
-    );
-  });
-
-  it('checking getCommand', async () => {
-    expect(await tools.getPackageCommand('linux')).toBe('add_composer_tool ');
-    expect(await tools.getPackageCommand('darwin')).toBe('add_composer_tool ');
-    expect(await tools.getPackageCommand('win32')).toBe('Add-Composer-Tool ');
-    expect(await tools.getPackageCommand('fedora')).toContain(
-      'Platform fedora is not supported'
-    );
-  });
-
-  it('checking getPECLCommand', async () => {
-    expect(await tools.getPECLCommand('linux')).toBe('add_pecl ');
-    expect(await tools.getPECLCommand('darwin')).toBe('add_pecl ');
-    expect(await tools.getPECLCommand('win32')).toBe('Add-PECL ');
-    expect(await tools.getPECLCommand('fedora')).toContain(
+    expect(await tools.getCommand('linux', 'tool')).toBe('add_tool ');
+    expect(await tools.getCommand('darwin', 'tool')).toBe('add_tool ');
+    expect(await tools.getCommand('win32', 'tool')).toBe('Add-Tool ');
+    expect(await tools.getCommand('fedora', 'tool')).toContain(
       'Platform fedora is not supported'
     );
   });
@@ -205,12 +187,12 @@ describe('Tools tests', () => {
     );
   });
 
-  it('checking getPhpunitUri', async () => {
-    expect(await tools.getPhpunitUrl('tool', 'latest')).toBe(
-      'https://phar.phpunit.de/tool.phar'
+  it('checking getPharUri', async () => {
+    expect(await tools.getPharUrl('domain', 'tool', '', 'latest')).toBe(
+      'domain/tool.phar'
     );
-    expect(await tools.getPhpunitUrl('tool', '1.2.3')).toBe(
-      'https://phar.phpunit.de/tool-1.2.3.phar'
+    expect(await tools.getPharUrl('domain', 'tool', 'v', '1.2.3')).toBe(
+      'domain/tool-v1.2.3.phar'
     );
   });
 
@@ -353,13 +335,13 @@ describe('Tools tests', () => {
       'user/',
       'linux'
     );
-    expect(script).toContain('add_composer_tool tool tool:1.2.3 user/');
+    expect(script).toContain('add_composertool tool tool:1.2.3 user/');
 
     script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'darwin');
-    expect(script).toContain('add_composer_tool tool tool:1.2.3 user/');
+    expect(script).toContain('add_composertool tool tool:1.2.3 user/');
 
     script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'win32');
-    expect(script).toContain('Add-Composer-Tool tool tool:1.2.3 user/');
+    expect(script).toContain('Add-Composertool tool tool:1.2.3 user/');
 
     script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'fedora');
     expect(script).toContain('Platform fedora is not supported');
@@ -367,9 +349,13 @@ describe('Tools tests', () => {
 
   it('checking addTools on linux', async () => {
     const script: string = await tools.addTools(
-      'cs2pr, flex, php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize, symfony, wp-cli',
+      'blackfire, blackfire-player, cs2pr, flex, php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize, symfony, wp-cli',
       '7.4',
       'linux'
+    );
+    expect(script).toContain('add_blackfire');
+    expect(script).toContain(
+      'add_tool https://get.blackfire.io/blackfire-player.phar blackfire-player'
     );
     expect(script).toContain(
       'add_tool https://getcomposer.org/composer-stable.phar composer'
@@ -396,18 +382,22 @@ describe('Tools tests', () => {
       'add_tool https://github.com/wp-cli/builds/blob/gh-pages/phar/wp-cli.phar?raw=true wp-cli'
     );
     expect(script).toContain('add_pecl');
-    expect(script).toContain('add_composer_tool flex flex symfony/');
-    expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
-    expect(script).toContain('add_composer_tool phinx phinx:1.2.3 robmorgan/');
+    expect(script).toContain('add_composertool flex flex symfony/');
+    expect(script).toContain('add_composertool phinx phinx robmorgan/');
+    expect(script).toContain('add_composertool phinx phinx:1.2.3 robmorgan/');
     expect(script).toContain('add_devtools');
     expect(script).toContain('add_log "$tick" "php-config" "Added"');
     expect(script).toContain('add_log "$tick" "phpize" "Added"');
   });
   it('checking addTools on darwin', async () => {
     const script: string = await tools.addTools(
-      'flex, phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, phive:1.2.3, cs2pr:1.2.3, composer-prefetcher:1.2.3, phpize, php-config, symfony, symfony:1.2.3, wp-cli',
+      'blackfire, blackfire-player, flex, phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, phive:1.2.3, cs2pr:1.2.3, composer-prefetcher:1.2.3, phpize, php-config, symfony, symfony:1.2.3, wp-cli',
       '7.4',
       'darwin'
+    );
+    expect(script).toContain('add_blackfire');
+    expect(script).toContain(
+      'add_tool https://get.blackfire.io/blackfire-player.phar blackfire-player'
     );
     expect(script).toContain(
       'add_tool https://getcomposer.org/composer-stable.phar composer'
@@ -430,13 +420,13 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'https://github.com/vimeo/psalm/releases/latest/download/psalm.phar psalm'
     );
-    expect(script).toContain('add_composer_tool flex flex symfony/');
-    expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
+    expect(script).toContain('add_composertool flex flex symfony/');
+    expect(script).toContain('add_composertool phinx phinx robmorgan/');
     expect(script).toContain(
       'add_tool https://github.com/phar-io/phive/releases/download/1.2.3/phive-1.2.3.phar phive'
     );
     expect(script).toContain(
-      'add_composer_tool composer-prefetcher composer-prefetcher:1.2.3 narrowspark/automatic-'
+      'add_composertool composer-prefetcher composer-prefetcher:1.2.3 narrowspark/automatic-'
     );
     expect(script).toContain(
       'add_tool https://github.com/symfony/cli/releases/latest/download/symfony_darwin_amd64 symfony'
@@ -452,9 +442,13 @@ describe('Tools tests', () => {
   });
   it('checking addTools on windows', async () => {
     const script: string = await tools.addTools(
-      'codeception, cs2pr, deployer, flex, prestissimo, phpmd, phinx, phive:0.13.2, php-config, phpize, symfony, wp-cli, does_not_exit',
+      'blackfire, blackfire-player:1.8.1, codeception, cs2pr, deployer, flex, prestissimo, phpmd, phinx, phive:0.13.2, php-config, phpize, symfony, wp-cli, does_not_exit',
       '7.4',
       'win32'
+    );
+    expect(script).toContain('Add-Blackfire 1.32.0');
+    expect(script).toContain(
+      'Add-Tool https://get.blackfire.io/blackfire-player-v1.8.1.phar blackfire-player'
     );
     expect(script).toContain(
       'Add-Tool https://getcomposer.org/composer-stable.phar composer'
@@ -462,17 +456,15 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'Add-Tool https://github.com/staabm/annotate-pull-request-from-checkstyle/releases/latest/download/cs2pr cs2pr'
     );
-    expect(script).toContain('Add-Composer-Tool flex flex symfony/');
+    expect(script).toContain('Add-Composertool flex flex symfony/');
     expect(script).toContain(
       'Add-Tool https://deployer.org/deployer.phar deployer'
     );
-    expect(script).toContain(
-      'Add-Composer-Tool prestissimo prestissimo hirak/'
-    );
+    expect(script).toContain('Add-Composertool prestissimo prestissimo hirak/');
     expect(script).toContain(
       'Add-Tool https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar phpmd'
     );
-    expect(script).toContain('Add-Composer-Tool phinx phinx robmorgan/');
+    expect(script).toContain('Add-Composertool phinx phinx robmorgan/');
     expect(script).toContain(
       'Add-Tool https://github.com/phar-io/phive/releases/download/0.13.2/phive-0.13.2.phar phive'
     );
@@ -496,12 +488,10 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'Add-Tool https://getcomposer.org/composer-stable.phar composer'
     );
+    expect(script).toContain('Add-Composertool prestissimo prestissimo hirak/');
+    expect(script).toContain('Add-Composertool phinx phinx robmorgan/');
     expect(script).toContain(
-      'Add-Composer-Tool prestissimo prestissimo hirak/'
-    );
-    expect(script).toContain('Add-Composer-Tool phinx phinx robmorgan/');
-    expect(script).toContain(
-      'Add-Composer-Tool composer-prefetcher composer-prefetcher narrowspark/automatic-'
+      'Add-Composertool composer-prefetcher composer-prefetcher narrowspark/automatic-'
     );
   });
 });

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -372,7 +372,7 @@ describe('Tools tests', () => {
       'linux'
     );
     expect(script).toContain(
-      'add_tool https://github.com/composer/composer/releases/latest/download/composer.phar composer'
+      'add_tool https://getcomposer.org/composer-stable.phar composer'
     );
     expect(script).toContain(
       'add_tool https://github.com/staabm/annotate-pull-request-from-checkstyle/releases/latest/download/cs2pr cs2pr'
@@ -410,7 +410,7 @@ describe('Tools tests', () => {
       'darwin'
     );
     expect(script).toContain(
-      'add_tool https://github.com/composer/composer/releases/latest/download/composer.phar composer'
+      'add_tool https://getcomposer.org/composer-stable.phar composer'
     );
     expect(script).toContain(
       'add_tool https://github.com/staabm/annotate-pull-request-from-checkstyle/releases/download/1.2.3/cs2pr cs2pr'
@@ -457,7 +457,7 @@ describe('Tools tests', () => {
       'win32'
     );
     expect(script).toContain(
-      'Add-Tool https://github.com/composer/composer/releases/latest/download/composer.phar composer'
+      'Add-Tool https://getcomposer.org/composer-stable.phar composer'
     );
     expect(script).toContain(
       'Add-Tool https://github.com/staabm/annotate-pull-request-from-checkstyle/releases/latest/download/cs2pr cs2pr'
@@ -494,7 +494,7 @@ describe('Tools tests', () => {
       'win32'
     );
     expect(script).toContain(
-      'Add-Tool https://github.com/composer/composer/releases/latest/download/composer.phar composer'
+      'Add-Tool https://getcomposer.org/composer-stable.phar composer'
     );
     expect(script).toContain(
       'Add-Composer-Tool prestissimo prestissimo hirak/'

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -276,6 +276,15 @@ describe('Tools tests', () => {
     ]);
   });
 
+  it('checking getWpCliUri', async () => {
+    expect(await tools.getWpCliUrl('latest')).toBe(
+      'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar'
+    );
+    expect(await tools.getWpCliUrl('2.4.0')).toBe(
+      'https://github.com/wp-cli/wp-cli/releases/download/v2.4.0/wp-cli-2.4.0.phar'
+    );
+  });
+
   it('checking addArchive', async () => {
     let script: string = await tools.addArchive(
       'tool',
@@ -358,7 +367,7 @@ describe('Tools tests', () => {
 
   it('checking addTools on linux', async () => {
     const script: string = await tools.addTools(
-      'cs2pr, php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize, symfony',
+      'cs2pr, php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize, symfony, wp-cli',
       '7.4',
       'linux'
     );
@@ -383,6 +392,9 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'add_tool https://github.com/symfony/cli/releases/latest/download/symfony_linux_amd64 symfony'
     );
+    expect(script).toContain(
+      'add_tool https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar wp-cli'
+    );
     expect(script).toContain('add_pecl');
     expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
     expect(script).toContain('add_composer_tool phinx phinx:1.2.3 robmorgan/');
@@ -392,7 +404,7 @@ describe('Tools tests', () => {
   });
   it('checking addTools on darwin', async () => {
     const script: string = await tools.addTools(
-      'phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, phive:1.2.3, cs2pr:1.2.3, composer-prefetcher:1.2.3, phpize, php-config, symfony, symfony:1.2.3',
+      'phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, phive:1.2.3, cs2pr:1.2.3, composer-prefetcher:1.2.3, phpize, php-config, symfony, symfony:1.2.3, wp-cli',
       '7.4',
       'darwin'
     );
@@ -430,12 +442,15 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'add_tool https://github.com/symfony/cli/releases/download/v1.2.3/symfony_darwin_amd64 symfony'
     );
+    expect(script).toContain(
+      'add_tool https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar wp-cli'
+    );
     expect(script).toContain('add_log "$tick" "phpize" "Added"');
     expect(script).toContain('add_log "$tick" "php-config" "Added"');
   });
   it('checking addTools on windows', async () => {
     const script: string = await tools.addTools(
-      'codeception, cs2pr, deployer, prestissimo, phpmd, phinx, phive:0.13.2, php-config, phpize, symfony, does_not_exit',
+      'codeception, cs2pr, deployer, prestissimo, phpmd, phinx, phive:0.13.2, php-config, phpize, symfony, wp-cli, does_not_exit',
       '7.4',
       'win32'
     );
@@ -460,6 +475,9 @@ describe('Tools tests', () => {
     );
     expect(script).toContain(
       'Add-Tool https://github.com/symfony/cli/releases/latest/download/symfony_windows_amd64.exe symfony'
+    );
+    expect(script).toContain(
+      'Add-Tool https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar wp-cli'
     );
     expect(script).toContain('phpize is not a windows tool');
     expect(script).toContain('php-config is not a windows tool');

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -223,7 +223,7 @@ describe('Tools tests', () => {
     );
   });
 
-  it('checking getDeployerUri', async () => {
+  it('checking addComposer', async () => {
     expect(await tools.addComposer(['a', 'b'])).toStrictEqual([
       'composer',
       'a',

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -367,7 +367,7 @@ describe('Tools tests', () => {
 
   it('checking addTools on linux', async () => {
     const script: string = await tools.addTools(
-      'cs2pr, php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize, symfony, wp-cli',
+      'cs2pr, flex, php-cs-fixer, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize, symfony, wp-cli',
       '7.4',
       'linux'
     );
@@ -396,6 +396,7 @@ describe('Tools tests', () => {
       'add_tool https://github.com/wp-cli/builds/blob/gh-pages/phar/wp-cli.phar?raw=true wp-cli'
     );
     expect(script).toContain('add_pecl');
+    expect(script).toContain('add_composer_tool flex flex symfony/');
     expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
     expect(script).toContain('add_composer_tool phinx phinx:1.2.3 robmorgan/');
     expect(script).toContain('add_devtools');
@@ -404,7 +405,7 @@ describe('Tools tests', () => {
   });
   it('checking addTools on darwin', async () => {
     const script: string = await tools.addTools(
-      'phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, phive:1.2.3, cs2pr:1.2.3, composer-prefetcher:1.2.3, phpize, php-config, symfony, symfony:1.2.3, wp-cli',
+      'flex, phpcs, phpcbf, phpcpd, phpmd, psalm, phinx, phive:1.2.3, cs2pr:1.2.3, composer-prefetcher:1.2.3, phpize, php-config, symfony, symfony:1.2.3, wp-cli',
       '7.4',
       'darwin'
     );
@@ -429,6 +430,7 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'https://github.com/vimeo/psalm/releases/latest/download/psalm.phar psalm'
     );
+    expect(script).toContain('add_composer_tool flex flex symfony/');
     expect(script).toContain('add_composer_tool phinx phinx robmorgan/');
     expect(script).toContain(
       'add_tool https://github.com/phar-io/phive/releases/download/1.2.3/phive-1.2.3.phar phive'
@@ -450,7 +452,7 @@ describe('Tools tests', () => {
   });
   it('checking addTools on windows', async () => {
     const script: string = await tools.addTools(
-      'codeception, cs2pr, deployer, prestissimo, phpmd, phinx, phive:0.13.2, php-config, phpize, symfony, wp-cli, does_not_exit',
+      'codeception, cs2pr, deployer, flex, prestissimo, phpmd, phinx, phive:0.13.2, php-config, phpize, symfony, wp-cli, does_not_exit',
       '7.4',
       'win32'
     );
@@ -460,6 +462,7 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'Add-Tool https://github.com/staabm/annotate-pull-request-from-checkstyle/releases/latest/download/cs2pr cs2pr'
     );
+    expect(script).toContain('Add-Composer-Tool flex flex symfony/');
     expect(script).toContain(
       'Add-Tool https://deployer.org/deployer.phar deployer'
     );

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -162,10 +162,10 @@ describe('Utils tests', () => {
     );
   });
 
-  it('checking getMinorVersion', async () => {
-    expect(await utils.getMinorVersion('7.14.0')).toEqual('7.14');
-    expect(await utils.getMinorVersion('7.4')).toEqual('7.4');
-    expect(await utils.getMinorVersion('7.4.1')).toEqual('7.4');
-    expect(await utils.getMinorVersion('7.aa')).toEqual('7.aa');
+  it('checking getBlackfireVersion', async () => {
+    expect(await utils.getBlackfireVersion('')).toEqual('1.31.0');
+    expect(await utils.getBlackfireVersion(undefined)).toEqual('1.31.0');
+    expect(await utils.getBlackfireVersion(null)).toEqual('1.31.0');
+    expect(await utils.getBlackfireVersion('1.32.0')).toEqual('1.32.0');
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -168,4 +168,7 @@ describe('Utils tests', () => {
     expect(await utils.getBlackfireVersion(null)).toEqual('1.31.0');
     expect(await utils.getBlackfireVersion('1.32.0')).toEqual('1.32.0');
   });
+  it('checking getBlackfireAgentVersion', async () => {
+    expect(await utils.getBlackfireAgentVersion()).toEqual('1.32.0');
+  });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -161,4 +161,11 @@ describe('Utils tests', () => {
       'Platform fedora is not supported'
     );
   });
+
+  it('checking getMinorVersion', async () => {
+    expect(await utils.getMinorVersion('7.14.0')).toEqual('7.14');
+    expect(await utils.getMinorVersion('7.4')).toEqual('7.4');
+    expect(await utils.getMinorVersion('7.4.1')).toEqual('7.4');
+    expect(await utils.getMinorVersion('7.aa')).toEqual('7.aa');
+  });
 });

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,7 @@ author: shivammathur
 description: 'Setup PHP with required extensions, php.ini configuration, code-coverage support and various tools like composer'
 branding:
   color: 'purple'
+  icon: 'play-circle'
 inputs:
   php-version:
     description: 'Setup PHP version.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2711,6 +2711,11 @@ function addExtensionDarwin(extension_csv, version, pipe) {
                                 ' ' +
                                 prefix;
                         return;
+                    // match exact versions
+                    case /.*-\d+\.\d+\.\d+.*/.test(version_extension):
+                        script +=
+                            '\nadd_pecl_extension ' + ext_name + ' ' + ext_version + ' ' + prefix;
+                        return;
                     case /5\.3xdebug/.test(version_extension):
                         install_command = 'sudo pecl install -f xdebug-2.2.7' + pipe;
                         break;
@@ -2748,7 +2753,7 @@ function addExtensionDarwin(extension_csv, version, pipe) {
                 }
                 script +=
                     '\nadd_extension ' +
-                        ext_name +
+                        extension +
                         ' "' +
                         install_command +
                         '" ' +
@@ -2842,7 +2847,8 @@ function addExtensionLinux(extension_csv, version, pipe) {
                         return;
                     // match exact versions
                     case /.*-\d+\.\d+\.\d+.*/.test(version_extension):
-                        script += '\nadd_pecl_extension ' + ext_name + ' ' + ext_version;
+                        script +=
+                            '\nadd_pecl_extension ' + ext_name + ' ' + ext_version + ' ' + prefix;
                         return;
                     // match 5.6gearman..7.4gearman
                     case /^((5\.6)|(7\.[0-4]))gearman$/.test(version_extension):

--- a/dist/index.js
+++ b/dist/index.js
@@ -1872,13 +1872,9 @@ function getWpCliUrl(version) {
     return __awaiter(this, void 0, void 0, function* () {
         switch (version) {
             case 'latest':
-                return 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
+                return 'wp-cli/builds/blob/gh-pages/phar/wp-cli.phar?raw=true';
             default:
-                return ('https://github.com/wp-cli/wp-cli/releases/download/v' +
-                    version +
-                    '/wp-cli-' +
-                    version +
-                    '.phar');
+                return yield getUri('wp-cli', '-' + version + '.phar', version, 'wp-cli/wp-cli/releases', 'v', 'download');
         }
     });
 }
@@ -2069,7 +2065,7 @@ function addTools(tools_csv, php_version, os_version) {
                         script += yield addArchive('symfony', version, url, os_version);
                         break;
                     case 'wp-cli':
-                        url = yield getWpCliUrl(version);
+                        url = github + (yield getWpCliUrl(version));
                         script += yield addArchive(tool, version, url, os_version);
                         break;
                     default:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1247,17 +1247,24 @@ function suppressOutput(os_version) {
     });
 }
 exports.suppressOutput = suppressOutput;
-function getMinorVersion(version) {
+/**
+ * Function to get Blackfire version
+ *
+ * @param blackfire_version
+ */
+function getBlackfireVersion(blackfire_version) {
     return __awaiter(this, void 0, void 0, function* () {
-        const regex = /^\d+\.\d+/;
-        const match = version.match(regex);
-        if (match === null) {
-            return version;
+        switch (blackfire_version) {
+            case null:
+            case undefined:
+            case '':
+                return '1.31.0';
+            default:
+                return blackfire_version;
         }
-        return match[0];
     });
 }
-exports.getMinorVersion = getMinorVersion;
+exports.getBlackfireVersion = getBlackfireVersion;
 
 
 /***/ }),
@@ -2717,18 +2724,15 @@ function addExtensionDarwin(extension_csv, version, pipe) {
                 const prefix = yield utils.getExtensionPrefix(ext_name);
                 let install_command = '';
                 switch (true) {
-                    case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
-                        script +=
-                            '\nsh ' +
+                    case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(version_extension):
+                        install_command =
+                            'bash ' +
                                 path.join(__dirname, '../src/scripts/ext/blackfire_darwin.sh') +
                                 ' ' +
                                 version +
                                 ' ' +
-                                (yield utils.getMinorVersion(version)).replace('.', '');
-                        if (ext_version) {
-                            script += ' ' + ext_version;
-                        }
-                        return;
+                                (yield utils.getBlackfireVersion(ext_version));
+                        break;
                     // match pre-release versions
                     case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
                         script +=
@@ -2811,15 +2815,14 @@ function addExtensionWindows(extension_csv, version, pipe) {
                 let matches;
                 switch (true) {
                     // match blackfire...blackfire-1.31.0
-                    case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
+                    case /^(5\.[4-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(version_extension):
                         script +=
                             '\n& ' +
                                 path.join(__dirname, '../src/scripts/ext/blackfire.ps1') +
                                 ' ' +
-                                (yield utils.getMinorVersion(version)).replace('.', '');
-                        if (ext_version) {
-                            script += ' ' + ext_version;
-                        }
+                                version +
+                                ' ' +
+                                (yield utils.getBlackfireVersion(ext_version));
                         return;
                     // match pre-release versions
                     case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
@@ -2875,18 +2878,15 @@ function addExtensionLinux(extension_csv, version, pipe) {
                 let install_command = '';
                 switch (true) {
                     // match blackfire... blackfire-1.31.0
-                    case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
-                        script +=
-                            '\nsh ' +
+                    case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(version_extension):
+                        install_command =
+                            'bash ' +
                                 path.join(__dirname, '../src/scripts/ext/blackfire.sh') +
                                 ' ' +
                                 version +
                                 ' ' +
-                                (yield utils.getMinorVersion(version)).replace('.', '');
-                        if (ext_version) {
-                            script += ' ' + ext_version;
-                        }
-                        return;
+                                (yield utils.getBlackfireVersion(ext_version));
+                        break;
                     // match pre-release versions
                     case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
                         script +=

--- a/dist/index.js
+++ b/dist/index.js
@@ -2748,7 +2748,7 @@ function addExtensionDarwin(extension_csv, version, pipe) {
                 }
                 script +=
                     '\nadd_extension ' +
-                        extension +
+                        ext_name +
                         ' "' +
                         install_command +
                         '" ' +

--- a/dist/index.js
+++ b/dist/index.js
@@ -1864,6 +1864,26 @@ function getSymfonyUri(version, os_version) {
 }
 exports.getSymfonyUri = getSymfonyUri;
 /**
+ * Function to get the WP-CLI url
+ *
+ * @param version
+ */
+function getWpCliUrl(version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        switch (version) {
+            case 'latest':
+                return 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
+            default:
+                return ('https://github.com/wp-cli/wp-cli/releases/download/v' +
+                    version +
+                    '/wp-cli-' +
+                    version +
+                    '.phar');
+        }
+    });
+}
+exports.getWpCliUrl = getWpCliUrl;
+/**
  * Function to add/move composer in the tools list
  *
  * @param tools
@@ -2047,6 +2067,10 @@ function addTools(tools_csv, php_version, os_version) {
                         uri = yield getSymfonyUri(version, os_version);
                         url = github + 'symfony/cli/' + uri;
                         script += yield addArchive('symfony', version, url, os_version);
+                        break;
+                    case 'wp-cli':
+                        url = yield getWpCliUrl(version);
+                        script += yield addArchive(tool, version, url, os_version);
                         break;
                     default:
                         script += yield utils.addLog('$cross', tool, 'Tool ' + tool + ' is not supported', os_version);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2042,6 +2042,9 @@ function addTools(tools_csv, php_version, os_version) {
                         url = yield getDeployerUrl(version);
                         script += yield addArchive(tool, version, url, os_version);
                         break;
+                    case 'flex':
+                        script += yield addPackage(tool, release, 'symfony/', os_version);
+                        break;
                     case 'phinx':
                         script += yield addPackage(tool, release, 'robmorgan/', os_version);
                         break;

--- a/dist/index.js
+++ b/dist/index.js
@@ -2023,8 +2023,10 @@ function addTools(tools_csv, php_version, os_version) {
                         script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'composer':
-                        url =
-                            github + 'composer/composer/releases/latest/download/composer.phar';
+                        // If RC is released as latest release, switch to getcomposer.
+                        // Prefered source is GitHub as it is faster.
+                        // url = github + 'composer/composer/releases/latest/download/composer.phar';
+                        url = 'https://getcomposer.org/composer-stable.phar';
                         script += yield addArchive(tool, version, url, os_version);
                         break;
                     case 'codeception':

--- a/dist/index.js
+++ b/dist/index.js
@@ -1900,7 +1900,7 @@ function getCleanedToolsList(tools_csv) {
             .map(function (extension) {
             return extension
                 .trim()
-                .replace(/robmorgan\/|hirak\/|narrowspark\/automatic-/, '');
+                .replace(/symfony\/|robmorgan\/|hirak\/|narrowspark\/automatic-/, '');
         })
             .filter(Boolean);
         return [...new Set(tools_list)];

--- a/dist/index.js
+++ b/dist/index.js
@@ -1247,6 +1247,17 @@ function suppressOutput(os_version) {
     });
 }
 exports.suppressOutput = suppressOutput;
+function getMinorVersion(version) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const regex = /^\d+\.\d+/;
+        const match = version.match(regex);
+        if (match === null) {
+            return version;
+        }
+        return match[0];
+    });
+}
+exports.getMinorVersion = getMinorVersion;
 
 
 /***/ }),
@@ -2706,6 +2717,18 @@ function addExtensionDarwin(extension_csv, version, pipe) {
                 const prefix = yield utils.getExtensionPrefix(ext_name);
                 let install_command = '';
                 switch (true) {
+                    case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
+                        script +=
+                            '\nsh ' +
+                                path.join(__dirname, '../src/scripts/ext/blackfire_darwin.sh') +
+                                ' ' +
+                                version +
+                                ' ' +
+                                (yield utils.getMinorVersion(version)).replace('.', '');
+                        if (ext_version) {
+                            script += ' ' + ext_version;
+                        }
+                        return;
                     // match pre-release versions
                     case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
                         script +=
@@ -2787,6 +2810,17 @@ function addExtensionWindows(extension_csv, version, pipe) {
                 const version_extension = version + extension;
                 let matches;
                 switch (true) {
+                    // match blackfire...blackfire-1.31.0
+                    case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
+                        script +=
+                            '\n& ' +
+                                path.join(__dirname, '../src/scripts/ext/blackfire.ps1') +
+                                ' ' +
+                                (yield utils.getMinorVersion(version)).replace('.', '');
+                        if (ext_version) {
+                            script += ' ' + ext_version;
+                        }
+                        return;
                     // match pre-release versions
                     case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
                         script += '\nAdd-Extension ' + ext_name + ' ' + ext_version;
@@ -2840,6 +2874,19 @@ function addExtensionLinux(extension_csv, version, pipe) {
                 const prefix = yield utils.getExtensionPrefix(ext_name);
                 let install_command = '';
                 switch (true) {
+                    // match blackfire... blackfire-1.31.0
+                    case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
+                        script +=
+                            '\nsh ' +
+                                path.join(__dirname, '../src/scripts/ext/blackfire.sh') +
+                                ' ' +
+                                version +
+                                ' ' +
+                                (yield utils.getMinorVersion(version)).replace('.', '');
+                        if (ext_version) {
+                            script += ' ' + ext_version;
+                        }
+                        return;
                     // match pre-release versions
                     case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
                         script +=

--- a/examples/blackfire-player.yml
+++ b/examples/blackfire-player.yml
@@ -1,8 +1,8 @@
-# GitHub Action for Blackfire
-name: Profiling with blackfire
+# GitHub Action for Blackfire Player
+name: Play a Blackfire Scenario
 on: [push, pull_request]
 jobs:
-  blackfire:
+  blackfire-player:
     name: Blackfire (PHP ${{ matrix.php-versions }})
     # Add your Blackfire credentials securely using GitHub Secrets
     env:
@@ -16,7 +16,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
         php-versions: ['7.2', '7.3', '7.4']
-        # Blackfire supports PHP >= 5.3 on ubuntu and macos and PHP >= 5.4 on windows
+        # blackfire-player supports PHP >= 5.5
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: blackfire
-          tools: blackfire #Setup Blackfire client and agent
+          tools: blackfire, blackfire-player #Setup Blackfire client, agent and player
           coverage: none
-      - name: Profile
-        run: blackfire run php my-script.php # Refer to https://blackfire.io/docs/cookbooks/profiling-cli
+      - name: Play the scenario
+        run: blackfire-player run scenario.bkf # Refer to https://blackfire.io/docs/player/index#usage

--- a/examples/blackfire.yml
+++ b/examples/blackfire.yml
@@ -1,0 +1,32 @@
+# GitHub Action for blackfire
+name: Profiling with blackfire
+on: [push, pull_request]
+jobs:
+  bedrock:
+    name: Blackfire (PHP ${{ matrix.php-versions }})
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      blackfire:
+        image: blackfire/blackfire
+        ports:
+          - 8707:8707
+        env:
+          BLACKFIRE_SERVER_ID: "<id>"
+          BLACKFIRE_SERVER_TOKEN: "<token>"
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        php-versions: ['7.1', '7.2', '7.3', '7.4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: blackfire-1.30.0
+          ini-values: blackfire.agent_socket=tcp://localhost:8707
+      - name: Profile
+        # Note that blackfire agent is not installed. So an implementation with the sdk is required!
+        run: php your-blackfire-sdk-script.php

--- a/examples/cakephp-mysql.yml
+++ b/examples/cakephp-mysql.yml
@@ -34,6 +34,8 @@ jobs:
           # Install memcached if using ext-memcached
           extensions: mbstring, intl, redis, pdo_mysql
           coverage: pcov
+      - name: Start mysql service
+        run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/examples/laravel-mysql.yml
+++ b/examples/laravel-mysql.yml
@@ -41,6 +41,8 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug #optional
+      - name: Start mysql service
+        run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/examples/lumen-mysql.yml
+++ b/examples/lumen-mysql.yml
@@ -41,6 +41,8 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug #optional
+      - name: Start mysql service
+        run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/examples/phalcon-mysql.yml
+++ b/examples/phalcon-mysql.yml
@@ -41,6 +41,8 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, zip, phalcon4, mysql #use phalcon3 for the phalcon 3.x.
           coverage: xdebug #optional
+      - name: Start mysql service
+        run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/examples/symfony-mysql.yml
+++ b/examples/symfony-mysql.yml
@@ -28,6 +28,8 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql
           coverage: xdebug #optional
+      - name: Start mysql service
+        run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/examples/yii2-mysql.yml
+++ b/examples/yii2-mysql.yml
@@ -38,6 +38,8 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, gd, imagick, zip, dom, mysql
           coverage: xdebug #optional
+      - name: Start mysql service
+        run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -32,18 +32,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
-      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.6.tgz",
+      "integrity": "sha512-Sheg7yEJD51YHAvLEV/7Uvw95AeWqYPL3Vk3zGujJKIhJ+8oLw2ALaf3hbucILhKsgSoADOvtKRJuNVdcJkOrg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
+        "@babel/generator": "^7.8.6",
         "@babel/helpers": "^7.8.4",
-        "@babel/parser": "^7.8.4",
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.4",
-        "@babel/types": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -69,12 +69,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+      "integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3",
+        "@babel/types": "^7.8.6",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -198,9 +198,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+      "integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
       "dev": true
     },
     "@babel/plugin-syntax-bigint": {
@@ -231,28 +231,28 @@
       }
     },
     "@babel/template": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+      "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
+        "@babel/generator": "^7.8.6",
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.4",
-        "@babel/types": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -267,9 +267,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+      "integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -584,9 +584,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.5.tgz",
-      "integrity": "sha512-+ckxwNj892FWgvwrUWLOghQ2JDgOgeqTPwrcl+0t1pG59CP8qMJ6S/efmEd999vCFSJKOpyMakvU+w380rduUQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
+      "integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -678,9 +678,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
-      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
+      "version": "13.7.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
+      "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==",
       "dev": true
     },
     "@types/parse-json": {
@@ -696,9 +696,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.3.tgz",
-      "integrity": "sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==",
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
+      "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -711,12 +711,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.20.0.tgz",
-      "integrity": "sha512-cimIdVDV3MakiGJqMXw51Xci6oEDEoPkvh8ggJe2IIzcc0fYqAxOXN6Vbeanahz6dLZq64W+40iUEc9g32FLDQ==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.21.0.tgz",
+      "integrity": "sha512-b5jjjDMxzcjh/Sbjuo7WyhrQmVJg0WipTHQgXh5Xwx10uYm6nPWqN1WGOsaNq4HR3Zh4wUx4IRQdDkCHwyewyw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.20.0",
+        "@typescript-eslint/experimental-utils": "2.21.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -724,32 +724,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.20.0.tgz",
-      "integrity": "sha512-fEBy9xYrwG9hfBLFEwGW2lKwDRTmYzH3DwTmYbT+SMycmxAoPl0eGretnBFj/s+NfYBG63w/5c3lsvqqz5mYag==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.21.0.tgz",
+      "integrity": "sha512-olKw9JP/XUkav4lq0I7S1mhGgONJF9rHNhKFn9wJlpfRVjNo3PPjSvybxEldvCXnvD+WAshSzqH5cEjPp9CsBA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.20.0",
+        "@typescript-eslint/typescript-estree": "2.21.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.20.0.tgz",
-      "integrity": "sha512-o8qsKaosLh2qhMZiHNtaHKTHyCHc3Triq6aMnwnWj7budm3xAY9owSZzV1uon5T9cWmJRJGzTFa90aex4m77Lw==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.21.0.tgz",
+      "integrity": "sha512-VrmbdrrrvvI6cPPOG7uOgGUFXNYTiSbnRq8ZMyuGa4+qmXJXVLEEz78hKuqupvkpwJQNk1Ucz1TenrRP90gmBg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.20.0",
-        "@typescript-eslint/typescript-estree": "2.20.0",
+        "@typescript-eslint/experimental-utils": "2.21.0",
+        "@typescript-eslint/typescript-estree": "2.21.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.20.0.tgz",
-      "integrity": "sha512-WlFk8QtI8pPaE7JGQGxU7nGcnk1ccKAJkhbVookv94ZcAef3m6oCE/jEDL6dGte3JcD7reKrA0o55XhBRiVT3A==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.21.0.tgz",
+      "integrity": "sha512-NC/nogZNb9IK2MEFQqyDBAciOT8Lp8O3KgAfvHx2Skx6WBo+KmDqlU3R9KxHONaijfTIKtojRe3SZQyMjr3wBw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -798,9 +798,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "acorn-walk": {
@@ -810,9 +810,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -1875,9 +1875,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.7.0.tgz",
-      "integrity": "sha512-zkiyGlvJeHNjAEz8FaIxTXNblJJ/zj3waNbYbgflK7K6uy0cpE5zJBt/JpJtOBGM/UGkC6BqsQ4n0y7kQ2HA8w==",
+      "version": "23.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.8.0.tgz",
+      "integrity": "sha512-DKXmLxguZ1Lru4u5YM12ko3WLq6gqo7dhV2b63K731+/PNyZ/Ff6NGONQsGUtPLG9zU3kdz/N+2LTbweNZifeg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^2.5.0"
@@ -2498,9 +2498,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.7.tgz",
+      "integrity": "sha512-ChkjQtKJ3GI6SsI4O5jwr8q8EPrWCnxuc4Tbx+vRI5x6mDOpjKKltNo1lRlszw3xwgTOSns1ZRBiMmmwpcvLxg==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -2731,74 +2731,33 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-      "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.5.tgz",
+      "integrity": "sha512-6Z5cP+LAO0rzNE7xWjWtT84jxKa5ScLEGLgegPXeO3dGeU8lNe5Ii7SlXH6KVtLGlDuaEhsvsFjrjWjw8j5lFg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
+        "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "^2.2.0",
+        "run-async": "^2.4.0",
         "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
-        "strip-ansi": "^5.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -4427,9 +4386,9 @@
       "dev": true
     },
     "react-is": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
       "dev": true
     },
     "read-pkg": {
@@ -4656,9 +4615,9 @@
       "dev": true
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
@@ -5543,9 +5502,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-      "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
     "tsutils": {
@@ -5603,9 +5562,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
-      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "union-value": {
@@ -5871,9 +5830,9 @@
       }
     },
     "write-file-atomic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
-      "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",
@@ -31,21 +31,21 @@
   },
   "devDependencies": {
     "@types/jest": "^25.1.3",
-    "@types/node": "^13.7.4",
-    "@typescript-eslint/eslint-plugin": "^2.20.0",
-    "@typescript-eslint/parser": "^2.20.0",
+    "@types/node": "^13.7.7",
+    "@typescript-eslint/eslint-plugin": "^2.21.0",
+    "@typescript-eslint/parser": "^2.21.0",
     "@zeit/ncc": "^0.21.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-jest": "^23.7.0",
+    "eslint-plugin-jest": "^23.8.0",
     "eslint-plugin-prettier": "^3.1.2",
     "husky": "^4.2.3",
     "jest": "^25.1.0",
     "jest-circus": "^25.1.0",
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.1",
-    "typescript": "^3.8.2"
+    "typescript": "^3.8.3"
   },
   "husky": {
     "skipCI": true,

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -22,19 +22,17 @@ export async function addExtensionDarwin(
     const prefix = await utils.getExtensionPrefix(ext_name);
     let install_command = '';
     switch (true) {
-      case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
-        script +=
-          '\nsh ' +
+      case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(
+        version_extension
+      ):
+        install_command =
+          'bash ' +
           path.join(__dirname, '../src/scripts/ext/blackfire_darwin.sh') +
           ' ' +
           version +
           ' ' +
-          (await utils.getMinorVersion(version)).replace('.', '');
-
-        if (ext_version) {
-          script += ' ' + ext_version;
-        }
-        return;
+          (await utils.getBlackfireVersion(ext_version));
+        break;
       // match pre-release versions
       case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
         script +=
@@ -117,16 +115,16 @@ export async function addExtensionWindows(
     let matches: RegExpExecArray;
     switch (true) {
       // match blackfire...blackfire-1.31.0
-      case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
+      case /^(5\.[4-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(
+        version_extension
+      ):
         script +=
           '\n& ' +
           path.join(__dirname, '../src/scripts/ext/blackfire.ps1') +
           ' ' +
-          (await utils.getMinorVersion(version)).replace('.', '');
-
-        if (ext_version) {
-          script += ' ' + ext_version;
-        }
+          version +
+          ' ' +
+          (await utils.getBlackfireVersion(ext_version));
         return;
       // match pre-release versions
       case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
@@ -186,19 +184,17 @@ export async function addExtensionLinux(
     let install_command = '';
     switch (true) {
       // match blackfire... blackfire-1.31.0
-      case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
-        script +=
-          '\nsh ' +
+      case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(
+        version_extension
+      ):
+        install_command =
+          'bash ' +
           path.join(__dirname, '../src/scripts/ext/blackfire.sh') +
           ' ' +
           version +
           ' ' +
-          (await utils.getMinorVersion(version)).replace('.', '');
-
-        if (ext_version) {
-          script += ' ' + ext_version;
-        }
-        return;
+          (await utils.getBlackfireVersion(ext_version));
+        break;
       // match pre-release versions
       case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
         script +=

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -22,6 +22,8 @@ export async function addExtensionDarwin(
     const prefix = await utils.getExtensionPrefix(ext_name);
     let install_command = '';
     switch (true) {
+      // match 5.3blackfire...5.6blackfire, 7.0blackfire...7.4blackfire
+      // match 5.3blackfire-1.31.0...5.6blackfire-1.31.0, 7.0blackfire-1.31.0...7.4blackfire-1.31.0
       case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(
         version_extension
       ):
@@ -114,7 +116,8 @@ export async function addExtensionWindows(
     const version_extension: string = version + extension;
     let matches: RegExpExecArray;
     switch (true) {
-      // match blackfire...blackfire-1.31.0
+      // match 5.4blackfire...5.6blackfire, 7.0blackfire...7.4blackfire
+      // match 5.4blackfire-1.31.0...5.6blackfire-1.31.0, 7.0blackfire-1.31.0...7.4blackfire-1.31.0
       case /^(5\.[4-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(
         version_extension
       ):
@@ -183,7 +186,8 @@ export async function addExtensionLinux(
     const prefix = await utils.getExtensionPrefix(ext_name);
     let install_command = '';
     switch (true) {
-      // match blackfire... blackfire-1.31.0
+      // match 5.3blackfire...5.6blackfire, 7.0blackfire...7.4blackfire
+      // match 5.3blackfire-1.31.0...5.6blackfire-1.31.0, 7.0blackfire-1.31.0...7.4blackfire-1.31.0
       case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(
         version_extension
       ):

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -22,6 +22,19 @@ export async function addExtensionDarwin(
     const prefix = await utils.getExtensionPrefix(ext_name);
     let install_command = '';
     switch (true) {
+      case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
+        script +=
+          '\nsh ' +
+          path.join(__dirname, '../src/scripts/ext/blackfire_darwin.sh') +
+          ' ' +
+          version +
+          ' ' +
+          (await utils.getMinorVersion(version)).replace('.', '');
+
+        if (ext_version) {
+          script += ' ' + ext_version;
+        }
+        return;
       // match pre-release versions
       case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
         script +=
@@ -103,6 +116,18 @@ export async function addExtensionWindows(
     const version_extension: string = version + extension;
     let matches: RegExpExecArray;
     switch (true) {
+      // match blackfire...blackfire-1.31.0
+      case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
+        script +=
+          '\n& ' +
+          path.join(__dirname, '../src/scripts/ext/blackfire.ps1') +
+          ' ' +
+          (await utils.getMinorVersion(version)).replace('.', '');
+
+        if (ext_version) {
+          script += ' ' + ext_version;
+        }
+        return;
       // match pre-release versions
       case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
         script += '\nAdd-Extension ' + ext_name + ' ' + ext_version;
@@ -160,6 +185,20 @@ export async function addExtensionLinux(
     const prefix = await utils.getExtensionPrefix(ext_name);
     let install_command = '';
     switch (true) {
+      // match blackfire... blackfire-1.31.0
+      case /^blackfire(-\d+\.\d+\.\d+)?$/.test(extension):
+        script +=
+          '\nsh ' +
+          path.join(__dirname, '../src/scripts/ext/blackfire.sh') +
+          ' ' +
+          version +
+          ' ' +
+          (await utils.getMinorVersion(version)).replace('.', '');
+
+        if (ext_version) {
+          script += ' ' + ext_version;
+        }
+        return;
       // match pre-release versions
       case /.*-(beta|alpha|devel|snapshot)/.test(version_extension):
         script +=

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -32,6 +32,11 @@ export async function addExtensionDarwin(
           ' ' +
           prefix;
         return;
+      // match exact versions
+      case /.*-\d+\.\d+\.\d+.*/.test(version_extension):
+        script +=
+          '\nadd_pecl_extension ' + ext_name + ' ' + ext_version + ' ' + prefix;
+        return;
       case /5\.3xdebug/.test(version_extension):
         install_command = 'sudo pecl install -f xdebug-2.2.7' + pipe;
         break;
@@ -69,7 +74,7 @@ export async function addExtensionDarwin(
     }
     script +=
       '\nadd_extension ' +
-      ext_name +
+      extension +
       ' "' +
       install_command +
       '" ' +
@@ -167,7 +172,8 @@ export async function addExtensionLinux(
         return;
       // match exact versions
       case /.*-\d+\.\d+\.\d+.*/.test(version_extension):
-        script += '\nadd_pecl_extension ' + ext_name + ' ' + ext_version;
+        script +=
+          '\nadd_pecl_extension ' + ext_name + ' ' + ext_version + ' ' + prefix;
         return;
       // match 5.6gearman..7.4gearman
       case /^((5\.6)|(7\.[0-4]))gearman$/.test(version_extension):

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -69,7 +69,7 @@ export async function addExtensionDarwin(
     }
     script +=
       '\nadd_extension ' +
-      extension +
+      ext_name +
       ' "' +
       install_command +
       '" ' +

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -158,29 +158,6 @@ add_pecl() {
   add_log "$tick" "PECL" "Added"
 }
 
-# Function to get api version for PHP 5.3, 5.4 and 5.5
-get_old_apiv() {
-  case $version in
-    5.3) echo "20090626" ;;
-    5.4) echo "20100525" ;;
-    5.5) echo "20121212" ;;
-  esac
-}
-
-# Function to setup PHP 5.3, 5.4 and 5.5
-setup_php_old() {
-  ext_dir_parent="$php5"/lib/php/extensions
-  ext_dir_name=no-debug-non-zts-$(get_old_apiv)
-  ext_dir="$ext_dir_parent/$ext_dir_name"
-  sudo mv "$ext_dir" /tmp >/dev/null 2>&1 && sudo rm -rf "$php5"
-  sudo curl -s https://php-osx.liip.ch/install.sh | bash -s "$version" >/dev/null 2>&1
-  sudo rsync -a /tmp/"$ext_dir_name"/ "$ext_dir" >/dev/null 2>&1
-  sudo rm -rf "$php5"/php.d/*developer.ini "$php5"/php.d/*xdebug.ini /tmp/"$ext_dir_name"
-  for tool in pear peardev pecl php php-config phpize; do
-    sudo ln -sf "$php5"/bin/"$tool" /usr/local/bin/"$tool"
-  done
-}
-
 # Function to setup PHP >=5.6
 setup_php() {
   action=$1
@@ -195,7 +172,6 @@ tick="✓"
 cross="✗"
 version=$1
 old_versions="5.[3-5]"
-php5="/usr/local/php5"
 tool_path_dir="/usr/local/bin"
 existing_version=$(php-config --version | cut -c 1-3)
 [[ -z "${update}" ]] && update='false' || update="${update}"
@@ -203,7 +179,8 @@ existing_version=$(php-config --version | cut -c 1-3)
 # Setup PHP
 step_log "Setup PHP"
 if [[ "$version" =~ $old_versions ]]; then
-  setup_php_old
+  script="https://github.com/shivammathur/php5-darwin/releases/latest/download/install.sh"
+  curl -sSL "$script" | bash -s "$version" >/dev/null 2>&1 &&
   status="Installed"
 elif [ "$existing_version" != "$version" ]; then
   setup_php "install"

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -109,6 +109,8 @@ add_tool() {
         sudo sed -i '' 's/exit(9)/exit(0)/' "$tool_path"
         tr -d '\r' < "$tool_path" | sudo tee "$tool_path.tmp" >/dev/null 2>&1 && sudo mv "$tool_path.tmp" "$tool_path"
         sudo chmod a+x "$tool_path"
+      elif [ "$tool" = "wp-cli" ]; then
+        sudo cp "$tool_path" /usr/local/bin/wp
       fi
       add_log "$tick" "$tool" "Added"
     else

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -123,7 +123,7 @@ add_tool() {
 }
 
 # Function to add a tool using composer
-add_composer_tool() {
+add_composertool() {
   tool=$1
   release=$2
   prefix=$3
@@ -132,6 +132,16 @@ add_composer_tool() {
     sudo ln -sf "$(composer -q global config home)"/vendor/bin/"$tool" /usr/local/bin/"$tool" &&
     add_log "$tick" "$tool" "Added"
   ) || add_log "$cross" "$tool" "Could not setup $tool"
+}
+
+add_blackfire() {
+  sudo mkdir -p usr/local/var/run
+  brew tap blackfireio/homebrew-blackfire >/dev/null 2>&1
+  brew install blackfire-agent >/dev/null 2>&1
+  sudo blackfire-agent --register --server-id="$BLACKFIRE_SERVER_ID" --server-token="$BLACKFIRE_SERVER_TOKEN" >/dev/null 2>&1
+  brew services start blackfire-agent >/dev/null 2>&1
+  sudo blackfire --config --client-id="$BLACKFIRE_CLIENT_ID" --client-token="$BLACKFIRE_CLIENT_TOKEN" >/dev/null 2>&1
+
 }
 
 # Function to configure PECL

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -33,14 +33,8 @@ add_extension() {
   elif php -m | grep -i -q -w "$extension"; then
     add_log "$tick" "$extension" "Enabled"
   elif ! php -m | grep -i -q -w "$extension"; then
-    if [[ "$version" =~ $old_versions ]]; then
-      (sudo port install php"$nodot_version"-"$extension" >/dev/null 2>&1 && add_log "$tick" "$extension" "Installed and enabled") ||
-      (eval "$install_command" >/dev/null 2>&1 && echo "$prefix=$ext_dir/$extension.so" >>"$ini_file" && add_log "$tick" "$extension" "Installed and enabled") ||
-      add_log "$cross" "$extension" "Could not install $extension on PHP $semver"
-    else
-      (eval "$install_command" >/dev/null 2>&1 && add_log "$tick" "$extension" "Installed and enabled") ||
-      add_log "$cross" "$extension" "Could not install $extension on PHP $semver"
-    fi
+    (eval "$install_command" >/dev/null 2>&1 && test -f "$ext_dir/$extension.so" && add_log "$tick" "$extension" "Installed and enabled") ||
+    add_log "$cross" "$extension" "Could not install $extension on PHP $semver"
   fi
 }
 
@@ -88,35 +82,31 @@ add_unstable_extension() {
 add_tool() {
   url=$1
   tool=$2
-  if [ "$tool" = "composer" ]; then
-    brew install composer >/dev/null 2>&1
-    composer -q global config process-timeout 0
+  tool_path_dir=/usr/local/bin
+  tool_path="$tool_path_dir/$tool"
+  if [ ! -e "$tool_path" ]; then
+    rm -rf "$tool_path"
+  fi
+
+  status_code=$(sudo curl -s -w "%{http_code}" -o "$tool_path" -L "$url")
+  if [ "$status_code" = "200" ]; then
+    sudo chmod a+x "$tool_path"
+    if [ "$tool" = "composer" ]; then
+      composer -q global config process-timeout 0
+    elif [ "$tool" = "phive" ]; then
+      add_extension curl "sudo pecl install -f curl" extension >/dev/null 2>&1
+      add_extension mbstring "sudo pecl install -f mbstring" extension >/dev/null 2>&1
+      add_extension xml "sudo pecl install -f xml" extension >/dev/null 2>&1
+    elif [ "$tool" = "cs2pr" ]; then
+      sudo sed -i '' 's/exit(9)/exit(0)/' "$tool_path"
+      tr -d '\r' <"$tool_path" | sudo tee "$tool_path.tmp" >/dev/null 2>&1 && sudo mv "$tool_path.tmp" "$tool_path"
+      sudo chmod a+x "$tool_path"
+    elif [ "$tool" = "wp-cli" ]; then
+      sudo cp -p "$tool_path" "$tool_path_dir"/wp
+    fi
     add_log "$tick" "$tool" "Added"
   else
-    tool_path_dir=/usr/local/bin
-    tool_path="$tool_path_dir/$tool"
-    if [ ! -e "$tool_path" ]; then
-      rm -rf "$tool_path"
-    fi
-
-    status_code=$(sudo curl -s -w "%{http_code}" -o "$tool_path" -L "$url")
-    if [ "$status_code" = "200" ]; then
-      sudo chmod a+x "$tool_path"
-      if [ "$tool" = "phive" ]; then
-        add_extension curl "sudo pecl install -f curl" extension >/dev/null 2>&1
-        add_extension mbstring "sudo pecl install -f mbstring" extension >/dev/null 2>&1
-        add_extension xml "sudo pecl install -f xml" extension >/dev/null 2>&1
-      elif [ "$tool" = "cs2pr" ]; then
-        sudo sed -i '' 's/exit(9)/exit(0)/' "$tool_path"
-        tr -d '\r' < "$tool_path" | sudo tee "$tool_path.tmp" >/dev/null 2>&1 && sudo mv "$tool_path.tmp" "$tool_path"
-        sudo chmod a+x "$tool_path"
-      elif [ "$tool" = "wp-cli" ]; then
-        sudo cp -p "$tool_path" "$tool_path_dir"/wp
-      fi
-      add_log "$tick" "$tool" "Added"
-    else
-      add_log "$cross" "$tool" "Could not setup $tool"
-    fi
+    add_log "$cross" "$tool" "Could not setup $tool"
   fi
 }
 
@@ -127,20 +117,18 @@ add_composer_tool() {
   prefix=$3
   (
     composer global require "$prefix$release" >/dev/null 2>&1 &&
-    sudo ln -sf "$(composer -q global config home)"/vendor/bin/"$tool" /usr/local/bin/"$tool" &&
-    add_log "$tick" "$tool" "Added"
+      sudo ln -sf "$(composer -q global config home)"/vendor/bin/"$tool" /usr/local/bin/"$tool" &&
+      add_log "$tick" "$tool" "Added"
   ) || add_log "$cross" "$tool" "Could not setup $tool"
 }
 
 # Function to configure PECL
 configure_pecl() {
-  if [[ ! "$version" =~ $old_versions ]]; then
-    for tool in pear pecl; do
-      sudo "$tool" config-set php_ini "$ini_file" >/dev/null 2>&1
-      sudo "$tool" config-set auto_discover 1 >/dev/null 2>&1
-      sudo "$tool" channel-update "$tool".php.net >/dev/null 2>&1
-    done
-  fi
+  for tool in pear pecl; do
+    sudo "$tool" config-set php_ini "$ini_file" >/dev/null 2>&1
+    sudo "$tool" config-set auto_discover 1 >/dev/null 2>&1
+    sudo "$tool" channel-update "$tool".php.net >/dev/null 2>&1
+  done
 }
 
 # Function to log PECL, it is installed along with PHP
@@ -148,44 +136,33 @@ add_pecl() {
   add_log "$tick" "PECL" "Added"
 }
 
-# Function to add PECL when macports is used
-add_pecl_old() {
-  pecl_version='master'
-  if [ "$1" = "53" ]; then
-    pecl_version='v1.9.5'
-  fi
-  curl -o pear.phar -sSL https://github.com/pear/pearweb_phars/raw/$pecl_version/install-pear-nozlib.phar
-  sudo php pear.phar -d /opt/local/lib/php$1 -b /usr/local/bin && rm -rf pear.phar
+# Function to get api version for PHP 5.3, 5.4 and 5.5
+get_old_apiv() {
+  case $version in
+    5.3) echo "20090626" ;;
+    5.4) echo "20100525" ;;
+    5.5) echo "20121212" ;;
+  esac
 }
 
-add_macports() {
-  uri=$(curl -sSL https://github.com/macports/macports-base/releases | grep -Eo "(\/.*Catalina.pkg)" | head -n 1)
-  curl -o port.pkg -sSL https://github.com"$uri"
-  sudo installer -pkg port.pkg -target / && rm -rf port.pkg
-}
-
-sync_macports() {
-  while true; do
-    status=0
-    sudo port sync || status=$?
-    if [[ "$status" -eq 0 ]]; then
-      break
-    fi
-    sleep 2
+# Function to setup PHP 5.3, 5.4 and 5.5
+setup_php_old() {
+  php5=/usr/local/php5
+  ext_dir_parent="$php5"/lib/php/extensions
+  ext_dir_name=no-debug-non-zts-$(get_old_apiv)
+  ext_dir="$ext_dir_parent/$ext_dir_name"
+  sudo mv "$ext_dir" /tmp >/dev/null 2>&1 && sudo rm -rf "$php5"
+  sudo curl -s https://php-osx.liip.ch/install.sh | bash -s "$version" >/dev/null 2>&1
+  sudo rsync -a /tmp/"$ext_dir_name"/ "$ext_dir" >/dev/null 2>&1
+  sudo rm -rf "$php5"/php.d/*developer.ini "$php5"/php.d/*xdebug.ini /tmp/ext
+  for tool in pear peardev pecl php php-config phpize; do
+    sudo ln -sf "$php5"/bin/"$tool" /usr/local/bin/"$tool"
   done
 }
 
-port_setup_php() {
-  sudo port install php$1 php$1-curl php$1-mbstring php$1-xmlrpc php$1-openssl php$1-opcache
-  sudo cp /opt/local/etc/php$1/php.ini-development /opt/local/etc/php$1/php.ini
-  sudo port select --set php php$1
-  sudo ln -sf /opt/local/bin/* /usr/local/bin
-  add_pecl_old "$1"
-}
-
+# Function to setup PHP >=5.6
 setup_php() {
   action=$1
-  step_log "Setup PHP"
   export HOMEBREW_NO_INSTALL_CLEANUP=TRUE >/dev/null 2>&1
   brew tap shivammathur/homebrew-php >/dev/null 2>&1
   brew "$action" shivammathur/php/php@"$version" >/dev/null 2>&1
@@ -196,22 +173,14 @@ setup_php() {
 tick="✓"
 cross="✗"
 version=$1
-nodot_version=${1/./}
 old_versions="5.[3-5]"
 existing_version=$(php-config --version | cut -c 1-3)
 [[ -z "${update}" ]] && update='false' || update="${update}"
 
 # Setup PHP
+step_log "Setup PHP"
 if [[ "$version" =~ $old_versions ]]; then
-  export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
-  export TERM=xterm
-  step_log "Setup Macports"
-  add_macports >/dev/null 2>&1
-  add_log "$tick" "Macports" "Installed"
-  sync_macports >/dev/null 2>&1
-  add_log "$tick" "Macports" "Synced"
-  step_log "Setup PHP"
-  port_setup_php $nodot_version >/dev/null 2>&1
+  setup_php_old
   status="Installed"
 elif [ "$existing_version" != "$version" ]; then
   setup_php "install"
@@ -220,13 +189,13 @@ elif [ "$existing_version" = "$version" ] && [ "$update" = "true" ]; then
   setup_php "upgrade"
   status="Updated to"
 else
-  step_log "Setup PHP"
   status="Found"
 fi
 ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
 sudo chmod 777 "$ini_file"
 echo "date.timezone=UTC" >>"$ini_file"
-ext_dir=$(php -i | grep -Ei "extension_dir => /(usr|opt)" | sed -e "s|.*=> s*||")
+echo "detect_unicode=Off" >>"$ini_file"
+ext_dir=$(php -i | grep -Ei "extension_dir => /usr" | sed -e "s|.*=> s*||")
 sudo mkdir -p "$ext_dir"
 semver=$(php -v | head -n 1 | cut -f 2 -d ' ')
 configure_pecl

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -95,7 +95,6 @@ add_unstable_extension() {
 add_tool() {
   url=$1
   tool=$2
-  tool_path_dir=/usr/local/bin
   tool_path="$tool_path_dir/$tool"
   if [ ! -e "$tool_path" ]; then
     rm -rf "$tool_path"
@@ -186,7 +185,8 @@ tick="✓"
 cross="✗"
 version=$1
 old_versions="5.[3-5]"
-php5=/usr/local/php5
+php5="/usr/local/php5"
+tool_path_dir="/usr/local/bin"
 existing_version=$(php-config --version | cut -c 1-3)
 [[ -z "${update}" ]] && update='false' || update="${update}"
 
@@ -205,7 +205,7 @@ else
   status="Found"
 fi
 ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
-sudo chmod 777 "$ini_file"
+sudo chmod 777 "$ini_file" "$tool_path_dir"
 echo "date.timezone=UTC" >>"$ini_file"
 echo "detect_unicode=Off" >>"$ini_file"
 ext_dir=$(php -i | grep -Ei "extension_dir => /usr" | sed -e "s|.*=> s*||")

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -93,7 +93,8 @@ add_tool() {
     composer -q global config process-timeout 0
     add_log "$tick" "$tool" "Added"
   else
-    tool_path=/usr/local/bin/"$tool"
+    tool_path_dir=/usr/local/bin
+    tool_path="$tool_path_dir/$tool"
     if [ ! -e "$tool_path" ]; then
       rm -rf "$tool_path"
     fi
@@ -110,7 +111,7 @@ add_tool() {
         tr -d '\r' < "$tool_path" | sudo tee "$tool_path.tmp" >/dev/null 2>&1 && sudo mv "$tool_path.tmp" "$tool_path"
         sudo chmod a+x "$tool_path"
       elif [ "$tool" = "wp-cli" ]; then
-        sudo cp "$tool_path" /usr/local/bin/wp
+        sudo cp -p "$tool_path" "$tool_path_dir"/wp
       fi
       add_log "$tick" "$tool" "Added"
     else

--- a/src/scripts/ext/blackfire.ps1
+++ b/src/scripts/ext/blackfire.ps1
@@ -2,26 +2,29 @@ Param (
     [Parameter(Position = 0, Mandatory = $true)]
     [ValidateNotNull()]
     [string]
-    $phpversion,
-    [Parameter(Position = 1, Mandatory = $true)]
+    $version,
+    [Parameter(Position = 2, Mandatory = $false)]
     [ValidateNotNull()]
-    [ValidateLength(1, [int]::MaxValue)]
     [string]
-    $version = '1.31.0'
+    $extension_version
 )
-
-Function Install-Blackfire() {
-    $installed = Get-Php -Path $php_dir
-    $nts = if (!$installed.ThreadSafe) { "_nts" } else { "" }
-    Invoke-WebRequest -UseBasicParsing -Uri "https://packages.blackfire.io/binaries/blackfire-php/${version}/blackfire-php-windows_x64-php-${phpversion}${nts}.dll" -OutFile $ENV:RUNNER_TOOL_CACHE\blackfire.dll > $null 2>&1
-    Copy-Item -Path "$ENV:RUNNER_TOOL_CACHE\blackfire.dll" -Destination "$ext_dir\blackfire.dll"
-    Enable-PhpExtension -Extension blackfire -Path $php_dir
-    printf "\033[%s;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s \033[0m\n" "32" $tick "Blackfire" "Installed and enabled"
-}
 
 $tick = ([char]8730)
 $php_dir = 'C:\tools\php'
 $ext_dir = $php_dir + '\ext'
+$arch='x64'
+if ($version -lt '7.0') { $arch='x86' }
+$version = $version.replace('.', '')
 
-Install-Blackfire
+if (Test-Path $ext_dir\blackfire.dll) {
+    Enable-PhpExtension -Extension blackfire -Path $php_dir
+    $status="Enabled"
+} else {
+    $installed = Get-Php -Path $php_dir
+    $nts = if (!$installed.ThreadSafe) { "_nts" } else { "" }
+    Invoke-WebRequest -UseBasicParsing -Uri "https://packages.blackfire.io/binaries/blackfire-php/${extension_version}/blackfire-php-windows_${arch}-php-${version}${nts}.dll" -OutFile $ext_dir\blackfire.dll > $null 2>&1
+    Enable-PhpExtension -Extension blackfire -Path $php_dir
+    $status="Installed and enabled"
+}
+printf "\033[%s;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s \033[0m\n" "32" $tick "blackfire" "$status"
 

--- a/src/scripts/ext/blackfire.ps1
+++ b/src/scripts/ext/blackfire.ps1
@@ -1,0 +1,27 @@
+Param (
+    [Parameter(Position = 0, Mandatory = $true)]
+    [ValidateNotNull()]
+    [string]
+    $phpversion,
+    [Parameter(Position = 1, Mandatory = $true)]
+    [ValidateNotNull()]
+    [ValidateLength(1, [int]::MaxValue)]
+    [string]
+    $version = '1.31.0'
+)
+
+Function Install-Blackfire() {
+    $installed = Get-Php -Path $php_dir
+    $nts = if (!$installed.ThreadSafe) { "_nts" } else { "" }
+    Invoke-WebRequest -UseBasicParsing -Uri "https://packages.blackfire.io/binaries/blackfire-php/${version}/blackfire-php-windows_x64-php-${phpversion}${nts}.dll" -OutFile $ENV:RUNNER_TOOL_CACHE\blackfire.dll > $null 2>&1
+    Copy-Item -Path "$ENV:RUNNER_TOOL_CACHE\blackfire.dll" -Destination "$ext_dir\blackfire.dll"
+    Enable-PhpExtension -Extension blackfire -Path $php_dir
+    printf "\033[%s;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s \033[0m\n" "32" $tick "Blackfire" "Installed and enabled"
+}
+
+$tick = ([char]8730)
+$php_dir = 'C:\tools\php'
+$ext_dir = $php_dir + '\ext'
+
+Install-Blackfire
+

--- a/src/scripts/ext/blackfire.sh
+++ b/src/scripts/ext/blackfire.sh
@@ -1,23 +1,7 @@
-add_log() {
-  mark=$1
-  subject=$2
-  message=$3
-  if [ "$mark" = "$tick" ]; then
-    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
-  else
-    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
-  fi
-}
-
-phpversion=$2
-blackfireVersion=${3:-1.31.0}
-ini_file="/etc/php/$1/cli/conf.d/50-blackfire.ini"
-tick="✓"
-cross="✗"
-
-(curl -A "Github action" -o /tmp/blackfire.so -L -s https://packages.blackfire.io/binaries/blackfire-php/$blackfireVersion/blackfire-php-linux_amd64-php-$phpversion.so >/dev/null 2>&1 && \
-sudo mv /tmp/blackfire.so $(php -r "echo ini_get ('extension_dir');")/blackfire.so >/dev/null 2>&1 && \
-echo "extension=blackfire.so" | sudo tee -a "$ini_file" >/dev/null 2>&1 && \
-add_log "$tick" "blackfire" "Installed and enabled") || \
-add_log "$cross" "blackfire" "Could not install blackfire"
-
+version=${1/./}
+extension_version=$2
+ext_dir=$(php -i | grep "extension_dir => /" | sed -e "s|.*=> s*||")
+scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
+ini_file="$scan_dir/50-blackfire.ini"
+sudo curl -o $ext_dir/blackfire.so -SL https://packages.blackfire.io/binaries/blackfire-php/$extension_version/blackfire-php-linux_amd64-php-$version.so
+echo "extension=blackfire.so" | sudo tee -a "$ini_file"

--- a/src/scripts/ext/blackfire.sh
+++ b/src/scripts/ext/blackfire.sh
@@ -1,0 +1,23 @@
+add_log() {
+  mark=$1
+  subject=$2
+  message=$3
+  if [ "$mark" = "$tick" ]; then
+    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  else
+    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  fi
+}
+
+phpversion=$2
+blackfireVersion=${3:-1.31.0}
+ini_file="/etc/php/$1/cli/conf.d/50-blackfire.ini"
+tick="✓"
+cross="✗"
+
+(curl -A "Github action" -o /tmp/blackfire.so -L -s https://packages.blackfire.io/binaries/blackfire-php/$blackfireVersion/blackfire-php-linux_amd64-php-$phpversion.so >/dev/null 2>&1 && \
+sudo mv /tmp/blackfire.so $(php -r "echo ini_get ('extension_dir');")/blackfire.so >/dev/null 2>&1 && \
+echo "extension=blackfire.so" | sudo tee -a "$ini_file" >/dev/null 2>&1 && \
+add_log "$tick" "blackfire" "Installed and enabled") || \
+add_log "$cross" "blackfire" "Could not install blackfire"
+

--- a/src/scripts/ext/blackfire_darwin.sh
+++ b/src/scripts/ext/blackfire_darwin.sh
@@ -1,0 +1,23 @@
+# Function to log result of a operation
+add_log() {
+  mark=$1
+  subject=$2
+  message=$3
+  if [ "$mark" = "$tick" ]; then
+    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  else
+    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  fi
+}
+
+tick="✓"
+cross="✗"
+phpversion=$2
+blackfireVersion=${3:-1.31.0}
+ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+
+(curl -A "Github action" -o /tmp/blackfire.so -L -s https://packages.blackfire.io/binaries/blackfire-php/$blackfireVersion/blackfire-php-darwin_amd64-php-$phpversion.so && \
+sudo mv /tmp/blackfire.so $(php -r "echo ini_get ('extension_dir');")/blackfire.so && \
+echo "extension=blackfire.so" >>"$ini_file" && \
+add_log "$tick" "blackfire" "Installed and enabled") || \
+add_log "$cross" "blackfire" "Could not install blackfire"

--- a/src/scripts/ext/blackfire_darwin.sh
+++ b/src/scripts/ext/blackfire_darwin.sh
@@ -1,23 +1,7 @@
-# Function to log result of a operation
-add_log() {
-  mark=$1
-  subject=$2
-  message=$3
-  if [ "$mark" = "$tick" ]; then
-    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
-  else
-    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
-  fi
-}
-
-tick="✓"
-cross="✗"
-phpversion=$2
-blackfireVersion=${3:-1.31.0}
-ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
-
-(curl -A "Github action" -o /tmp/blackfire.so -L -s https://packages.blackfire.io/binaries/blackfire-php/$blackfireVersion/blackfire-php-darwin_amd64-php-$phpversion.so && \
-sudo mv /tmp/blackfire.so $(php -r "echo ini_get ('extension_dir');")/blackfire.so && \
-echo "extension=blackfire.so" >>"$ini_file" && \
-add_log "$tick" "blackfire" "Installed and enabled") || \
-add_log "$cross" "blackfire" "Could not install blackfire"
+version=${1/./}
+extension_version=$2
+ext_dir=$(php -i | grep -Ei "extension_dir => /usr" | sed -e "s|.*=> s*||")
+scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
+ini_file="$scan_dir/50-blackfire.ini"
+sudo curl -o $ext_dir/blackfire.so -SL https://packages.blackfire.io/binaries/blackfire-php/$extension_version/blackfire-php-darwin_amd64-php-$version.so
+echo "extension=blackfire.so" | sudo tee -a "$ini_file"

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -173,7 +173,7 @@ add_tool() {
 }
 
 # Function to setup a tool using composer
-add_composer_tool() {
+add_composertool() {
   tool=$1
   release=$2
   prefix=$3
@@ -192,6 +192,18 @@ add_devtools() {
   sudo update-alternatives --set php-config /usr/bin/php-config"$version" >/dev/null 2>&1
   sudo update-alternatives --set phpize /usr/bin/phpize"$version" >/dev/null 2>&1
   configure_pecl
+}
+
+add_blackfire() {
+  sudo mkdir -p /var/run/blackfire
+  sudo curl -o /tmp/blackfire-gpg.key -sSL https://packages.blackfire.io/gpg.key >/dev/null 2>&1
+  sudo apt-key add /tmp/blackfire-gpg.key >/dev/null 2>&1
+  echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list >/dev/null 2>&1
+  find /etc/apt/sources.list.d -type f -name blackfire.list -exec sudo "$debconf_fix" apt-fast update -o Dir::Etc::sourcelist="{}" ';' >/dev/null 2>&1
+  $apt_install blackfire-agent >/dev/null 2>&1
+  sudo blackfire-agent --register --server-id="$BLACKFIRE_SERVER_ID" --server-token="$BLACKFIRE_SERVER_TOKEN" >/dev/null 2>&1
+  sudo /etc/init.d/blackfire-agent restart >/dev/null 2>&1
+  sudo blackfire --config --client-id="$BLACKFIRE_CLIENT_ID" --client-token="$BLACKFIRE_CLIENT_TOKEN" >/dev/null 2>&1
 }
 
 # Function to setup the nightly build from master branch

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -202,7 +202,7 @@ setup_master() {
   tar_file=php_"$version"%2Bubuntu"$(lsb_release -r -s)".tar.xz
   install_dir=~/php/"$version"
   sudo mkdir -m 777 -p ~/php
-  update_ppa && $apt_install libicu64 libicu-dev >/dev/null 2>&1
+  update_ppa && $apt_install libicu-dev >/dev/null 2>&1
   curl -SLO https://dl.bintray.com/shivammathur/php/"$tar_file" >/dev/null 2>&1
   sudo tar xf "$tar_file" -C ~/php >/dev/null 2>&1
   rm -rf "$tar_file"

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -148,7 +148,6 @@ update_extension() {
 add_tool() {
   url=$1
   tool=$2
-  tool_path_dir=/usr/local/bin
   tool_path="$tool_path_dir/$tool"
   if [ ! -e "$tool_path" ]; then
     rm -rf "$tool_path"
@@ -274,6 +273,7 @@ version=$1
 old_versions="5.[4-5]"
 debconf_fix="DEBIAN_FRONTEND=noninteractive"
 apt_install="sudo $debconf_fix apt-fast install -y"
+tool_path_dir="/usr/local/bin"
 existing_version=$(php-config --version | cut -c 1-3)
 [[ -z "${update}" ]] && update='false' || update="${update}"
 
@@ -317,5 +317,5 @@ semver=$(php_semver)
 ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
 ext_dir=$(php -i | grep "extension_dir => /" | sed -e "s|.*=> s*||")
 scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
-sudo chmod 777 "$ini_file"
+sudo chmod 777 "$ini_file" "$tool_path_dir"
 add_log "$tick" "PHP" "$status PHP $semver"

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -150,7 +150,8 @@ update_extension() {
 add_tool() {
   url=$1
   tool=$2
-  tool_path=/usr/local/bin/"$tool"
+  tool_path_dir=/usr/local/bin
+  tool_path="$tool_path_dir/$tool"
   if [ ! -e "$tool_path" ]; then
     rm -rf "$tool_path"
   fi
@@ -166,7 +167,7 @@ add_tool() {
       add_extension mbstring "$apt_install php$version-mbstring" extension >/dev/null 2>&1
       add_extension xml "$apt_install php$version-xml" extension >/dev/null 2>&1
     elif [ "$tool" = "wp-cli" ]; then
-      sudo cp "$tool_path" /usr/local/bin/wp
+      sudo cp -p "$tool_path" "$tool_path_dir"/wp
     fi
     add_log "$tick" "$tool" "Added"
   else

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -86,8 +86,6 @@ add_extension() {
     install_command="update_ppa && ${install_command/5\.[4-5]-$extension/5-$extension=$release_version}"
   fi
   if ! check_extension "$extension" && [ -e "$ext_dir/$extension.so" ]; then
-    # shellcheck disable=SC2046
-    $apt_install $(apt-cache depends php"$version"-"$extension" 2>/dev/null | awk '/Depends:/{print$2}') >/dev/null 2>&1
     echo "$prefix=$extension.so" >>"$ini_file" && add_log "$tick" "$extension" "Enabled"
   elif check_extension "$extension"; then
     add_log "$tick" "$extension" "Enabled"

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -165,6 +165,8 @@ add_tool() {
       add_extension curl "$apt_install php$version-curl" extension >/dev/null 2>&1
       add_extension mbstring "$apt_install php$version-mbstring" extension >/dev/null 2>&1
       add_extension xml "$apt_install php$version-xml" extension >/dev/null 2>&1
+    elif [ "$tool" = "wp-cli" ]; then
+      sudo cp "$tool_path" /usr/local/bin/wp
     fi
     add_log "$tick" "$tool" "Added"
   else

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -103,7 +103,7 @@ Function Add-Tool() {
   }
   if ($tool -eq "symfony") {
     Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $php_dir\$tool.exe
-    Add-Content -Path $PsHome\profile.ps1 -Value "New-Alias $tool $php_dir\$tool.exe" > $null 2>&1
+    Add-Content -Path $PsHome\profile.ps1 -Value "New-Alias $tool $php_dir\$tool.exe" >$null 2>&1
   } else {
     try {
       Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $php_dir\$tool
@@ -113,7 +113,7 @@ Function Add-Tool() {
       $bat_content += "SET BIN_TARGET=%~dp0/" + $tool
       $bat_content += "php %BIN_TARGET% %*"
       Set-Content -Path $php_dir\$tool.bat -Value $bat_content
-      Add-Content -Path $PsHome\profile.ps1 -Value "New-Alias $tool $php_dir\$tool.bat" > $null 2>&1
+      Add-Content -Path $PsHome\profile.ps1 -Value "New-Alias $tool $php_dir\$tool.bat" >$null 2>&1
     } catch { }
   }
   if($tool -eq "phive") {
@@ -134,7 +134,7 @@ Function Add-Tool() {
   }
 }
 
-Function Add-Composer-Tool() {
+Function Add-Composertool() {
   Param (
     [Parameter(Position = 0, Mandatory = $true)]
     [ValidateNotNull()]
@@ -162,8 +162,29 @@ Function Add-Composer-Tool() {
   }
 }
 
-Function Add-PECL() {
+Function Add-Pecl() {
   Add-Log $tick "PECL" "Use extensions input to setup PECL extensions on windows"
+}
+
+Function Add-Blackfire() {
+  Param (
+    [Parameter(Position = 0, Mandatory = $true)]
+    [ValidateNotNull()]
+    [ValidateLength(1, [int]::MaxValue)]
+    [string]
+    $agent_version
+  )
+  $url = "https://packages.blackfire.io/binaries/blackfire-agent/${agent_version}/blackfire-agent-windows_${arch_name}.zip"
+  Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $php_dir\blackfire.zip >$null 2>&1
+  7z e $php_dir\blackfire.zip -o"$php_dir" -y >$null 2>&1
+  Add-Content -Path $PsHome\profile.ps1 -Value "New-Alias blackfire $php_dir\blackfire.exe"
+  Add-Content -Path $PsHome\profile.ps1 -Value "New-Alias blackfire-agent $php_dir\blackfire-agent.exe"
+  if ((Test-Path env:BLACKFIRE_SERVER_ID) -and (Test-Path env:BLACKFIRE_SERVER_TOKEN)) {
+    blackfire-agent --register --server-id=$env:BLACKFIRE_SERVER_ID --server-token=$env:BLACKFIRE_SERVER_TOKEN >$null 2>&1
+  }
+  if ((Test-Path env:BLACKFIRE_CLIENT_ID) -and (Test-Path env:BLACKFIRE_CLIENT_TOKEN)) {
+    blackfire --config --client-id=$env:BLACKFIRE_CLIENT_ID --client-token=$env:BLACKFIRE_CLIENT_TOKEN --ca-cert=$php_dir\ssl\cacert.pem >$null 2>&1
+  }
 }
 
 # Variables
@@ -174,6 +195,7 @@ $ext_dir = $php_dir + '\ext'
 $ProgressPreference = 'SilentlyContinue'
 $master_version = '8.0'
 $arch = 'x64'
+$arch_name='amd64'
 $ts = $false
 if((Test-Path env:PHPTS) -and $env:PHPTS -eq 'ts') {
   $ts = $true
@@ -197,6 +219,7 @@ if ($null -eq $installed -or -not("$($installed.Version).".StartsWith(($version 
   if ($version -lt '7.0') {
     Install-Module -Name VcRedist -Force
     $arch='x86'
+    $arch_name='386'
   }
   if ($version -eq $master_version) {
     $version = 'master'
@@ -205,7 +228,7 @@ if ($null -eq $installed -or -not("$($installed.Version).".StartsWith(($version 
   Install-Php -Version $version -Architecture $arch -ThreadSafe $ts -InstallVC -Path $php_dir -TimeZone UTC -InitialPhpIni Production -Force >$null 2>&1
 } else {
   if((Test-Path env:update) -and $env:update -eq 'true') {
-    Update-Php $php_dir > $null 2>&1
+    Update-Php $php_dir >$null 2>&1
     $status = "Updated to"
   } else {
     $status = "Found"

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -124,6 +124,8 @@ Function Add-Tool() {
     (Get-Content $php_dir/cs2pr).replace('exit(9)', 'exit(0)') | Set-Content $php_dir/cs2pr
   } elseif($tool -eq "composer") {
     composer -q global config process-timeout 0
+  } elseif($tool -eq "wp-cli") {
+    Copy-Item $php_dir\wp-cli.bat -Destination $php_dir\wp.bat
   }
   if (((Get-ChildItem -Path $php_dir/* | Where-Object Name -Match "^$tool(.exe|.phar)*$").Count -gt 0)) {
     Add-Log $tick $tool "Added"

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -498,8 +498,10 @@ export async function addTools(
         script += await addArchive(tool, version, url, os_version);
         break;
       case 'composer':
-        url =
-          github + 'composer/composer/releases/latest/download/composer.phar';
+        // If RC is released as latest release, switch to getcomposer.
+        // Prefered source is GitHub as it is faster.
+        // url = github + 'composer/composer/releases/latest/download/composer.phar';
+        url = 'https://getcomposer.org/composer-stable.phar';
         script += await addArchive(tool, version, url, os_version);
         break;
       case 'codeception':

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -316,14 +316,15 @@ export async function getSymfonyUri(
 export async function getWpCliUrl(version: string): Promise<string> {
   switch (version) {
     case 'latest':
-      return 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
+      return 'wp-cli/builds/blob/gh-pages/phar/wp-cli.phar?raw=true';
     default:
-      return (
-        'https://github.com/wp-cli/wp-cli/releases/download/v' +
-        version +
-        '/wp-cli-' +
-        version +
-        '.phar'
+      return await getUri(
+        'wp-cli',
+        '-' + version + '.phar',
+        version,
+        'wp-cli/wp-cli/releases',
+        'v',
+        'download'
       );
   }
 }
@@ -544,7 +545,7 @@ export async function addTools(
         script += await addArchive('symfony', version, url, os_version);
         break;
       case 'wp-cli':
-        url = await getWpCliUrl(version);
+        url = github + (await getWpCliUrl(version));
         script += await addArchive(tool, version, url, os_version);
         break;
       default:

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -309,6 +309,26 @@ export async function getSymfonyUri(
 }
 
 /**
+ * Function to get the WP-CLI url
+ *
+ * @param version
+ */
+export async function getWpCliUrl(version: string): Promise<string> {
+  switch (version) {
+    case 'latest':
+      return 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
+    default:
+      return (
+        'https://github.com/wp-cli/wp-cli/releases/download/v' +
+        version +
+        '/wp-cli-' +
+        version +
+        '.phar'
+      );
+  }
+}
+
+/**
  * Function to add/move composer in the tools list
  *
  * @param tools
@@ -522,6 +542,10 @@ export async function addTools(
         uri = await getSymfonyUri(version, os_version);
         url = github + 'symfony/cli/' + uri;
         script += await addArchive('symfony', version, url, os_version);
+        break;
+      case 'wp-cli':
+        url = await getWpCliUrl(version);
+        script += await addArchive(tool, version, url, os_version);
         break;
       default:
         script += await utils.addLog(

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -517,6 +517,9 @@ export async function addTools(
         url = await getDeployerUrl(version);
         script += await addArchive(tool, version, url, os_version);
         break;
+      case 'flex':
+        script += await addPackage(tool, release, 'symfony/', os_version);
+        break;
       case 'phinx':
         script += await addPackage(tool, release, 'robmorgan/', os_version);
         break;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -323,7 +323,7 @@ export async function getCleanedToolsList(
     .map(function(extension: string) {
       return extension
         .trim()
-        .replace(/robmorgan\/|hirak\/|narrowspark\/automatic-/, '');
+        .replace(/symfony\/|robmorgan\/|hirak\/|narrowspark\/automatic-/, '');
     })
     .filter(Boolean);
   return [...new Set(tools_list)];

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,60 +1,20 @@
 import * as utils from './utils';
 
 /**
- * Function to get command to setup tool
+ * Function to get command to setup tools
  *
  * @param os_version
  */
-export async function getArchiveCommand(os_version: string): Promise<string> {
+export async function getCommand(
+  os_version: string,
+  suffix: string
+): Promise<string> {
   switch (os_version) {
     case 'linux':
     case 'darwin':
-      return 'add_tool ';
+      return 'add_' + suffix + ' ';
     case 'win32':
-      return 'Add-Tool ';
-    default:
-      return await utils.log(
-        'Platform ' + os_version + ' is not supported',
-        os_version,
-        'error'
-      );
-  }
-}
-
-/**
- * Function to get command to setup tools using composer
- *
- * @param os_version
- */
-export async function getPackageCommand(os_version: string): Promise<string> {
-  switch (os_version) {
-    case 'linux':
-    case 'darwin':
-      return 'add_composer_tool ';
-    case 'win32':
-      return 'Add-Composer-Tool ';
-    default:
-      return await utils.log(
-        'Platform ' + os_version + ' is not supported',
-        os_version,
-        'error'
-      );
-  }
-}
-
-/**
- *
- * Function to get command to setup PECL
- *
- * @param os_version
- */
-export async function getPECLCommand(os_version: string): Promise<string> {
-  switch (os_version) {
-    case 'linux':
-    case 'darwin':
-      return 'add_pecl ';
-    case 'win32':
-      return 'Add-PECL ';
+      return 'Add-' + suffix.charAt(0).toUpperCase() + suffix.slice(1) + ' ';
     default:
       return await utils.log(
         'Platform ' + os_version + ' is not supported',
@@ -226,12 +186,12 @@ export async function addPhive(
   switch (version) {
     case 'latest':
       return (
-        (await getArchiveCommand(os_version)) +
+        (await getCommand(os_version, 'tool')) +
         'https://phar.io/releases/phive.phar phive'
       );
     default:
       return (
-        (await getArchiveCommand(os_version)) +
+        (await getCommand(os_version, 'tool')) +
         'https://github.com/phar-io/phive/releases/download/' +
         version +
         '/phive-' +
@@ -242,20 +202,21 @@ export async function addPhive(
 }
 
 /**
- * Function to get the PHPUnit url
+ * Function to get the phar url in domain/tool-version.phar format
  *
  * @param version
  */
-export async function getPhpunitUrl(
+export async function getPharUrl(
+  domain: string,
   tool: string,
+  prefix: string,
   version: string
 ): Promise<string> {
-  const phpunit = 'https://phar.phpunit.de';
   switch (version) {
     case 'latest':
-      return phpunit + '/' + tool + '.phar';
+      return domain + '/' + tool + '.phar';
     default:
-      return phpunit + '/' + tool + '-' + version + '.phar';
+      return domain + '/' + tool + '-' + prefix + version + '.phar';
   }
 }
 
@@ -382,7 +343,7 @@ export async function addArchive(
   url: string,
   os_version: string
 ): Promise<string> {
-  return (await getArchiveCommand(os_version)) + url + ' ' + tool;
+  return (await getCommand(os_version, 'tool')) + url + ' ' + tool;
 }
 
 /**
@@ -434,7 +395,7 @@ export async function addPackage(
   prefix: string,
   os_version: string
 ): Promise<string> {
-  const tool_command = await getPackageCommand(os_version);
+  const tool_command = await getCommand(os_version, 'composertool');
   return tool_command + tool + ' ' + release + ' ' + prefix;
 }
 
@@ -467,6 +428,17 @@ export async function addTools(
     script += '\n';
     let url = '';
     switch (tool) {
+      case 'blackfire':
+      case 'blackfire-agent':
+        script += await getCommand(
+          os_version,
+          'blackfire ' + (await utils.getBlackfireAgentVersion())
+        );
+        break;
+      case 'blackfire-player':
+        url = await getPharUrl('https://get.blackfire.io', tool, 'v', version);
+        script += await addArchive(tool, version, url, os_version);
+        break;
       case 'cs2pr':
         uri = await getUri(tool, '', version, 'releases', '', 'download');
         url = github + 'staabm/annotate-pull-request-from-checkstyle/' + uri;
@@ -512,7 +484,7 @@ export async function addTools(
         break;
       case 'phpcpd':
       case 'phpunit':
-        url = await getPhpunitUrl(tool, version);
+        url = await getPharUrl('https://phar.phpunit.de', tool, '', version);
         script += await addArchive(tool, version, url, os_version);
         break;
       case 'deployer':
@@ -537,7 +509,7 @@ export async function addTools(
         );
         break;
       case 'pecl':
-        script += await getPECLCommand(os_version);
+        script += await getCommand(os_version, 'pecl');
         break;
       case 'php-config':
       case 'phpize':

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -261,3 +261,14 @@ export async function suppressOutput(os_version: string): Promise<string> {
       );
   }
 }
+
+export async function getMinorVersion(version: string): Promise<string> {
+  const regex = /^\d+\.\d+/;
+  const match = version.match(regex);
+
+  if (match === null) {
+    return version;
+  }
+
+  return match[0];
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -279,3 +279,10 @@ export async function getBlackfireVersion(
       return blackfire_version;
   }
 }
+
+/**
+ * Function to get Blackfire Agent version
+ */
+export async function getBlackfireAgentVersion(): Promise<string> {
+  return '1.32.0';
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -262,13 +262,20 @@ export async function suppressOutput(os_version: string): Promise<string> {
   }
 }
 
-export async function getMinorVersion(version: string): Promise<string> {
-  const regex = /^\d+\.\d+/;
-  const match = version.match(regex);
-
-  if (match === null) {
-    return version;
+/**
+ * Function to get Blackfire version
+ *
+ * @param blackfire_version
+ */
+export async function getBlackfireVersion(
+  blackfire_version: null | undefined | string
+): Promise<string> {
+  switch (blackfire_version) {
+    case null:
+    case undefined:
+    case '':
+      return '1.31.0';
+    default:
+      return blackfire_version;
   }
-
-  return match[0];
 }


### PR DESCRIPTION
- Add support for these tools.
  - `blackfire` - client and agent
  - `blackfire-player`
  - `flex` - symfony/flex. Fixes #189 
  - `wp-cli`. Fixes #187 
- Add support for `ext-blackfire`. Fixes #191 
- Fix composer version and permissions. Fixes #192
- Fix to cache versioned extensions correctly.
- Move dependency setup to cache-extensions.
- Fix PHP 8.0 setup after `icu` version is bumped to `65.1`
- Use [`shivammathur/php5-darwin`](https://github.com/shivammathur/php5-darwin) for PHP 5.3, 5.4 and 5.5 on `macOS`.
- Update examples to start `mysql` service.
- Add example for `blackfire` and `blackfire-player`.
- Fix test name in `tools.test.ts`.
- Improve README.
- Update action icon in `action.yml`.
- Bump version to 2.1.0

🎉Thanks! @kidunot89 and @jaapio for the contributions in this release.