### PR TITLE
Specify PHP version when installing ast

### DIFF
--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -70,7 +70,7 @@ describe('Extension tests', () => {
       'sudo $debconf_fix apt-get install -y php7.4-sqlite3'
     );
     expect(linux).toContain('remove_extension intl');
-    expect(linux).toContain('sudo $debconf_fix apt-get install -y php-ast');
+    expect(linux).toContain('sudo $debconf_fix apt-get install -y php7.4-ast');
     expect(linux).toContain('sudo $debconf_fix apt-get install -y php-uopz');
     expect(linux).toContain('add_unstable_extension ast beta extension');
     expect(linux).toContain('add_pdo_extension mysql');

--- a/dist/index.js
+++ b/dist/index.js
@@ -3052,8 +3052,8 @@ async function addExtensionLinux(extension_csv, version, pipe) {
                 extension = extension.replace(/pdo[_-]|3/, '');
                 add_script += '\nadd_pdo_extension ' + extension;
                 return;
-            // match ast and uopz
-            case /^(ast|uopz)$/.test(extension):
+            // match uopz
+            case /^(uopz)$/.test(extension):
                 command = command_prefix + '-' + extension + pipe;
                 break;
             // match sqlite

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -295,8 +295,8 @@ export async function addExtensionLinux(
         extension = extension.replace(/pdo[_-]|3/, '');
         add_script += '\nadd_pdo_extension ' + extension;
         return;
-      // match ast and uopz
-      case /^(ast|uopz)$/.test(extension):
+      // match uopz
+      case /^(uopz)$/.test(extension):
         command = command_prefix + '-' + extension + pipe;
         break;
       // match sqlite


### PR DESCRIPTION
- Specify PHP version when installing ast. Fixes #305 
`apt-get install php-ast` is now `apt-get install php<version>-ast`.