### PR TITLE
Allow installing a specific Composer version

### DIFF
--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -267,6 +267,15 @@ describe('Tools tests', () => {
     expect(await tools.getComposerUrl('2')).toContain(
       'https://getcomposer.org/composer-2.phar'
     );
+    expect(await tools.getComposerUrl('1.7.2')).toContain(
+      'https://github.com/composer/composer/releases/download/1.7.2/composer.phar'
+    );
+    expect(await tools.getComposerUrl('2.0.0-RC2')).toContain(
+      'https://github.com/composer/composer/releases/download/2.0.0-RC2/composer.phar'
+    );
+    expect(await tools.getComposerUrl('wrong')).toContain(
+      'https://getcomposer.org/composer-stable.phar'
+    );
   });
 
   it('checking getSymfonyUri', async () => {

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -222,9 +222,17 @@ describe('Tools tests', () => {
       'a',
       'b'
     ]);
+    expect(await tools.addComposer(['a', 'b', 'composer:1.2'])).toStrictEqual([
+      'composer',
+      'a',
+      'b'
+    ]);
     expect(
       await tools.addComposer(['a', 'b', 'composer:1.2.3'])
-    ).toStrictEqual(['composer', 'a', 'b']);
+    ).toStrictEqual(['composer:1.2.3', 'a', 'b']);
+    expect(
+      await tools.addComposer(['a', 'b', 'composer:v1.2.3'])
+    ).toStrictEqual(['composer:1.2.3', 'a', 'b']);
     expect(
       await tools.addComposer(['a', 'b', 'composer:snapshot'])
     ).toStrictEqual(['composer:snapshot', 'a', 'b']);
@@ -304,7 +312,7 @@ describe('Tools tests', () => {
 
   it('checking getCleanedToolsList', async () => {
     const tools_list: string[] = await tools.getCleanedToolsList(
-      'tool, composer:1.2.3, behat/behat, icanhazstring/composer-unused, laravel/vapor-cli, robmorgan/phinx, phpspec/phpspec, symfony/flex'
+      'tool, composer:1.2, behat/behat, icanhazstring/composer-unused, laravel/vapor-cli, robmorgan/phinx, phpspec/phpspec, symfony/flex'
     );
     expect(tools_list).toStrictEqual([
       'composer',

--- a/dist/index.js
+++ b/dist/index.js
@@ -2022,7 +2022,7 @@ exports.getWpCliUrl = getWpCliUrl;
  */
 async function addComposer(tools_list) {
     const regex_any = /^composer($|:.*)/;
-    const regex_valid = /^composer:?($|preview$|snapshot$|v?[1-2]$)/;
+    const regex_valid = /^composer:?($|preview$|snapshot$|v?[1-2]$|v?\d+\.\d+\.\d+[\w-]*$)/;
     const regex_composer1_tools = /hirak|prestissimo|narrowspark|composer-prefetcher/;
     const matches = tools_list.filter(tool => regex_valid.test(tool));
     let composer = 'composer';
@@ -2034,7 +2034,7 @@ async function addComposer(tools_list) {
         case matches[0] == undefined:
             break;
         default:
-            composer = matches[matches.length - 1].replace(/v([1-2])/, '$1');
+            composer = matches[matches.length - 1].replace(/v(\d\S*)/, '$1');
             break;
     }
     tools_list.unshift(composer);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2058,6 +2058,10 @@ async function getComposerUrl(version) {
         case '2':
             return (cache_url + 'https://getcomposer.org/composer-' + version + '.phar');
         default:
+            if (/^\d+\.\d+\.\d+[\w-]*$/.test(version)) {
+                return (cache_url +
+                    `https://github.com/composer/composer/releases/download/${version}/composer.phar`);
+            }
             return cache_url + 'https://getcomposer.org/composer-stable.phar';
     }
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -305,7 +305,7 @@ export async function getWpCliUrl(version: string): Promise<string> {
  */
 export async function addComposer(tools_list: string[]): Promise<string[]> {
   const regex_any = /^composer($|:.*)/;
-  const regex_valid = /^composer:?($|preview$|snapshot$|v?[1-2]$)/;
+  const regex_valid = /^composer:?($|preview$|snapshot$|v?[1-2]$|v?\d+\.\d+\.\d+[\w-]*$)/;
   const regex_composer1_tools = /hirak|prestissimo|narrowspark|composer-prefetcher/;
   const matches: string[] = tools_list.filter(tool => regex_valid.test(tool));
   let composer = 'composer';
@@ -317,7 +317,7 @@ export async function addComposer(tools_list: string[]): Promise<string[]> {
     case matches[0] == undefined:
       break;
     default:
-      composer = matches[matches.length - 1].replace(/v([1-2])/, '$1');
+      composer = matches[matches.length - 1].replace(/v(\d\S*)/, '$1');
       break;
   }
   tools_list.unshift(composer);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -344,6 +344,12 @@ export async function getComposerUrl(version: string): Promise<string> {
         cache_url + 'https://getcomposer.org/composer-' + version + '.phar'
       );
     default:
+      if (/^\d+\.\d+\.\d+[\w-]*$/.test(version)) {
+        return (
+          cache_url +
+          `https://github.com/composer/composer/releases/download/${version}/composer.phar`
+        );
+      }
       return cache_url + 'https://getcomposer.org/composer-stable.phar';
   }
 }


### PR DESCRIPTION
---
name: ⚙ Improvement
about: What about letting users specify a specific Composer version
labels: enhancement

---

### Description

This PR let users specify a specific Composer version. This is useful in particular to test Composer plugins which should support old Composer versions.

- [X] I have written test cases for the changes in this pull request
- [X] I have run `npm run format` before the commit.
- [X] I have run `npm run lint` before the commit.
- [X] I have run `npm run release` before the commit.
- [X] `npm test` returns with no unit test errors and all code covered.
- [X] I have checked the edited scripts for syntax.
- [x] I have tested the changes in an integration test - see https://github.com/mlocati/composer-patcher/actions/runs/337536137
