### PR TITLE
Perform only one URL call to download latest PhpManager.zip asset

### DIFF
--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -91,9 +91,8 @@ Function Get-CleanPSProfile {
 Function Install-PhpManager() {
   $module_path = "$bin_dir\PhpManager\PhpManager.psm1"
   if(-not (Test-Path $module_path -PathType Leaf)) {
-    $release = Invoke-RestMethod https://api.github.com/repos/mlocati/powershell-phpmanager/releases/latest
     $zip_file = "$bin_dir\PhpManager.zip"
-    Invoke-WebRequest -UseBasicParsing -Uri $release.assets[0].browser_download_url -OutFile $zip_file
+    Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/mlocati/powershell-phpmanager/releases/latest/download/PhpManager.zip' -OutFile $zip_file
     Expand-Archive -Path $zip_file -DestinationPath $bin_dir -Force
   }
   Import-Module $module_path


### PR DESCRIPTION
Let's avoid making an unnecessary REST call, and make the code a bit more solid (previously we assumed that PhpManager.zip is the first asset, but it may not be so in future).