### PR TITLE
2.5.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,6 @@
 # These are supported funding model platforms
 
+open_collective: setup-php
 tidelift: "npm/setup-php"
 community_bridge: setup-php
 patreon: shivammathur

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -7,7 +7,7 @@ The following versions of this project are supported for security updates.
 | Version | Supported          |
 | ------- | ------------------ |
 | 1.9.x   | :white_check_mark: |
-| 2.4.x   | :white_check_mark: |
+| 2.5.x   | :white_check_mark: |
 
 ## Supported PHP Versions
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@
 <p align="center">
   <a href="https://github.com/shivammathur/setup-php" title="GitHub action to setup PHP"><img alt="GitHub Actions status" src="https://github.com/shivammathur/setup-php/workflows/Main%20workflow/badge.svg"></a>
   <a href="https://codecov.io/gh/shivammathur/setup-php" title="Code coverage"><img alt="Codecov Code Coverage" src="https://codecov.io/gh/shivammathur/setup-php/branch/master/graph/badge.svg"></a>
-  <a href="https://github.com/shivammathur/setup-php/blob/master/LICENSE" title="license"><img alt="LICENSE" src="https://img.shields.io/badge/license-MIT-428f7e.svg"></a>
-  <a href="#tada-php-support" title="PHP Versions Supported"><img alt="PHP Versions Supported" src="https://img.shields.io/badge/php-%3E%3D%205.3-8892BF.svg"></a>
-  <a href="https://twitter.com/setup_php" title="setup-php twitter"><img alt="setup-php twitter" src="https://img.shields.io/badge/twitter-follow-1DA1F2?logo=twitter"></a>
+  <a href="https://github.com/shivammathur/setup-php/blob/master/LICENSE" title="license"><img alt="LICENSE" src="https://img.shields.io/badge/license-MIT-428f7e.svg?logo=open%20source%20initiative&logoColor=white&labelColor=555555"></a>
+  <a href="#tada-php-support" title="PHP Versions Supported"><img alt="PHP Versions Supported" src="https://img.shields.io/badge/php-5.3%20to%208.0-777bb3.svg?logo=php&logoColor=white&labelColor=555555"></a>  
+</p>
+<p align="center">  
+  <a href="https://reddit.com/r/setup_php" title="setup-php reddit"><img alt="setup-php reddit" src="https://img.shields.io/badge/reddit-join-FF5700?logo=reddit&logoColor=FF5700&labelColor=555555"></a>
+  <a href="https://twitter.com/setup_php" title="setup-php twitter"><img alt="setup-php twitter" src="https://img.shields.io/badge/twitter-follow-1DA1F2?logo=twitter&logoColor=1DA1F2&labelColor=555555"></a>
+  <a href="https://setup-php.statuspage.io/" title="setup-php status"><img alt="setup-php status" src="https://img.shields.io/badge/status-subscribe-28A745?logo=statuspage&logoColor=28A745&labelColor=555555"></a>  
 </p>
 
 Setup PHP with required extensions, php.ini configuration, code-coverage support and various tools like composer in [GitHub Actions](https://github.com/features/actions "GitHub Actions"). This action gives you a cross platform interface to setup the PHP environment you need to test your application. Refer to [Usage](#memo-usage "How to use this") section and [examples](#examples "Examples of use") to see how to use this.
@@ -100,11 +104,12 @@ Both `GitHub-hosted` runners and `self-hosted` runners are supported on the foll
 - On `ubuntu` by default extensions which are available as a package can be installed. PECL extensions if not available as a package can be installed by specifying `pecl` in the tools input.
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'
-  tools: pecl
-  extensions: swoole
+- name: Setup PHP with pecl extension
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'
+    tools: pecl
+    extensions: swoole
 ```
 
 - On `windows` PECL extensions which have the `DLL` binary can be installed.
@@ -116,30 +121,43 @@ with:
 - Specific versions of PECL extensions can be installed by suffixing the version. This is useful for installing old versions of extensions which support end of life PHP versions.
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '5.4'
-  tools: pecl
-  extensions: swoole-1.9.3
+- name: Setup PHP with specific version of PECL extension
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '5.4'
+    tools: pecl
+    extensions: swoole-1.9.3
 ```
 
 - Pre-release versions of PECL extensions can be setup by suffixing the extension with its state i.e `alpha`, `beta`, `devel` or `snapshot`.
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'
-  tools: pecl
-  extensions: xdebug-beta
+- name: Setup PHP with pre-release PECL extension
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'
+    tools: pecl
+    extensions: xdebug-beta
 ```
 
 - Shared extensions can be removed by prefixing them with a `:`.
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'  
-  extensions: :opcache
+- name: Setup PHP and remove shared extension
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'  
+    extensions: :opcache
+```
+
+- Extension `intl` can be setup with specific `ICU` version for `PHP 5.6` to `PHP 7.4` in `Ubuntu` workflows by suffixing `intl` with the `ICU` version. `ICU 50.2` and newer versions are supported. Refer to [`ICU builds`](https://github.com/shivammathur/icu-intl#icu4c-builds) for the specific versions supported.
+
+```yaml
+- name: Setup PHP with intl
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'
+    extensions: intl-67.1
 ```
 
 - Extensions which cannot be added or removed gracefully leave an error message in the logs, the action is not interrupted.
@@ -150,36 +168,42 @@ with:
 
 These tools can be setup globally using the `tools` input.
 
-`blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `pecl`, `phan`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `protoc`, `psalm`, `symfony`, `vapor-cli`
+`blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpstan`, `phpunit`, `prestissimo`, `protoc`, `psalm`, `symfony`, `vapor-cli`
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'
-  tools: php-cs-fixer, phpunit
+- name: Setup PHP with tools
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'
+    tools: php-cs-fixer, phpunit
 ```
 
 To setup a particular version of a tool, specify it in the form `tool:version`.  
 Latest stable version of `composer` is setup by default. You can setup the required version by specifying `v1`, `v2`, `snapshot` or `preview` as version.
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'
-  tools: composer:v2
+- name: Setup PHP with composer v2
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'
+    tools: composer:v2
 ```
 
-Version for other tools should be in `semver` format and a valid release of the tool.
+Latest versions of both agent `blackfire-agent` and client `blackfire` are setup when `blackfire` is specified in tools input. Please refer to the [official documentation](https://blackfire.io/docs/integrations/ci/github-actions "Blackfire.io documentation for GitHub Actions") for using `blackfire` with GitHub Actions.
+
+Version for other tools should be in `semver` format and a valid release of the tool.  
+This is useful for installing tools for older versions of PHP.  
+For example to setup `PHPUnit` on `PHP 7.2`.
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'
-  tools: php-cs-fixer:2.16.2, phpunit:8.5.1
+- name: Setup PHP with tools
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.2'
+    tools: phpunit:8.5.8
 ```
 
 **Notes**
-- Latest versions of both agent `blackfire-agent` and client `blackfire` are setup when `blackfire` is specified in tools input.
 - If you have a tool in your `composer.json`, do not setup it globally using this action as the two instances of the tool might conflict.
 - Tools which cannot be setup gracefully leave an error message in the logs, the action is not interrupted.
 
@@ -191,10 +215,11 @@ Specify `coverage: xdebug` to use `Xdebug`.
 Runs on all [PHP versions supported](#tada-php-support "List of PHP versions supported on this GitHub Action").
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'
-  coverage: xdebug
+- name: Setup PHP with Xdebug
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'
+    coverage: xdebug
 ```
 
 ### PCOV
@@ -205,11 +230,23 @@ Tests with `PCOV` run much faster than with `Xdebug`.
 If your source code directory is other than `src`, `lib` or, `app`, specify `pcov.directory` using the `ini-values` input.  
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'
-  ini-values: pcov.directory=api #optional, see above for usage.
-  coverage: pcov
+- name: Setup PHP with PCOV
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'
+    ini-values: pcov.directory=api #optional, see above for usage.
+    coverage: pcov
+```
+
+`PHPUnit` 8 and above supports `PCOV` out of the box.  
+If you are using `PHPUnit` 5, 6 or 7, you will need `krakjoe/pcov-clobber`.  
+Before executing your tests add the following step.
+
+```yaml
+- name: Setup PCOV
+  run: |
+    composer require pcov/clobber
+    vendor/bin/pcov clobber
 ```
 
 ### Disable Coverage
@@ -223,10 +260,11 @@ Consider disabling the coverage using this PHP action for these reasons.
 - You are profiling your code using `blackfire`.
 
 ```yaml
-uses: shivammathur/setup-php@v2
-with:
-  php-version: '7.4'
-  coverage: none
+- name: Setup PHP with no coverage driver
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'
+    coverage: none
 ```
 
 ## :memo: Usage
@@ -326,7 +364,7 @@ steps:
 - name: Checkout
   uses: actions/checkout@v2
 
-- name: Setup PHP
+- name: Setup nightly PHP
   uses: shivammathur/setup-php@v2
   with:
     php-version: '8.0'
@@ -438,7 +476,7 @@ jobs:
 - You can specify the `update` environment variable to `true` to force update to the latest release.
 
 ```yaml
-- name: Setup PHP
+- name: Setup PHP with latest versions
   uses: shivammathur/setup-php@v2
   with:
     php-version: '7.4'
@@ -453,7 +491,7 @@ jobs:
 To debug any issues, you can use the `verbose` tag instead of `v2`.
 
 ```yaml
-- name: Setup PHP
+- name: Setup PHP with logs
   uses: shivammathur/setup-php@verbose
   with:
     php-version: '7.4'
@@ -613,21 +651,33 @@ Examples of using `setup-php` with various PHP Frameworks and Packages.
 - See [Contributor's Guide](.github/CONTRIBUTING.md "shivammathur/setup-php contribution guide") before you start.
 - If you face any issues while using this or want to suggest a feature/improvement, create an issue [here](https://github.com/shivammathur/setup-php/issues "Issues reported").
 
+*Join the list of setup-php contributions*
+
+<p align="center">
+  <a href="https://github.com/shivammathur/setup-php/graphs/contributors">
+    <img src="https://opencollective.com/setup-php/contributors.svg?width=1024&button=false" alt="setup-php contributers" width="100%">
+  </a>
+</p>
+
 ## :sparkling_heart: Support This Project
 
 - Please star the project and share it. If you blog, please share your experience of using this action.
-- Please consider supporting our work by sponsoring using [Paypal](https://www.paypal.me/shivammathur "Shivam Mathur PayPal") or by subscribing on [Patreon](https://www.patreon.com/shivammathur "Shivam Mathur Patreon").
+- Please consider supporting our work by sponsoring using [Open Collective](https://opencollective.com/setup-php), [Paypal](https://www.paypal.me/shivammathur "Shivam Mathur PayPal") or [Patreon](https://www.patreon.com/shivammathur "Shivam Mathur Patreon").
 - If you use `setup-php` at your company, please [reach out](mailto:contact@setup-php.com) to sponsor the project.
 
 *Huge thanks to the following companies for supporting `setup-php`*
 
-<p> 
+<p>
   <a href="https://www.jetbrains.com/?from=setup-php">
-    <img src="https://shivammathur.com/jetbrains.svg" alt="JetBrains" width="150" height="85">
-  </a>  
-  <img src="https://shivammathur.com/blank.svg" alt="spacer" width="40" height="85">  
-  <a href="https://tidelift.com/subscription/pkg/npm-setup-php">  
-    <img src="https://shivammathur.com/tidelift.png" alt="Tidelift" width="100" height="85">
+    <img src="https://shivammathur.com/jetbrains.svg" alt="JetBrains" width="106" height="60">
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://blackfire.io/?utm_source=setup-php">
+    <img src="https://shivammathur.com/blackfire.svg" alt="Blackfire" width="212" height="60">
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://tidelift.com/subscription/pkg/npm-setup-php">
+    <img src="https://shivammathur.com/tidelift.png" alt="Tidelift" width="70" height="60">
   </a>
 </p>
 
@@ -641,6 +691,7 @@ Examples of using `setup-php` with various PHP Frameworks and Packages.
 - [shivammathur/composer-cache](https://github.com/shivammathur/composer-cache "Cache composer releases")
 - [shivammathur/homebrew-extensions](https://github.com/shivammathur/homebrew-extensions "Tap for PHP extensions on MacOS")
 - [shivammathur/homebrew-php](https://github.com/shivammathur/homebrew-php "Tap for PHP builds on MacOS")
+- [shivammathur/icu-intl](https://github.com/shivammathur/icu-intl "icu4c and php-intl builds")
 - [shivammathur/php-builder](https://github.com/shivammathur/php-builder "Nightly PHP package for Ubuntu")
 - [shivammathur/php-builder-windows](https://github.com/shivammathur/php-builder-windows "Nightly PHP package for Windows")
 - [shivammathur/php-ubuntu](https://github.com/shivammathur/php-ubuntu "Cache stable PHP Packages for Ubuntu")

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -12,9 +12,9 @@ describe('Config tests', () => {
 
     win32 = await config.addINIValues(
       'post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata',
-      'fedora'
+      'openbsd'
     );
-    expect(win32).toContain('Platform fedora is not supported');
+    expect(win32).toContain('Platform openbsd is not supported');
   });
 
   it('checking addINIValuesOnLinux', async () => {
@@ -29,9 +29,9 @@ describe('Config tests', () => {
 
     linux = await config.addINIValues(
       'post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata',
-      'fedora'
+      'openbsd'
     );
-    expect(linux).toContain('Platform fedora is not supported');
+    expect(linux).toContain('Platform openbsd is not supported');
   });
 
   it('checking addINIValuesOnDarwin', async () => {
@@ -45,8 +45,8 @@ describe('Config tests', () => {
 
     darwin = await config.addINIValues(
       'post_max_size=256M, short_open_tag=On, date.timezone=Asia/Kolkata',
-      'fedora'
+      'openbsd'
     );
-    expect(darwin).toContain('Platform fedora is not supported');
+    expect(darwin).toContain('Platform openbsd is not supported');
   });
 });

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -46,8 +46,8 @@ describe('Extension tests', () => {
     expect(win32).toContain('Add-Phalcon phalcon3');
     expect(win32).toContain('Add-Extension does_not_exist');
 
-    win32 = await extensions.addExtension('xdebug', '7.2', 'fedora');
-    expect(win32).toContain('Platform fedora is not supported');
+    win32 = await extensions.addExtension('xdebug', '7.2', 'openbsd');
+    expect(win32).toContain('Platform openbsd is not supported');
 
     win32 = await extensions.addExtension('blackfire', '7.3', 'win32');
     expect(win32).toContain('Add-Blackfire blackfire');
@@ -100,8 +100,8 @@ describe('Extension tests', () => {
     linux = await extensions.addExtension('cubrid', '7.4', 'linux');
     expect(linux).toContain('add_cubrid cubrid');
 
-    linux = await extensions.addExtension('xdebug', '7.2', 'fedora');
-    expect(linux).toContain('Platform fedora is not supported');
+    linux = await extensions.addExtension('xdebug', '7.2', 'openbsd');
+    expect(linux).toContain('Platform openbsd is not supported');
 
     linux = await extensions.addExtension('phalcon3, phalcon4', '7.3', 'linux');
     expect(linux).toContain('add_phalcon phalcon3');
@@ -195,7 +195,7 @@ describe('Extension tests', () => {
     );
     expect(darwin).toContain('add_extension does_not_exist');
 
-    darwin = await extensions.addExtension('xdebug', '7.2', 'fedora');
-    expect(darwin).toContain('Platform fedora is not supported');
+    darwin = await extensions.addExtension('xdebug', '7.2', 'openbsd');
+    expect(darwin).toContain('Platform openbsd is not supported');
   });
 });

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -119,6 +119,12 @@ describe('Extension tests', () => {
 
     linux = await extensions.addExtension('blackfire-1.31.0', '7.3', 'linux');
     expect(linux).toContain('add_blackfire blackfire-1.31.0');
+
+    linux = await extensions.addExtension('intl-65.1', '5.6', 'linux');
+    expect(linux).toContain('add_intl intl-65.1');
+
+    linux = await extensions.addExtension('intl-67.1', '7.3', 'linux');
+    expect(linux).toContain('add_intl intl-67.1');
   });
 
   it('checking addExtensionOnDarwin', async () => {

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -270,8 +270,8 @@ describe('Tools tests', () => {
     expect(await tools.getSymfonyUri('1.2.3', 'win32')).toContain(
       'releases/download/v1.2.3/symfony_windows_amd64'
     );
-    expect(await tools.getSymfonyUri('1.2.3', 'fedora')).toContain(
-      'Platform fedora is not supported'
+    expect(await tools.getSymfonyUri('1.2.3', 'openbsd')).toContain(
+      'Platform openbsd is not supported'
     );
   });
 
@@ -320,9 +320,9 @@ describe('Tools tests', () => {
     script = await tools.addArchive(
       'tool',
       'https://tool.com/tool.phar',
-      'fedora'
+      'openbsd'
     );
-    expect(script).toContain('Platform fedora is not supported');
+    expect(script).toContain('Platform openbsd is not supported');
   });
 
   it('checking addDevTools', async () => {
@@ -350,8 +350,8 @@ describe('Tools tests', () => {
       'Add-Log "$cross" "php-config" "php-config is not a windows tool"'
     );
 
-    script = await tools.addDevTools('tool', 'fedora');
-    expect(script).toContain('Platform fedora is not supported');
+    script = await tools.addDevTools('tool', 'openbsd');
+    expect(script).toContain('Platform openbsd is not supported');
   });
 
   it('checking addPackage', async () => {
@@ -369,8 +369,8 @@ describe('Tools tests', () => {
     script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'win32');
     expect(script).toContain('Add-Composertool tool tool:1.2.3 user/');
 
-    script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'fedora');
-    expect(script).toContain('Platform fedora is not supported');
+    script = await tools.addPackage('tool', 'tool:1.2.3', 'user/', 'openbsd');
+    expect(script).toContain('Platform openbsd is not supported');
   });
 
   it('checking addTools on linux', async () => {

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -300,21 +300,18 @@ describe('Tools tests', () => {
   it('checking addArchive', async () => {
     let script: string = await tools.addArchive(
       'tool',
-      '1.2.3',
       'https://tool.com/tool.phar',
       'linux'
     );
     expect(script).toContain('add_tool https://tool.com/tool.phar tool');
     script = await tools.addArchive(
       'tool',
-      '1.2.3',
       'https://tool.com/tool.phar',
       'darwin'
     );
     expect(script).toContain('add_tool https://tool.com/tool.phar tool');
     script = await tools.addArchive(
       'tool',
-      '1.2.3',
       'https://tool.com/tool.phar',
       'win32'
     );
@@ -322,7 +319,6 @@ describe('Tools tests', () => {
 
     script = await tools.addArchive(
       'tool',
-      '1.2.3',
       'https://tool.com/tool.phar',
       'fedora'
     );

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -375,7 +375,7 @@ describe('Tools tests', () => {
 
   it('checking addTools on linux', async () => {
     const script: string = await tools.addTools(
-      'blackfire, blackfire-player, cs2pr, flex, grpc_php_plugin, php-cs-fixer, phplint, phpstan, phpunit, pecl, phinx, phinx:1.2.3, phive, php-config, phpize, protoc, symfony, wp-cli',
+      'blackfire, blackfire-player, cs2pr, flex, grpc_php_plugin, php-cs-fixer, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, php-config, phpize, protoc, symfony, wp-cli',
       '7.4',
       'linux'
     );
@@ -394,6 +394,9 @@ describe('Tools tests', () => {
     );
     expect(script).toContain(
       'add_tool https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar phpstan'
+    );
+    expect(script).toContain(
+      'add_tool https://www.phing.info/get/phing-latest.phar phing'
     );
     expect(script).toContain(
       'add_tool https://phar.io/releases/phive.phar phive'
@@ -432,6 +435,7 @@ describe('Tools tests', () => {
       'infection',
       'phan',
       'phan:2.7.2',
+      'phing:1.2.3',
       'phinx',
       'phive:1.2.3',
       'php-config',
@@ -478,6 +482,9 @@ describe('Tools tests', () => {
     );
     expect(script).toContain(
       'add_tool https://github.com/phan/phan/releases/latest/download/phan.phar phan'
+    );
+    expect(script).toContain(
+      'add_tool https://www.phing.info/get/phing-1.2.3.phar phing'
     );
     expect(script).toContain(
       'add_tool https://github.com/squizlabs/PHP_CodeSniffer/releases/latest/download/phpcs.phar phpcs'

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -131,8 +131,8 @@ describe('Utils tests', () => {
     expect(step_log).toEqual('step_log "Test message"');
     step_log = await utils.stepLog(message, 'darwin');
     expect(step_log).toEqual('step_log "Test message"');
-    step_log = await utils.stepLog(message, 'fedora');
-    expect(step_log).toContain('Platform fedora is not supported');
+    step_log = await utils.stepLog(message, 'openbsd');
+    expect(step_log).toContain('Platform openbsd is not supported');
 
     let add_log: string = await utils.addLog(
       'tick',
@@ -145,8 +145,8 @@ describe('Utils tests', () => {
     expect(add_log).toEqual('add_log "tick" "xdebug" "enabled"');
     add_log = await utils.addLog('tick', 'xdebug', 'enabled', 'darwin');
     expect(add_log).toEqual('add_log "tick" "xdebug" "enabled"');
-    add_log = await utils.addLog('tick', 'xdebug', 'enabled', 'fedora');
-    expect(add_log).toContain('Platform fedora is not supported');
+    add_log = await utils.addLog('tick', 'xdebug', 'enabled', 'openbsd');
+    expect(add_log).toContain('Platform openbsd is not supported');
   });
 
   it('checking getExtensionPrefix', async () => {
@@ -163,8 +163,8 @@ describe('Utils tests', () => {
     expect(await utils.suppressOutput('win32')).toEqual(' >$null 2>&1');
     expect(await utils.suppressOutput('linux')).toEqual(' >/dev/null 2>&1');
     expect(await utils.suppressOutput('darwin')).toEqual(' >/dev/null 2>&1');
-    expect(await utils.suppressOutput('fedora')).toContain(
-      'Platform fedora is not supported'
+    expect(await utils.suppressOutput('openbsd')).toContain(
+      'Platform openbsd is not supported'
     );
   });
 
@@ -178,8 +178,8 @@ describe('Utils tests', () => {
     expect(await utils.getCommand('linux', 'tool')).toBe('add_tool ');
     expect(await utils.getCommand('darwin', 'tool')).toBe('add_tool ');
     expect(await utils.getCommand('win32', 'tool')).toBe('Add-Tool ');
-    expect(await utils.getCommand('fedora', 'tool')).toContain(
-      'Platform fedora is not supported'
+    expect(await utils.getCommand('openbsd', 'tool')).toContain(
+      'Platform openbsd is not supported'
     );
   });
 
@@ -191,8 +191,8 @@ describe('Utils tests', () => {
     expect(await utils.scriptExtension('linux')).toBe('.sh');
     expect(await utils.scriptExtension('darwin')).toBe('.sh');
     expect(await utils.scriptExtension('win32')).toBe('.ps1');
-    expect(await utils.scriptExtension('fedora')).toContain(
-      'Platform fedora is not supported'
+    expect(await utils.scriptExtension('openbsd')).toContain(
+      'Platform openbsd is not supported'
     );
   });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -973,7 +973,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -1030,7 +1030,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -1682,7 +1682,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -2212,7 +2212,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -2355,7 +2355,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -2448,7 +2448,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -2470,6 +2470,8 @@ const matchers = __importStar(__webpack_require__(86));
  * @param os_version
  */
 async function build(filename, version, os_version) {
+    const name = 'setup-php';
+    const url = 'setup-php.com/support';
     // taking inputs
     const extension_csv = (await utils.getInput('extensions', false)) ||
         (await utils.getInput('extension', false));
@@ -2493,6 +2495,8 @@ async function build(filename, version, os_version) {
     if (ini_values_csv) {
         script += await config.addINIValues(ini_values_csv, os_version);
     }
+    script += '\n' + (await utils.stepLog('Support this project', os_version));
+    script += '\n' + (await utils.addLog('$tick', name, url, os_version));
     return await utils.writeScript(filename, script);
 }
 exports.build = build;
@@ -2766,7 +2770,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -2106,6 +2106,10 @@ async function addTools(tools_csv, php_version, os_version) {
                 url = github + 'phan/phan/' + uri;
                 script += await addArchive(tool, url, os_version);
                 break;
+            case 'phing':
+                url = 'https://www.phing.info/get/phing-' + version + '.phar';
+                script += await addArchive(tool, url, os_version);
+                break;
             case 'phinx':
                 script += await addPackage(tool, release, 'robmorgan/', os_version);
                 break;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1986,11 +1986,10 @@ exports.getCleanedToolsList = getCleanedToolsList;
  * Helper function to get script to setup a tool using a phar url
  *
  * @param tool
- * @param version
  * @param url
  * @param os_version
  */
-async function addArchive(tool, version, url, os_version) {
+async function addArchive(tool, url, os_version) {
     return (await utils.getCommand(os_version, 'tool')) + url + ' ' + tool;
 }
 exports.addArchive = addArchive;
@@ -2054,22 +2053,22 @@ async function addTools(tools_csv, php_version, os_version) {
                 break;
             case 'blackfire-player':
                 url = await getPharUrl('https://get.blackfire.io', tool, 'v', version);
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'codeception':
                 url =
                     'https://codeception.com/' +
                         (await getCodeceptionUri(version, php_version));
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'composer':
                 url = await getComposerUrl(version);
-                script += await addArchive('composer', version, url, os_version);
+                script += await addArchive('composer', url, os_version);
                 break;
             case 'composer-normalize':
                 uri = await getUri(tool, '.phar', version, 'releases', '', 'download');
                 url = github + 'ergebnis/composer-normalize/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'composer-prefetcher':
                 script += await addPackage(tool, release, 'narrowspark/automatic-', os_version);
@@ -2077,35 +2076,35 @@ async function addTools(tools_csv, php_version, os_version) {
             case 'composer-require-checker':
                 uri = await getUri(tool, '.phar', version, 'releases', '', 'download');
                 url = github + 'maglnet/ComposerRequireChecker/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'composer-unused':
                 uri = await getUri(tool, '.phar', version, 'releases', '', 'download');
                 url = github + 'composer-unused/composer-unused/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'cs2pr':
                 uri = await getUri(tool, '', version, 'releases', '', 'download');
                 url = github + 'staabm/annotate-pull-request-from-checkstyle/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'deployer':
                 url = await getDeployerUrl(version);
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'flex':
                 script += await addPackage(tool, release, 'symfony/', os_version);
                 break;
             case 'infection':
                 url = github + 'infection/infection/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'pecl':
                 script += await utils.getCommand(os_version, 'pecl');
                 break;
             case 'phan':
                 url = github + 'phan/phan/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'phinx':
                 script += await addPackage(tool, release, 'robmorgan/', os_version);
@@ -2120,48 +2119,48 @@ async function addTools(tools_csv, php_version, os_version) {
             case 'php-cs-fixer':
                 uri = await getUri(tool, '.phar', version, 'releases', 'v', 'download');
                 url = github + 'FriendsOfPHP/PHP-CS-Fixer/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'phpcbf':
             case 'phpcs':
                 url = github + 'squizlabs/PHP_CodeSniffer/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'phpcpd':
             case 'phpunit':
                 url = await getPharUrl('https://phar.phpunit.de', tool, '', version);
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'phplint':
                 script += await addPackage(tool, release, 'overtrue/', os_version);
                 break;
             case 'phpmd':
                 url = github + 'phpmd/phpmd/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'phpstan':
                 url = github + 'phpstan/phpstan/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'prestissimo':
                 script += await addPackage(tool, release, 'hirak/', os_version);
                 break;
             case 'psalm':
                 url = github + 'vimeo/psalm/' + uri;
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             case 'symfony':
             case 'symfony-cli':
                 uri = await getSymfonyUri(version, os_version);
                 url = github + 'symfony/cli/' + uri;
-                script += await addArchive('symfony', version, url, os_version);
+                script += await addArchive('symfony', url, os_version);
                 break;
             case 'vapor-cli':
                 script += await addPackage(tool, release, 'laravel/', os_version);
                 break;
             case 'wp-cli':
                 url = github + (await getWpCliUrl(version));
-                script += await addArchive(tool, version, url, os_version);
+                script += await addArchive(tool, url, os_version);
                 break;
             default:
                 script += await utils.addLog('$cross', tool, 'Tool ' + tool + ' is not supported', os_version);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2953,6 +2953,7 @@ async function addExtensionLinux(extension_csv, version, pipe) {
             case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(version_extension):
             case /^((5\.[3-6])|(7\.[0-2]))pdo_cubrid$|^((5\.[3-6])|(7\.[0-4]))cubrid$/.test(version_extension):
             case /^pdo_oci$|^oci8$/.test(extension):
+            case /^5\.6intl-[\d]+\.[\d]+$|^7\.[0-4]intl-[\d]+\.[\d]+$/.test(version_extension):
             case /^5\.[3-6]ioncube$|^7\.[0-4]ioncube$/.test(version_extension):
             case /^7\.[0-3]phalcon3$|^7\.[2-4]phalcon4$/.test(version_extension):
             case /^((5\.6)|(7\.[0-4]))gearman$/.test(version_extension):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "setup-php",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-mwpoNjHSWWh0IiALdDEQi3tru124JKn0yVNziIBzTME8QRv7thwoghVuT1jBRjFvdtoHsqD58IRHy1nf86paRg=="
     },
     "@actions/exec": {
       "version": "1.0.4",
@@ -32,19 +32,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
-      "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.0",
+        "@babel/generator": "^7.11.6",
         "@babel/helper-module-transforms": "^7.11.0",
         "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.1",
+        "@babel/parser": "^7.11.5",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.11.0",
-        "@babel/types": "^7.11.0",
+        "@babel/traverse": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -79,12 +79,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-      "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.11.0",
+        "@babel/types": "^7.11.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -277,9 +277,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
-      "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -393,17 +393,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-      "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.0",
+        "@babel/generator": "^7.11.5",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.11.0",
-        "@babel/types": "^7.11.0",
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -418,9 +418,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-      "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -442,6 +442,32 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -569,13 +595,13 @@
       }
     },
     "@jest/core": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.0.tgz",
-      "integrity": "sha512-mpXm4OjWQbz7qbzGIiSqvfNZ1FxX6ywWgLtdSD2luPORt5zKPtqcdDnX7L8RdfMaj1znDBgN2+gB094ZIr7vnA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
+      "integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
       "dev": true,
       "requires": {
         "@jest/console": "^26.3.0",
-        "@jest/reporters": "^26.4.0",
+        "@jest/reporters": "^26.4.1",
         "@jest/test-result": "^26.3.0",
         "@jest/transform": "^26.3.0",
         "@jest/types": "^26.3.0",
@@ -585,17 +611,17 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
         "jest-changed-files": "^26.3.0",
-        "jest-config": "^26.4.0",
+        "jest-config": "^26.4.2",
         "jest-haste-map": "^26.3.0",
         "jest-message-util": "^26.3.0",
         "jest-regex-util": "^26.0.0",
         "jest-resolve": "^26.4.0",
-        "jest-resolve-dependencies": "^26.4.0",
-        "jest-runner": "^26.4.0",
-        "jest-runtime": "^26.4.0",
-        "jest-snapshot": "^26.4.0",
+        "jest-resolve-dependencies": "^26.4.2",
+        "jest-runner": "^26.4.2",
+        "jest-runtime": "^26.4.2",
+        "jest-snapshot": "^26.4.2",
         "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.0",
+        "jest-validate": "^26.4.2",
         "jest-watcher": "^26.3.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
@@ -742,14 +768,14 @@
       }
     },
     "@jest/globals": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.0.tgz",
-      "integrity": "sha512-QKwoVAeL9d0xaEM9ebPvfc+bolN04F+o3zM2jswGDBiiNjCogZ3LvOaqumRdDyz6kLmbx+UhgMBAVuLunbXZ2A==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
+      "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
       "dev": true,
       "requires": {
         "@jest/environment": "^26.3.0",
         "@jest/types": "^26.3.0",
-        "expect": "^26.4.0"
+        "expect": "^26.4.2"
       },
       "dependencies": {
         "@jest/types": {
@@ -787,9 +813,9 @@
       }
     },
     "@jest/reporters": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.0.tgz",
-      "integrity": "sha512-14OPAAuYhgRBSNxAocVluX6ksdMdK/EuP9NmtBXU9g1uKaVBrPnohn/CVm6iMot1a9iU8BCxa5715YRf8FEg/A==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
+      "integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -811,7 +837,7 @@
         "jest-resolve": "^26.4.0",
         "jest-util": "^26.3.0",
         "jest-worker": "^26.3.0",
-        "node-notifier": "^7.0.0",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -911,16 +937,16 @@
       }
     },
     "@jest/test-sequencer": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.0.tgz",
-      "integrity": "sha512-9Z7lCShS7vERp+DRwIVNH/6sHMWwJK1DPnGCpGeVLGJJWJ4Y08sQI3vIKdmKHu2KmwlUBpRM+BFf7NlVUkl5XA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
+      "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
       "dev": true,
       "requires": {
         "@jest/test-result": "^26.3.0",
         "graceful-fs": "^4.2.4",
         "jest-haste-map": "^26.3.0",
-        "jest-runner": "^26.4.0",
-        "jest-runtime": "^26.4.0"
+        "jest-runner": "^26.4.2",
+        "jest-runtime": "^26.4.2"
       }
     },
     "@jest/transform": {
@@ -992,6 +1018,32 @@
         "chalk": "^3.0.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -1057,12 +1109,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-      "dev": true
-    },
     "@types/graceful-fs": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
@@ -1098,9 +1144,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.10",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.10.tgz",
-      "integrity": "sha512-i2m0oyh8w/Lum7wWK/YOZJakYF8Mx08UaKA1CtbmFeDquVhAEdA7znacsVSf2hJ1OQ/OfVMGN90pw/AtzF8s/Q==",
+      "version": "26.0.13",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.13.tgz",
+      "integrity": "sha512-sCzjKow4z9LILc6DhBvn5AkIfmQzDZkgtVVKmGwVrs5tuid38ws281D4l+7x1kP487+FlKDh5kfMZ8WSPAdmdA==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",
@@ -1108,9 +1154,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
     "@types/json5": {
@@ -1120,9 +1166,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
+      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1138,9 +1184,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
-      "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.0.tgz",
+      "integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -1165,12 +1211,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.9.1.tgz",
-      "integrity": "sha512-XIr+Mfv7i4paEdBf0JFdIl9/tVxyj+rlilWIfZ97Be0lZ7hPvUbS5iHt9Glc8kRI53dsr0PcAEudbf8rO2wGgg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.0.1.tgz",
+      "integrity": "sha512-pQZtXupCn11O4AwpYVUX4PDFfmIJl90ZgrEBg0CEcqlwvPiG0uY81fimr1oMFblZnpKAq6prrT9a59pj1x58rw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.9.1",
+        "@typescript-eslint/experimental-utils": "4.0.1",
+        "@typescript-eslint/scope-manager": "4.0.1",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1179,47 +1226,57 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.1.tgz",
-      "integrity": "sha512-lkiZ8iBBaYoyEKhCkkw4SAeatXyBq9Ece5bZXdLe1LWBUwTszGbmbiqmQbwWA8cSYDnjWXp9eDbXpf9Sn0hLAg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.0.1.tgz",
+      "integrity": "sha512-gAqOjLiHoED79iYTt3F4uSHrYmg/GPz/zGezdB0jAdr6S6gwNiR/j7cTZ8nREKVzMVKLd9G3xbg1sV9GClW3sw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/types": "3.9.1",
-        "@typescript-eslint/typescript-estree": "3.9.1",
+        "@typescript-eslint/scope-manager": "4.0.1",
+        "@typescript-eslint/types": "4.0.1",
+        "@typescript-eslint/typescript-estree": "4.0.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.9.1.tgz",
-      "integrity": "sha512-y5QvPFUn4Vl4qM40lI+pNWhTcOWtpZAJ8pOEQ21fTTW4xTJkRplMjMRje7LYTXqVKKX9GJhcyweMz2+W1J5bMg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.0.1.tgz",
+      "integrity": "sha512-1+qLmXHNAWSQ7RB6fdSQszAiA7JTwzakj5cNYjBTUmpH2cqilxMZEIV+DRKjVZs8NzP3ALmKexB0w/ExjcK9Iw==",
       "dev": true,
       "requires": {
-        "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "3.9.1",
-        "@typescript-eslint/types": "3.9.1",
-        "@typescript-eslint/typescript-estree": "3.9.1",
-        "eslint-visitor-keys": "^1.1.0"
+        "@typescript-eslint/scope-manager": "4.0.1",
+        "@typescript-eslint/types": "4.0.1",
+        "@typescript-eslint/typescript-estree": "4.0.1",
+        "debug": "^4.1.1"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.0.1.tgz",
+      "integrity": "sha512-u3YEXVJ8jsj7QCJk3om0Y457fy2euEOkkzxIB/LKU3MdyI+FJ2gI0M4aKEaXzwCSfNDiZ13a3lDo5DVozc+XLQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.0.1",
+        "@typescript-eslint/visitor-keys": "4.0.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.9.1.tgz",
-      "integrity": "sha512-15JcTlNQE1BsYy5NBhctnEhEoctjXOjOK+Q+rk8ugC+WXU9rAcS2BYhoh6X4rOaXJEpIYDl+p7ix+A5U0BqPTw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.0.1.tgz",
+      "integrity": "sha512-S+gD3fgbkZYW2rnbjugNMqibm9HpEjqZBZkTiI3PwbbNGWmAcxolWIUwZ0SKeG4Dy2ktpKKaI/6+HGYVH8Qrlg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.1.tgz",
-      "integrity": "sha512-IqM0gfGxOmIKPhiHW/iyAEXwSVqMmR2wJ9uXHNdFpqVvPaQ3dWg302vW127sBpAiqM9SfHhyS40NKLsoMpN2KA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.0.1.tgz",
+      "integrity": "sha512-zGzleORFXrRWRJAMLTB2iJD1IZbCPkg4hsI8mGdpYlKaqzvKYSEWVAYh14eauaR+qIoZVWrXgYSXqLtTlxotiw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "3.9.1",
-        "@typescript-eslint/visitor-keys": "3.9.1",
+        "@typescript-eslint/types": "4.0.1",
+        "@typescript-eslint/visitor-keys": "4.0.1",
         "debug": "^4.1.1",
-        "glob": "^7.1.6",
+        "globby": "^11.0.1",
         "is-glob": "^4.0.1",
         "lodash": "^4.17.15",
         "semver": "^7.3.2",
@@ -1227,12 +1284,13 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.1.tgz",
-      "integrity": "sha512-zxdtUjeoSh+prCpogswMwVUJfEFmCOjdzK9rpNjNBfm6EyPt99x3RrJoBOGZO23FCt0WPKUCOL5mb/9D5LjdwQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.0.1.tgz",
+      "integrity": "sha512-yBSqd6FjnTzbg5RUy9J+9kJEyQjTI34JdGMJz+9ttlJzLCnGkBikxw+N5n2VDcc3CesbIEJ0MnZc5uRYnrEnCw==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.1.0"
+        "@typescript-eslint/types": "4.0.1",
+        "eslint-visitor-keys": "^2.0.0"
       }
     },
     "@zeit/ncc": {
@@ -1373,6 +1431,12 @@
         "es-abstract": "^1.17.0",
         "is-string": "^1.0.5"
       }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
@@ -1894,22 +1958,16 @@
       },
       "dependencies": {
         "parse-json": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-          "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
         }
       }
     },
@@ -2080,6 +2138,15 @@
       "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
       "dev": true
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2246,12 +2313,13 @@
       }
     },
     "eslint": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.7.0.tgz",
-      "integrity": "sha512-1KUxLzos0ZVsyL81PnRN335nDtQ8/vZUD6uMtWbF+5zDtjKcsklIi78XoE0MVL93QvWTu+E5y44VyyCsOMBrIg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.1.tgz",
+      "integrity": "sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.1.3",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2261,7 +2329,7 @@
         "eslint-scope": "^5.1.0",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^1.3.0",
-        "espree": "^7.2.0",
+        "espree": "^7.3.0",
         "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -2298,6 +2366,18 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
         }
       }
     },
@@ -2413,41 +2493,12 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.20.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz",
-      "integrity": "sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.0.0.tgz",
+      "integrity": "sha512-a0G7hSDbuBCW4PNT6MVpAyfnGbUDOqxzOyhR6wT2BIBnR7MhvfAqd6KKfsTjX+Z3gxzIHiEsihzdClU4cSc6qQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "^2.5.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.34.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
-          "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.34.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^2.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.34.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
-          "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "eslint-visitor-keys": "^1.1.0",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
-          }
-        }
+        "@typescript-eslint/experimental-utils": "^4.0.1"
       }
     },
     "eslint-plugin-prettier": {
@@ -2476,23 +2527,39 @@
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "espree": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.2.0.tgz",
-      "integrity": "sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.3.1",
+        "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -2519,12 +2586,20 @@
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "estraverse": {
@@ -2668,15 +2743,15 @@
       }
     },
     "expect": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.0.tgz",
-      "integrity": "sha512-dbYDJhFcqQsamlos6nEwAMe+ahdckJBk5fmw1DYGLQGabGSlUuT+Fm2jHYw5119zG3uIhP+lCQbjJhFEdZMJtg==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+      "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
       "dev": true,
       "requires": {
         "@jest/types": "^26.3.0",
         "ansi-styles": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-matcher-utils": "^26.4.0",
+        "jest-matcher-utils": "^26.4.2",
         "jest-message-util": "^26.3.0",
         "jest-regex-util": "^26.0.0"
       },
@@ -2831,6 +2906,20 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2842,6 +2931,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -3045,6 +3143,20 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.8.1"
+      }
+    },
+    "globby": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
       }
     },
     "graceful-fs": {
@@ -3285,9 +3397,9 @@
       }
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
     "import-fresh": {
@@ -3686,14 +3798,14 @@
       }
     },
     "jest": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.0.tgz",
-      "integrity": "sha512-lNCOS+ckRHE1wFyVtQClBmbsOVuH2GWUTJMDL3vunp9DXcah+V8vfvVVApngClcdoc3rgZpqOfCNKLjxjj2l4g==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
+      "integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.4.0",
+        "@jest/core": "^26.4.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.4.0"
+        "jest-cli": "^26.4.2"
       },
       "dependencies": {
         "@jest/types": {
@@ -3729,12 +3841,12 @@
           }
         },
         "jest-cli": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.0.tgz",
-          "integrity": "sha512-kw2Pr3V2x9/WzSDGsbz/MJBNlCoPMxMudrIavft4bqRlv5tASjU51tyO+1Os1LdW2dAnLQZYsxFUZ8oWPyssGQ==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
+          "integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.4.0",
+            "@jest/core": "^26.4.2",
             "@jest/test-result": "^26.3.0",
             "@jest/types": "^26.3.0",
             "chalk": "^4.0.0",
@@ -3742,9 +3854,9 @@
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.4.0",
+            "jest-config": "^26.4.2",
             "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.0",
+            "jest-validate": "^26.4.2",
             "prompts": "^2.0.1",
             "yargs": "^15.3.1"
           }
@@ -3812,9 +3924,9 @@
           }
         },
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -3838,9 +3950,9 @@
       }
     },
     "jest-circus": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.4.0.tgz",
-      "integrity": "sha512-kSjqHtvN+U3MdtyrruDMf2rrTUMNzkw+LHkC7S/s/G22qDlgV3nWPFllchatwY9AfMgYkWrEXx7+ulhgH4n8fQ==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.4.2.tgz",
+      "integrity": "sha512-gzxoteivskdUTNxT7Jx6hrANsEm+x1wh8jaXmQCtzC7zoNWirk9chYdSosHFC4tJlfDZa0EsPreVAxLicLsV0w==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
@@ -3851,16 +3963,16 @@
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^26.4.0",
+        "expect": "^26.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.4.0",
-        "jest-matcher-utils": "^26.4.0",
+        "jest-each": "^26.4.2",
+        "jest-matcher-utils": "^26.4.2",
         "jest-message-util": "^26.3.0",
-        "jest-runner": "^26.4.0",
-        "jest-runtime": "^26.4.0",
-        "jest-snapshot": "^26.4.0",
+        "jest-runner": "^26.4.2",
+        "jest-runtime": "^26.4.2",
+        "jest-snapshot": "^26.4.2",
         "jest-util": "^26.3.0",
-        "pretty-format": "^26.4.0",
+        "pretty-format": "^26.4.2",
         "stack-utils": "^2.0.2",
         "throat": "^5.0.0"
       },
@@ -3898,9 +4010,9 @@
           }
         },
         "pretty-format": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
-          "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
             "@jest/types": "^26.3.0",
@@ -3912,13 +4024,13 @@
       }
     },
     "jest-config": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.0.tgz",
-      "integrity": "sha512-MxsvrBug8YY+C4QcUBtmgnHyFeW7w3Ouk/w9eplCDN8VJGVyBEZFe8Lxzfp2pSqh0Dqurqv8Oik2YkbekGUlxg==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
+      "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^26.4.0",
+        "@jest/test-sequencer": "^26.4.2",
         "@jest/types": "^26.3.0",
         "babel-jest": "^26.3.0",
         "chalk": "^4.0.0",
@@ -3928,13 +4040,13 @@
         "jest-environment-jsdom": "^26.3.0",
         "jest-environment-node": "^26.3.0",
         "jest-get-type": "^26.3.0",
-        "jest-jasmine2": "^26.4.0",
+        "jest-jasmine2": "^26.4.2",
         "jest-regex-util": "^26.0.0",
         "jest-resolve": "^26.4.0",
         "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.0",
+        "jest-validate": "^26.4.2",
         "micromatch": "^4.0.2",
-        "pretty-format": "^26.4.0"
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "@jest/types": {
@@ -3976,9 +4088,9 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
-          "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
             "@jest/types": "^26.3.0",
@@ -4011,16 +4123,16 @@
       }
     },
     "jest-each": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.0.tgz",
-      "integrity": "sha512-+cyBh1ehs6thVT/bsZVG+WwmRn2ix4Q4noS9yLZgM10yGWPW12/TDvwuOV2VZXn1gi09/ZwJKJWql6YW1C9zNw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
+      "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
       "dev": true,
       "requires": {
         "@jest/types": "^26.3.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
         "jest-util": "^26.3.0",
-        "pretty-format": "^26.4.0"
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "@jest/types": {
@@ -4062,9 +4174,9 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
-          "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
             "@jest/types": "^26.3.0",
@@ -4235,9 +4347,9 @@
       }
     },
     "jest-jasmine2": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.0.tgz",
-      "integrity": "sha512-cGBxwzDDKB09EPJ4pE69BMDv+2lO442IB1xQd+vL3cua2OKdeXQK6iDlQKoRX/iP0RgU5T8sn9yahLcx/+ox8Q==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
+      "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
@@ -4248,15 +4360,15 @@
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^26.4.0",
+        "expect": "^26.4.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.4.0",
-        "jest-matcher-utils": "^26.4.0",
+        "jest-each": "^26.4.2",
+        "jest-matcher-utils": "^26.4.2",
         "jest-message-util": "^26.3.0",
-        "jest-runtime": "^26.4.0",
-        "jest-snapshot": "^26.4.0",
+        "jest-runtime": "^26.4.2",
+        "jest-snapshot": "^26.4.2",
         "jest-util": "^26.3.0",
-        "pretty-format": "^26.4.0",
+        "pretty-format": "^26.4.2",
         "throat": "^5.0.0"
       },
       "dependencies": {
@@ -4293,9 +4405,9 @@
           }
         },
         "pretty-format": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
-          "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
             "@jest/types": "^26.3.0",
@@ -4307,13 +4419,13 @@
       }
     },
     "jest-leak-detector": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.0.tgz",
-      "integrity": "sha512-7EXKKEKnAWUPyiVtGZzJflbPOtYUdlNoevNVOkAcPpdR8xWiYKPGNGA6sz25S+8YhZq3rmkQJYAh3/P0VnoRwA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
+      "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
       "dev": true,
       "requires": {
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.4.0"
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "@jest/types": {
@@ -4355,9 +4467,9 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
-          "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
             "@jest/types": "^26.3.0",
@@ -4369,15 +4481,15 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.0.tgz",
-      "integrity": "sha512-u+xdCdq+F262DH+PutJKXLGr2H5P3DImdJCir51PGSfi3TtbLQ5tbzKaN8BkXbiTIU6ayuAYBWTlU1nyckVdzA==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+      "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^26.4.0",
+        "jest-diff": "^26.4.2",
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.4.0"
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "@jest/types": {
@@ -4419,15 +4531,15 @@
           "dev": true
         },
         "jest-diff": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.0.tgz",
-          "integrity": "sha512-wwC38HlOW+iTq6j5tkj/ZamHn6/nrdcEOc/fKaVILNtN2NLWGdkfRaHWwfNYr5ehaLvuoG2LfCZIcWByVj0gjg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^26.3.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.0"
+            "pretty-format": "^26.4.2"
           }
         },
         "jest-get-type": {
@@ -4437,9 +4549,9 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
-          "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
             "@jest/types": "^26.3.0",
@@ -4648,14 +4760,14 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-          "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -4699,14 +4811,14 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.0.tgz",
-      "integrity": "sha512-hznK/hlrlhu8hwdbieRdHFKmcV83GW8t30libt/v6j1L3IEzb8iN21SaWzV8KRAAK4ijiU0kuge0wnHn+0rytQ==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
+      "integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
       "dev": true,
       "requires": {
         "@jest/types": "^26.3.0",
         "jest-regex-util": "^26.0.0",
-        "jest-snapshot": "^26.4.0"
+        "jest-snapshot": "^26.4.2"
       },
       "dependencies": {
         "@jest/types": {
@@ -4744,9 +4856,9 @@
       }
     },
     "jest-runner": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.0.tgz",
-      "integrity": "sha512-XF+tnUGolnPriu6Gg+HHWftspMjD5NkTV2mQppQnpZe39GcUangJ0al7aBGtA3GbVAcRd048DQiJPmsQRdugjw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
+      "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
       "dev": true,
       "requires": {
         "@jest/console": "^26.3.0",
@@ -4758,13 +4870,13 @@
         "emittery": "^0.7.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.4.0",
+        "jest-config": "^26.4.2",
         "jest-docblock": "^26.0.0",
         "jest-haste-map": "^26.3.0",
-        "jest-leak-detector": "^26.4.0",
+        "jest-leak-detector": "^26.4.2",
         "jest-message-util": "^26.3.0",
         "jest-resolve": "^26.4.0",
-        "jest-runtime": "^26.4.0",
+        "jest-runtime": "^26.4.2",
         "jest-util": "^26.3.0",
         "jest-worker": "^26.3.0",
         "source-map-support": "^0.5.6",
@@ -4806,15 +4918,15 @@
       }
     },
     "jest-runtime": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.0.tgz",
-      "integrity": "sha512-1fjZgGpkyQBUTo59Vi19I4IcsBwzY6uwVFNjUmR06iIi3XRErkY28yimi4IUDRrofQErqcDEw2n3DF9WmQ6vEg==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
+      "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
       "dev": true,
       "requires": {
         "@jest/console": "^26.3.0",
         "@jest/environment": "^26.3.0",
         "@jest/fake-timers": "^26.3.0",
-        "@jest/globals": "^26.4.0",
+        "@jest/globals": "^26.4.2",
         "@jest/source-map": "^26.3.0",
         "@jest/test-result": "^26.3.0",
         "@jest/transform": "^26.3.0",
@@ -4825,15 +4937,15 @@
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.4.0",
+        "jest-config": "^26.4.2",
         "jest-haste-map": "^26.3.0",
         "jest-message-util": "^26.3.0",
         "jest-mock": "^26.3.0",
         "jest-regex-util": "^26.0.0",
         "jest-resolve": "^26.4.0",
-        "jest-snapshot": "^26.4.0",
+        "jest-snapshot": "^26.4.2",
         "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.0",
+        "jest-validate": "^26.4.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^15.3.1"
@@ -4890,25 +5002,25 @@
       }
     },
     "jest-snapshot": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.0.tgz",
-      "integrity": "sha512-vFGmNGWHMBomrlOpheTMoqihymovuH3GqfmaEIWoPpsxUXyxT3IlbxI5I4m2vg0uv3HUJYg5JoGrkgMzVsAwCg==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
+      "integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
         "@jest/types": "^26.3.0",
         "@types/prettier": "^2.0.0",
         "chalk": "^4.0.0",
-        "expect": "^26.4.0",
+        "expect": "^26.4.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^26.4.0",
+        "jest-diff": "^26.4.2",
         "jest-get-type": "^26.3.0",
         "jest-haste-map": "^26.3.0",
-        "jest-matcher-utils": "^26.4.0",
+        "jest-matcher-utils": "^26.4.2",
         "jest-message-util": "^26.3.0",
         "jest-resolve": "^26.4.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^26.4.0",
+        "pretty-format": "^26.4.2",
         "semver": "^7.3.2"
       },
       "dependencies": {
@@ -4951,15 +5063,15 @@
           "dev": true
         },
         "jest-diff": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.0.tgz",
-          "integrity": "sha512-wwC38HlOW+iTq6j5tkj/ZamHn6/nrdcEOc/fKaVILNtN2NLWGdkfRaHWwfNYr5ehaLvuoG2LfCZIcWByVj0gjg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^26.3.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.0"
+            "pretty-format": "^26.4.2"
           }
         },
         "jest-get-type": {
@@ -4969,9 +5081,9 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
-          "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
             "@jest/types": "^26.3.0",
@@ -5031,9 +5143,9 @@
       }
     },
     "jest-validate": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.0.tgz",
-      "integrity": "sha512-t56Z/FRMrLP6mpmje7/YgHy0wOzcuc6i3LBXz6kjmsUWYN62OuMdC86Vg9/dX59SvyitSqqegOrx+h7BkNXeaQ==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+      "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
       "dev": true,
       "requires": {
         "@jest/types": "^26.3.0",
@@ -5041,7 +5153,7 @@
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
         "leven": "^3.1.0",
-        "pretty-format": "^26.4.0"
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
         "@jest/types": {
@@ -5089,9 +5201,9 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.0.tgz",
-          "integrity": "sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
             "@jest/types": "^26.3.0",
@@ -5224,10 +5336,10 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema": {
@@ -5402,6 +5514,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -5528,9 +5646,9 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.2.tgz",
-      "integrity": "sha512-ux+n4hPVETuTL8+daJXTOC6uKLgMsl1RYfFv7DKRzyvzBapqco0rZZ9g72ZN8VS6V+gvNYHYa/ofcCY8fkJWsA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+      "integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -5538,7 +5656,7 @@
         "is-wsl": "^2.2.0",
         "semver": "^7.3.2",
         "shellwords": "^0.1.1",
-        "uuid": "^8.2.0",
+        "uuid": "^8.3.0",
         "which": "^2.0.2"
       }
     },
@@ -5811,13 +5929,10 @@
       "dev": true
     },
     "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
-      "requires": {
-        "pify": "^2.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -5877,9 +5992,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -5962,6 +6077,17 @@
         "load-json-file": "^2.0.0",
         "normalize-package-data": "^2.3.2",
         "path-type": "^2.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        }
       }
     },
     "read-pkg-up": {
@@ -6142,6 +6268,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -6155,6 +6287,12 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
     "safe-buffer": {
@@ -6815,9 +6953,9 @@
       "dev": true
     },
     "supports-color": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
@@ -6958,9 +7096,9 @@
       }
     },
     "ts-jest": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.2.0.tgz",
-      "integrity": "sha512-9+y2qwzXdAImgLSYLXAb/Rhq9+K4rbt0417b8ai987V60g2uoNWBBmMkYgutI7D8Zhu+IbCSHbBtrHxB9d7xyA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.3.0.tgz",
+      "integrity": "sha512-Jq2uKfx6bPd9+JDpZNMBJMdMQUC3sJ08acISj8NXlVgR2d5OqslEHOR2KHMgwymu8h50+lKIm0m0xj/ioYdW2Q==",
       "dev": true,
       "requires": {
         "@types/jest": "26.x",
@@ -7066,9 +7204,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "union-value": {
@@ -7124,9 +7262,9 @@
       }
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -7246,22 +7384,14 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
-      "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",
-        "webidl-conversions": "^5.0.0"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-          "dev": true
-        }
+        "webidl-conversions": "^6.1.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",
@@ -24,28 +24,28 @@
   "author": "shivammathur",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.4",
+    "@actions/core": "^1.2.5",
     "@actions/exec": "^1.0.4",
     "@actions/io": "^1.0.2",
     "fs": "0.0.1-security"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.10",
-    "@types/node": "^14.6.0",
-    "@typescript-eslint/eslint-plugin": "^3.9.1",
-    "@typescript-eslint/parser": "^3.9.1",
+    "@types/jest": "^26.0.13",
+    "@types/node": "^14.6.4",
+    "@typescript-eslint/eslint-plugin": "^4.0.1",
+    "@typescript-eslint/parser": "^4.0.1",
     "@zeit/ncc": "^0.22.3",
-    "eslint": "^7.7.0",
+    "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-jest": "^23.20.0",
+    "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.2.5",
-    "jest": "^26.4.0",
-    "jest-circus": "^26.4.0",
-    "prettier": "^2.0.5",
-    "ts-jest": "^26.2.0",
-    "typescript": "^3.9.7"
+    "jest": "^26.4.2",
+    "jest-circus": "^26.4.2",
+    "prettier": "^2.1.1",
+    "ts-jest": "^26.3.0",
+    "typescript": "^4.0.2"
   },
   "husky": {
     "skipCI": true,

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -245,6 +245,9 @@ export async function addExtensionLinux(
         version_extension
       ):
       case /^pdo_oci$|^oci8$/.test(extension):
+      case /^5\.6intl-[\d]+\.[\d]+$|^7\.[0-4]intl-[\d]+\.[\d]+$/.test(
+        version_extension
+      ):
       case /^5\.[3-6]ioncube$|^7\.[0-4]ioncube$/.test(version_extension):
       case /^7\.[0-3]phalcon3$|^7\.[2-4]phalcon4$/.test(version_extension):
       case /^((5\.6)|(7\.[0-4]))gearman$/.test(version_extension):

--- a/src/install.ts
+++ b/src/install.ts
@@ -19,6 +19,8 @@ export async function build(
   version: string,
   os_version: string
 ): Promise<string> {
+  const name = 'setup-php';
+  const url = 'setup-php.com/support';
   // taking inputs
   const extension_csv: string =
     (await utils.getInput('extensions', false)) ||
@@ -47,6 +49,9 @@ export async function build(
   if (ini_values_csv) {
     script += await config.addINIValues(ini_values_csv, os_version);
   }
+
+  script += '\n' + (await utils.stepLog('Support this project', os_version));
+  script += '\n' + (await utils.addLog('$tick', name, url, os_version));
 
   return await utils.writeScript(filename, script);
 }

--- a/src/scripts/ext/intl.sh
+++ b/src/scripts/ext/intl.sh
@@ -1,0 +1,23 @@
+# Function to install ICU
+install_icu() {
+  icu=$1
+  if [ "$(php -i | grep "ICU version =>" | sed -e "s|.*=> s*||")" != "$icu" ]; then
+    sudo curl -o /tmp/icu.tar.zst -sL "https://dl.bintray.com/shivammathur/icu4c/icu4c-$icu.tar.zst"
+    sudo tar -I zstd -xf /tmp/icu.tar.zst -C /usr/local
+    sudo cp -r /usr/local/icu/lib/* /usr/lib/x86_64-linux-gnu/
+  fi
+}
+
+# Function to add ext-intl with the given version of ICU
+add_intl() {
+  icu=$(echo "$1" | cut -d'-' -f 2)
+  supported_version=$(curl "${curl_opts[@]:?}" https://api.bintray.com/packages/shivammathur/icu4c/icu4c | grep -Po "$icu" | head -n 1)
+  if [ "$icu" != "$supported_version" ]; then
+    add_log "${cross:?}" "intl" "ICU $icu is not supported"
+  else
+    install_icu "$icu" >/dev/null 2>&1
+    sudo curl "${curl_opts[@]:?}" -o "${ext_dir:?}/intl.so" "https://dl.bintray.com/shivammathur/icu4c/php${version:?}-intl-$icu.so"
+    enable_extension intl extension
+    add_extension_log intl "Installed and enabled with ICU $icu"
+  fi
+}

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -41,6 +41,7 @@ cleanup_lists() {
     sudo mv /etc/apt/sources.list.d /etc/apt/sources.list.d.save
     sudo mkdir /etc/apt/sources.list.d
     sudo mv /etc/apt/sources.list.d.save/*ondrej*.list /etc/apt/sources.list.d/
+    sudo mv /etc/apt/sources.list.d.save/*dotdeb*.list /etc/apt/sources.list.d/ 2>/dev/null || true
     trap "sudo mv /etc/apt/sources.list.d.save/*.list /etc/apt/sources.list.d/" exit
   fi
 }

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -125,7 +125,10 @@ delete_extension() {
   sudo sed -i "/$extension/d" "$pecl_file"
   sudo rm -rf "$scan_dir"/*"$extension"* >/dev/null 2>&1
   sudo rm -rf "$ext_dir"/"$extension".so >/dev/null 2>&1
-  [ "$runner" = "self-hosted" ] && $apt_remove "php-$extension"
+  if [ "$runner" = "self-hosted" ]; then
+    $apt_remove "php-$extension" >/dev/null 2>&1 || true
+    $apt_remove "php$version-$extension" >/dev/null 2>&1 || true
+  fi
 }
 
 # Function to disable and delete extensions.

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -230,7 +230,7 @@ add_extension_from_source() {
   (
     add_devtools
     delete_extension "$extension"
-    curl -o /tmp/"$extension".tar.gz "${curl_opts[@]}" https://github.com/"$repo"/archive/"$release".tar.gz
+    curl -o /tmp/"$extension".tar.gz  "${curl_opts[@]}" https://github.com/"$repo"/archive/"$release".tar.gz
     tar xf /tmp/"$extension".tar.gz -C /tmp
     cd /tmp/"$extension-$release" || exit 1
     phpize  && ./configure "$args" && make && sudo make install

--- a/src/scripts/tools/blackfire.ps1
+++ b/src/scripts/tools/blackfire.ps1
@@ -1,5 +1,9 @@
 # Function to add blackfire and blackfire-agent.
 Function Add-Blackfire() {
+  $arch_name ='amd64'
+  if(-not([Environment]::Is64BitOperatingSystem) -or $version -lt '7.0') {
+    $arch_name = '386'
+  }
   $agent_version = (Invoke-RestMethod https://blackfire.io/api/v1/releases).agent
   $url = "https://packages.blackfire.io/binaries/blackfire-agent/${agent_version}/blackfire-agent-windows_${arch_name}.zip"
   Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $bin_dir\blackfire.zip >$null 2>&1

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -289,10 +289,8 @@ $master_version = '8.0'
 $cert_source='CurrentUser'
 
 $arch = 'x64'
-$arch_name ='amd64'
 if(-not([Environment]::Is64BitOperatingSystem) -or $version -lt '7.0') {
   $arch = 'x86'
-  $arch_name = '386'
 }
 
 $ts = $env:PHPTS -eq 'ts'

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -333,11 +333,8 @@ if ($null -eq $installed -or -not("$($installed.Version).".StartsWith(($version 
   }
   if ($version -eq $master_version) {
     $version = 'master'
-    Invoke-WebRequest -UseBasicParsing -Uri https://dl.bintray.com/shivammathur/php/Install-PhpMaster.ps1 -OutFile $php_dir\Install-PhpMaster.ps1 > $null 2>&1
-    & $php_dir\Install-PhpMaster.ps1 -Architecture $arch -ThreadSafe $ts -Path $php_dir
-  } else {
-    Install-Php -Version $version -Architecture $arch -ThreadSafe $ts -InstallVC -Path $php_dir -TimeZone UTC -InitialPhpIni Production -Force > $null 2>&1
   }
+  Install-Php -Version $version -Architecture $arch -ThreadSafe $ts -InstallVC -Path $php_dir -TimeZone UTC -InitialPhpIni Production -Force > $null 2>&1
 } else {
   if($env:update -eq 'true') {
     Update-Php $php_dir >$null 2>&1
@@ -357,6 +354,12 @@ if($version -lt "5.5") {
   Enable-PhpExtension -Extension openssl, curl, mbstring -Path $php_dir
 } else {
   Enable-PhpExtension -Extension openssl, curl, opcache, mbstring -Path $php_dir
+}
+if($version -eq "master") {
+  "xdebug", "pcov" | ForEach-Object { Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/shivammathur/php-extensions-windows/releases/latest/download/php_$env:PHPTS`_$arch`_$_.dll" -OutFile $ext_dir"\php`_$_.dll" }
+  Rename-Item $ext_dir\php_oci8_12c.dll -NewName $ext_dir\php_oci8.dll
+  Set-PhpIniKey -Key 'opcache.jit_buffer_size' -Value '256M' -Path $php_dir
+  Set-PhpIniKey -Key 'opcache.jit' -Value '1235' -Path $php_dir
 }
 Update-PhpCAInfo -Path $php_dir -Source $cert_source
 Add-Log $tick "PHP" "$status PHP $($installed.FullVersion)"

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -76,7 +76,7 @@ Function Get-CleanPSProfile {
 # Function to install PhpManager.
 Function Install-PhpManager() {
   $repo = "mlocati/powershell-phpmanager"
-  $tag = (Invoke-RestMethod https://api.github.com/repos/$repo/tags)[0].Name
+  $tag = (Invoke-RestMethod https://api.github.com/repos/$repo/releases/latest).tag_name
   $module_path = "$bin_dir\PhpManager\powershell-phpmanager-$tag\PhpManager\PhpManager.psm1"
   if(-not (Test-Path $module_path -PathType Leaf)) {
     $zip_file = "$bin_dir\PhpManager.zip"

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -346,13 +346,11 @@ export async function getCleanedToolsList(
  * Helper function to get script to setup a tool using a phar url
  *
  * @param tool
- * @param version
  * @param url
  * @param os_version
  */
 export async function addArchive(
   tool: string,
-  version: string,
   url: string,
   os_version: string
 ): Promise<string> {
@@ -449,22 +447,22 @@ export async function addTools(
         break;
       case 'blackfire-player':
         url = await getPharUrl('https://get.blackfire.io', tool, 'v', version);
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'codeception':
         url =
           'https://codeception.com/' +
           (await getCodeceptionUri(version, php_version));
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'composer':
         url = await getComposerUrl(version);
-        script += await addArchive('composer', version, url, os_version);
+        script += await addArchive('composer', url, os_version);
         break;
       case 'composer-normalize':
         uri = await getUri(tool, '.phar', version, 'releases', '', 'download');
         url = github + 'ergebnis/composer-normalize/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'composer-prefetcher':
         script += await addPackage(
@@ -477,35 +475,35 @@ export async function addTools(
       case 'composer-require-checker':
         uri = await getUri(tool, '.phar', version, 'releases', '', 'download');
         url = github + 'maglnet/ComposerRequireChecker/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'composer-unused':
         uri = await getUri(tool, '.phar', version, 'releases', '', 'download');
         url = github + 'composer-unused/composer-unused/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'cs2pr':
         uri = await getUri(tool, '', version, 'releases', '', 'download');
         url = github + 'staabm/annotate-pull-request-from-checkstyle/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'deployer':
         url = await getDeployerUrl(version);
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'flex':
         script += await addPackage(tool, release, 'symfony/', os_version);
         break;
       case 'infection':
         url = github + 'infection/infection/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'pecl':
         script += await utils.getCommand(os_version, 'pecl');
         break;
       case 'phan':
         url = github + 'phan/phan/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'phinx':
         script += await addPackage(tool, release, 'robmorgan/', os_version);
@@ -520,48 +518,48 @@ export async function addTools(
       case 'php-cs-fixer':
         uri = await getUri(tool, '.phar', version, 'releases', 'v', 'download');
         url = github + 'FriendsOfPHP/PHP-CS-Fixer/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'phpcbf':
       case 'phpcs':
         url = github + 'squizlabs/PHP_CodeSniffer/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'phpcpd':
       case 'phpunit':
         url = await getPharUrl('https://phar.phpunit.de', tool, '', version);
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'phplint':
         script += await addPackage(tool, release, 'overtrue/', os_version);
         break;
       case 'phpmd':
         url = github + 'phpmd/phpmd/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'phpstan':
         url = github + 'phpstan/phpstan/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'prestissimo':
         script += await addPackage(tool, release, 'hirak/', os_version);
         break;
       case 'psalm':
         url = github + 'vimeo/psalm/' + uri;
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       case 'symfony':
       case 'symfony-cli':
         uri = await getSymfonyUri(version, os_version);
         url = github + 'symfony/cli/' + uri;
-        script += await addArchive('symfony', version, url, os_version);
+        script += await addArchive('symfony', url, os_version);
         break;
       case 'vapor-cli':
         script += await addPackage(tool, release, 'laravel/', os_version);
         break;
       case 'wp-cli':
         url = github + (await getWpCliUrl(version));
-        script += await addArchive(tool, version, url, os_version);
+        script += await addArchive(tool, url, os_version);
         break;
       default:
         script += await utils.addLog(

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -505,6 +505,10 @@ export async function addTools(
         url = github + 'phan/phan/' + uri;
         script += await addArchive(tool, url, os_version);
         break;
+      case 'phing':
+        url = 'https://www.phing.info/get/phing-' + version + '.phar';
+        script += await addArchive(tool, url, os_version);
+        break;
       case 'phinx':
         script += await addPackage(tool, release, 'robmorgan/', os_version);
         break;


### PR DESCRIPTION
- Add support for `phing`. Closes #275
```yml
- name: Setup PHP with phing
  uses: shivammathur/setup-php@v2
  with:
    php-version: '7.4'
    tools: phing
```
- Add support to install `intl` extension with different `ICU` versions for `PHP 5.6` to `PHP 7.4` on `Ubuntu`.
`ICU 50.2` and newer versions are supported. Refer to [ICU builds](https://github.com/shivammathur/icu-intl#icu4c-builds) for the specific versions supported. Closes #282.
```yml
- name: Setup PHP with intl and ICU 67.1
  uses: shivammathur/setup-php@v2
  with:
    php-version: '7.4'
    extensions: intl-67.1
```
- Add `printf` to `PATH` if not found in `Windows`.
- Add [status page](https://setup-php.statuspage.io) badge in `README`.
- Revert to `Powershell PhpManager` to install `PHP 8` on `Windows`. (Ref: mlocati/powershell-phpmanager#62).
- Switch from tags to releases and use release assets to get `Powershell PhpManager`.
- Fix installing extensions from `Dotdeb` PPA for `PHP 5.4` and `PHP 5.5`. Ref: #281.
- Fix removing extensions for `Ubuntu` self-hosted runners.
- Replace `fedora` references with a valid platform name to validate against `process.platform`.
- Refactor `tools.ts` and `win32.ps1`.
- Bump `Typescript` version to `4.0.1`.
- Bump version to `2.5.0`.

Thanks @mlocati for the contributions 🎉 