### PR TITLE
Fixed Xdebug version for PHP 5.6 and 7.0

### DIFF
--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -5,7 +5,7 @@ describe('Extension tests', () => {
     expect(await extensions.getXdebugVersion('5.3')).toContain('2.2.7');
     expect(await extensions.getXdebugVersion('5.4')).toContain('2.4.1');
     expect(await extensions.getXdebugVersion('5.5')).toContain('2.5.5');
-    expect(await extensions.getXdebugVersion('5.6')).toContain('2.9.6');
+    expect(await extensions.getXdebugVersion('7.2')).toContain('2.9.6');
   });
   it('checking addExtensionOnWindows', async () => {
     let win32: string = await extensions.addExtension(

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -13,7 +13,10 @@ export async function getXdebugVersion(version: string): Promise<string> {
     case '5.4':
       return '2.4.1';
     case '5.5':
+    case '5.6':
       return '2.5.5';
+    case '7.0':
+      return '2.7.2';
     default:
       return '2.9.6';
   }


### PR DESCRIPTION
---
name: 🐞 Bug Fix,
about: The incorrect version of Xdebug is installed on PHP 5.6 and 7.0
labels: bug

---

See https://xdebug.org/docs/compat for the definitive compatibility table.