### PR TITLE
2.8.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,13 +18,6 @@ Due to time constraints, you may not always get a quick response. Please do not 
 
 ## Coding Guidelines
 
-This project comes with `.prettierrc.json` and `eslintrc.json` configuration files. Please run the following commands to format the code before committing it.
-
-```bash
-$ npm run format
-$ npm run lint
-```
-
 ## Using setup-php from a Git checkout
 
 The following commands can be used to perform the initial checkout of setup-php:
@@ -39,6 +32,19 @@ Install setup-php dependencies using [npm](https://www.npmjs.com/):
 
 ```bash
 $ npm install
+```
+
+If you are using `Windows` configure `git` to handle line endings.
+
+```cmd
+git config --local core.autocrlf true
+```
+
+This project comes with `.prettierrc.json` and `eslintrc.json` configuration files. Please run the following commands to fix and verify the code quality.
+
+```bash
+$ npm run format
+$ npm run lint
 ```
 
 ## Running the test suite

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ This PR [briefly explain what it does]
 > In case this PR edits any scripts:
 
 - [ ] I have checked the edited scripts for syntax.
-- [ ] I have tested the changes in an integration test (If yes, provide workflow link).
+- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).
 
 <!--
 - Please target the develop branch when submitting the pull request.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,8 +6,8 @@ The following versions of this project are supported for security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.9.x   | :white_check_mark: |
-| 2.6.x   | :white_check_mark: |
+| 1.10.x  | :white_check_mark: |
+| 2.8.x   | :white_check_mark: |
 
 ## Supported PHP Versions
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,73 @@
+name: Docs workflow
+on:
+  repository_dispatch:
+  schedule:
+    - cron: '0 0 * * 2'
+jobs:
+  create:
+    name: Create
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, windows-2019, macos-10.15, macos-11.0]
+        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Save unix
+        env:
+          file: php${{ matrix.php-versions }}-${{ matrix.operating-system }}.md
+          version: ${{ matrix.php-versions }}
+        if: matrix.operating-system != 'windows-2019'
+        run: |
+          echo "## PHP $version" >> "$file"
+          printf "\n" >> "$file"
+          echo "\`\`\`" >> "$file"
+          php -m >> "$file"
+          echo "\`\`\`" >> "$file"
+          printf "\n" >> "$file"
+      - name: Save Windows
+        env:
+          file: php${{ matrix.php-versions }}-${{ matrix.operating-system }}.md
+          version: ${{ matrix.php-versions }}
+        if: matrix.operating-system == 'windows-2019'
+        run: |
+          Write-Output "## PHP $version`n" | Out-File -FilePath "$env:file"
+          Write-Output "``````" | Out-File -FilePath "$env:file" -Append
+          php -m | Out-File -FilePath "$env:file" -Append
+          Write-Output "```````n" | Out-File -FilePath "$env:file" -Append
+      - uses: actions/upload-artifact@v2
+        with:
+          name: lists
+          path: php${{ matrix.php-versions }}-${{ matrix.operating-system }}.md
+  update:
+    name: Update
+    needs: create
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}.wiki
+      - uses: actions/download-artifact@v2
+        with:
+          path: ${{ github.workspace }}
+      - name: Combine
+        run: |
+          git config --local user.email "${{ secrets.email }}"
+          git config --local user.name "${{ github.repository_owner }}"
+          for os in ubuntu-20.04 ubuntu-18.04 ubuntu-16.04 windows-2019 macos-10.15 macos-11.0; do
+            echo "# PHP Extensions on $os" > Php-extensions-on-"$os".md
+            for version in 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1; do
+              cat lists/php"$version"-"$os".md >> Php-extensions-on-"$os".md
+            done
+          done
+          rm -rf ./lists
+          if [ "$(git status --porcelain=v1 2>/dev/null | wc -l)" != "0" ]; then
+            git add .
+            git commit -m "Update PHP extensions on wiki - $(date +'%d-%m-%y')"
+            git push -f https://${{ github.repository_owner }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git master || true
+          fi

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup cache environment
-        id: extcache
+        id: cache-env
         uses: shivammathur/cache-extensions@develop
         with:
           php-version: ${{ matrix.php-versions }}
@@ -44,9 +44,9 @@ jobs:
       - name: Cache extensions
         uses: actions/cache@v2
         with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
+          path: ${{ steps.cache-env.outputs.dir }}
+          key: ${{ steps.cache-env.outputs.key }}
+          restore-keys: ${{ steps.cache-env.outputs.key }}
 
       - name: Setup PHP with extensions and custom config
         run: node dist/index.js

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ To debug any issues, you can use the `verbose` tag instead of `v2`.
 ### Cache Extensions
 
 You can cache PHP extensions using `shivammathur/cache-extensions` and `action/cache` GitHub Actions. Extensions which take very long to set up when cached are available in the next workflow run and are enabled directly. This reduces the workflow execution time.  
-Refer to [`shivammathur/cache-extensions`](https://github.com/shivammathur/cache-extensions "GitHub Action to cache php extensions") for details. 
+Refer to [`shivammathur/cache-extensions`](https://github.com/shivammathur/cache-extensions "GitHub Action to cache php extensions") for details.
 
 ### Cache Composer Dependencies
 
@@ -563,13 +563,13 @@ If your project uses composer, you can persist the composer's internal cache dir
 
 ```yaml
 - name: Get composer cache directory
-  id: composercache
+  id: composer-cache
   run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
 - name: Cache dependencies
   uses: actions/cache@v2
   with:
-    path: ${{ steps.composercache.outputs.dir }}
+    path: ${{ steps.composer-cache.outputs.dir }}
     key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
     restore-keys: ${{ runner.os }}-composer-
 
@@ -591,13 +591,13 @@ If your project has node.js dependencies, you can persist NPM or yarn cache dire
 
 ```yaml
 - name: Get node.js cache directory
-  id: nodecache
+  id: node-cache-dir
   run: echo "::set-output name=dir::$(npm config get cache)" # Use $(yarn cache dir) for yarn
 
 - name: Cache dependencies
   uses: actions/cache@v2
   with:
-    path: ${{ steps.nodecache.outputs.dir }}
+    path: ${{ steps.node-cache-dir.outputs.dir }}
     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }} # Use '**/yarn.lock' for yarn
     restore-keys: ${{ runner.os }}-node-
 ```

--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ Examples of using `setup-php` with various PHP Frameworks and Packages.
 ## :package: Dependencies
 
 - [Node.js dependencies](https://github.com/shivammathur/setup-php/network/dependencies "Node.js dependencies")
+- [aaronparker/VcRedist](https://github.com/aaronparker/VcRedist "VcRedist PowerShell package")
 - [gplessis/dotdeb-php](https://github.com/gplessis/dotdeb-php "Packaging for end of life PHP versions")
 - [mlocati/powershell-phpmanager](https://github.com/mlocati/powershell-phpmanager "Package to handle PHP on windows")
 - [ppa:ondrej/php](https://launchpad.net/~ondrej/+archive/ubuntu/php "Packaging active PHP packages")

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ These tools can be setup globally using the `tools` input.
     tools: php-cs-fixer, phpunit
 ```
 
-- To set up a particular version of a tool, specify it in the form `tool:version`. The latest stable version of `composer` is set up by default. You can set up the required version by specifying `v1`, `v2`, `snapshot` or `preview` as version.
+- To set up a particular version of a tool, specify it in the form `tool:version`. The latest stable version of `composer` is set up by default. You can set up the required `composer` version by specifying `v1`, `v2`, `snapshot` or `preview` as versions or the exact version in semver format.
 
 ```yaml
 - name: Setup PHP with composer v2
@@ -202,6 +202,8 @@ These tools can be setup globally using the `tools` input.
     php-version: '7.4'
     tools: composer:v2
 ```
+
+- If you have specified composer plugins `prestissimo` or `composer-prefetcher` in tools, the latest stable version of `composer v1` will be setup. Unless some of your packages require `composer v1`, it is recommended to drop `prestissimo` and use `composer v2`.
 
 - The latest versions of both agent `blackfire-agent` and client `blackfire` are setup when `blackfire` is specified in tools input. Please refer to the [official documentation](https://blackfire.io/docs/integrations/ci/github-actions "Blackfire.io documentation for GitHub Actions") for using `blackfire` with GitHub Actions.
 

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -59,31 +59,21 @@ describe('Extension tests', () => {
 
   it('checking addExtensionOnLinux', async () => {
     let linux: string = await extensions.addExtension(
-      'Xdebug, xdebug3, pcov, sqlite, :intl, ast, uopz, ast-beta, pdo_mysql, pdo-odbc, xdebug-alpha, grpc-1.2.3',
+      'Xdebug, xdebug3, pcov, sqlite, :intl, ast, ast-beta, pdo_mysql, pdo-odbc, xdebug-alpha, grpc-1.2.3',
       '7.4',
       'linux'
     );
     expect(linux).toContain(
       'add_extension_from_source xdebug xdebug/xdebug master --enable-xdebug zend_extension'
     );
-    expect(linux).toContain('sudo $debconf_fix apt-get install -y php7.4-pcov');
-    expect(linux).toContain(
-      'sudo $debconf_fix apt-get install -y php7.4-sqlite3'
-    );
+    expect(linux).toContain('add_extension sqlite3');
     expect(linux).toContain('remove_extension intl');
-    expect(linux).toContain('sudo $debconf_fix apt-get install -y php7.4-ast');
-    expect(linux).toContain('sudo $debconf_fix apt-get install -y php-uopz');
     expect(linux).toContain('add_unstable_extension ast beta extension');
     expect(linux).toContain('add_pdo_extension mysql');
     expect(linux).toContain('add_pdo_extension odbc');
     expect(linux).toContain('add_pecl_extension grpc 1.2.3 extension');
     expect(linux).toContain(
       'add_unstable_extension xdebug alpha zend_extension'
-    );
-
-    linux = await extensions.addExtension('xdebug3', '8.0', 'linux');
-    expect(linux).toContain(
-      'sudo $debconf_fix apt-get install -y php8.0-xdebug'
     );
 
     linux = await extensions.addExtension('pcov', '5.6', 'linux');
@@ -134,14 +124,14 @@ describe('Extension tests', () => {
       '7.2',
       'darwin'
     );
-    expect(darwin).toContain('add_brew_extension xdebug');
-    expect(darwin).toContain('add_brew_extension pcov');
-    expect(darwin).toContain('add_brew_extension grpc');
-    expect(darwin).toContain('add_brew_extension igbinary');
-    expect(darwin).toContain('add_brew_extension imagick');
-    expect(darwin).toContain('add_brew_extension protobuf');
-    expect(darwin).toContain('add_brew_extension swoole');
-    expect(darwin).toContain('pecl_install sqlite3');
+    expect(darwin).toContain('add_brew_extension xdebug zend_extension');
+    expect(darwin).toContain('add_brew_extension pcov extension');
+    expect(darwin).toContain('add_brew_extension grpc extension');
+    expect(darwin).toContain('add_brew_extension igbinary extension');
+    expect(darwin).toContain('add_brew_extension imagick extension');
+    expect(darwin).toContain('add_brew_extension protobuf extension');
+    expect(darwin).toContain('add_brew_extension swoole extension');
+    expect(darwin).toContain('add_extension sqlite3');
     expect(darwin).toContain('remove_extension intl');
     expect(darwin).toContain('add_unstable_extension ast beta extension');
     expect(darwin).toContain('add_pecl_extension grpc 1.2.3 extension');
@@ -177,14 +167,13 @@ describe('Extension tests', () => {
     expect(darwin).toContain('add_brew_extension xdebug');
 
     darwin = await extensions.addExtension('redis', '5.6', 'darwin');
-    expect(darwin).toContain('pecl_install redis-2.2.8');
+    expect(darwin).toContain('add_extension redis-2.2.8');
 
     darwin = await extensions.addExtension('redis', '7.2', 'darwin');
-    expect(darwin).toContain('pecl_install redis');
+    expect(darwin).toContain('add_extension redis');
 
     darwin = await extensions.addExtension('imagick', '5.5', 'darwin');
-    expect(darwin).toContain('brew install pkg-config imagemagick');
-    expect(darwin).toContain('pecl_install imagick');
+    expect(darwin).toContain('add_extension imagick');
 
     darwin = await extensions.addExtension('blackfire', '7.3', 'darwin');
     expect(darwin).toContain('add_blackfire blackfire');

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -81,10 +81,15 @@ describe('Extension tests', () => {
       'add_log "$cross" "pcov" "pcov is not supported on PHP 5.6"'
     );
 
-    linux = await extensions.addExtension('gearman', '7.0', 'linux');
+    linux = await extensions.addExtension('gearman', '5.6', 'linux');
     expect(linux).toContain('add_gearman');
     linux = await extensions.addExtension('gearman', '7.4', 'linux');
     expect(linux).toContain('add_gearman');
+
+    linux = await extensions.addExtension('couchbase', '5.6', 'linux');
+    expect(linux).toContain('add_couchbase');
+    linux = await extensions.addExtension('couchbase', '7.4', 'linux');
+    expect(linux).toContain('add_couchbase');
 
     linux = await extensions.addExtension('pdo_cubrid', '7.0', 'linux');
     expect(linux).toContain('add_cubrid pdo_cubrid');
@@ -141,6 +146,12 @@ describe('Extension tests', () => {
 
     darwin = await extensions.addExtension('phalcon4', '7.3', 'darwin');
     expect(darwin).toContain('add_phalcon phalcon4');
+
+    darwin = await extensions.addExtension('couchbase', '5.6', 'darwin');
+    expect(darwin).toContain('add_couchbase');
+
+    darwin = await extensions.addExtension('couchbase', '7.3', 'darwin');
+    expect(darwin).toContain('add_couchbase');
 
     darwin = await extensions.addExtension('ioncube', '7.3', 'darwin');
     expect(darwin).toContain('add_ioncube');

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -3,7 +3,7 @@ import * as extensions from '../src/extensions';
 describe('Extension tests', () => {
   it('checking addExtensionOnWindows', async () => {
     let win32: string = await extensions.addExtension(
-      'Xdebug, pcov, sqlite, :intl, phalcon4, ioncube, oci8, pdo_oci, ast-beta, grpc-1.2.3, inotify-1.2.3alpha2',
+      'Xdebug, pcov, sqlite, :intl, phalcon4, ioncube, oci8, pdo_oci, ast-beta, grpc-1.2.3, inotify-1.2.3alpha2, sqlsrv-1.2.3preview1',
       '7.4',
       'win32'
     );
@@ -18,6 +18,7 @@ describe('Extension tests', () => {
     expect(win32).toContain('Add-Extension ast beta');
     expect(win32).toContain('Add-Extension grpc stable 1.2.3');
     expect(win32).toContain('Add-Extension inotify alpha 1.2.3');
+    expect(win32).toContain('Add-Extension sqlsrv devel 1.2.3');
 
     win32 = await extensions.addExtension('pcov', '5.6', 'win32');
     expect(win32).toContain(

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -278,8 +278,14 @@ describe('Tools tests', () => {
     expect(await tools.getComposerUrl('1.7.2')).toContain(
       'https://github.com/composer/composer/releases/download/1.7.2/composer.phar'
     );
+    expect(await tools.getComposerUrl('1.7.2')).toContain(
+      'https://getcomposer.org/composer-1.7.2.phar'
+    );
     expect(await tools.getComposerUrl('2.0.0-RC2')).toContain(
       'https://github.com/composer/composer/releases/download/2.0.0-RC2/composer.phar'
+    );
+    expect(await tools.getComposerUrl('2.0.0-RC2')).toContain(
+      'https://getcomposer.org/composer-2.0.0-RC2.phar'
     );
     expect(await tools.getComposerUrl('wrong')).toContain(
       'https://getcomposer.org/composer-stable.phar'

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -187,6 +187,21 @@ describe('Tools tests', () => {
     );
   });
 
+  it('checking getBlackfirePlayerUrl', async () => {
+    expect(await tools.getBlackfirePlayerUrl('latest', '7.4')).toBe(
+      'https://get.blackfire.io/blackfire-player.phar'
+    );
+    expect(await tools.getBlackfirePlayerUrl('latest', '5.5')).toBe(
+      'https://get.blackfire.io/blackfire-player-v1.9.3.phar'
+    );
+    expect(await tools.getBlackfirePlayerUrl('latest', '7.0')).toBe(
+      'https://get.blackfire.io/blackfire-player-v1.9.3.phar'
+    );
+    expect(await tools.getBlackfirePlayerUrl('1.2.3', '7.0')).toBe(
+      'https://get.blackfire.io/blackfire-player-v1.2.3.phar'
+    );
+  });
+
   it('checking getDeployerUri', async () => {
     expect(await tools.getDeployerUrl('latest')).toBe(
       'https://deployer.org/deployer.phar'

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -228,6 +228,9 @@ describe('Tools tests', () => {
     expect(
       await tools.addComposer(['a', 'b', 'c', 'composer:v2'])
     ).toStrictEqual(['composer:2', 'a', 'b', 'c']);
+    expect(
+      await tools.addComposer(['hirak', 'b', 'c', 'composer:v2'])
+    ).toStrictEqual(['composer:1', 'hirak', 'b', 'c']);
   });
 
   it('checking getComposerUrl', async () => {
@@ -277,7 +280,7 @@ describe('Tools tests', () => {
 
   it('checking getCleanedToolsList', async () => {
     const tools_list: string[] = await tools.getCleanedToolsList(
-      'tool, composer:1.2.3, behat/behat, icanhazstring/composer-unused, laravel/vapor-cli, robmorgan/phinx, hirak/prestissimo, narrowspark/automatic-composer-prefetcher, phpspec/phpspec, symfony/flex'
+      'tool, composer:1.2.3, behat/behat, icanhazstring/composer-unused, laravel/vapor-cli, robmorgan/phinx, phpspec/phpspec, symfony/flex'
     );
     expect(tools_list).toStrictEqual([
       'composer',
@@ -286,8 +289,6 @@ describe('Tools tests', () => {
       'composer-unused',
       'vapor-cli',
       'phinx',
-      'prestissimo',
-      'composer-prefetcher',
       'phpspec',
       'flex'
     ]);
@@ -433,7 +434,6 @@ describe('Tools tests', () => {
       'blackfire',
       'blackfire-player',
       'composer-normalize',
-      'composer-prefetcher:1.2.3',
       'composer-require-checker',
       'composer-unused',
       'cs2pr:1.2.3',
@@ -523,9 +523,6 @@ describe('Tools tests', () => {
       'add_composertool composer-unused composer-unused icanhazstring/'
     );
     expect(script).toContain(
-      'add_composertool composer-prefetcher composer-prefetcher:1.2.3 narrowspark/automatic-'
-    );
-    expect(script).toContain(
       'add_tool https://github.com/symfony/cli/releases/latest/download/symfony_darwin_amd64 symfony version'
     );
     expect(script).toContain(
@@ -551,7 +548,6 @@ describe('Tools tests', () => {
       'php-config',
       'phpize',
       'phpmd',
-      'prestissimo',
       'symfony',
       'wp-cli'
     ];
@@ -576,7 +572,6 @@ describe('Tools tests', () => {
     expect(script).toContain(
       'Add-Tool https://deployer.org/deployer.phar deployer "-V"'
     );
-    expect(script).toContain('Add-Composertool prestissimo prestissimo hirak/');
     expect(script).toContain(
       'Add-Tool https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar phpmd "--version"'
     );
@@ -608,7 +603,7 @@ describe('Tools tests', () => {
     );
 
     expect(script).toContain(
-      'Add-Tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-stable.phar,https://getcomposer.org/composer-stable.phar composer'
+      'Add-Tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-1.phar,https://getcomposer.org/composer-1.phar composer'
     );
     expect(script).toContain('Add-Composertool prestissimo prestissimo hirak/');
     expect(script).toContain('Add-Composertool phinx phinx robmorgan/');

--- a/dist/index.js
+++ b/dist/index.js
@@ -2974,9 +2974,9 @@ async function addExtensionWindows(extension_csv, version) {
                 add_script += await utils.joins('\nAdd-Extension', ext_name, 'stable', ext_version);
                 break;
             // match semver with state
-            case /.*-(\d+\.\d+\.\d)(beta|alpha|devel|snapshot)\d*/.test(version_extension):
-                matches = /.*-(\d+\.\d+\.\d)(beta|alpha|devel|snapshot)\d*/.exec(version_extension);
-                add_script += await utils.joins('\nAdd-Extension', ext_name, matches[2], matches[1]);
+            case /.*-(\d+\.\d+\.\d)([a-zA-Z+]+)\d*/.test(version_extension):
+                matches = /.*-(\d+\.\d+\.\d)([a-zA-Z+]+)\d*/.exec(version_extension);
+                add_script += await utils.joins('\nAdd-Extension', ext_name, matches[2].replace('preview', 'devel'), matches[1]);
                 break;
             // match 5.3pcov to 7.0pcov
             case /(5\.[3-6]|7\.0)pcov/.test(version_extension):

--- a/dist/index.js
+++ b/dist/index.js
@@ -2884,10 +2884,12 @@ async function addExtensionDarwin(extension_csv, version) {
             // match pdo_oci and oci8
             // match 5.3ioncube...7.4ioncube, 7.0ioncube...7.4ioncube
             // match 7.0phalcon3...7.3phalcon3 and 7.2phalcon4...7.4phalcon4
+            // match 5.6couchbase...7.4couchbase
             case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(version_extension):
             case /^pdo_oci$|^oci8$/.test(extension):
             case /^5\.[3-6]ioncube$|^7\.[0-4]ioncube$/.test(version_extension):
             case /^7\.[0-3]phalcon3$|^7\.[2-4]phalcon4$/.test(version_extension):
+            case /^5\.6couchbase$|^7\.[0-4]couchbase$/.test(version_extension):
                 add_script += await utils.customPackage(ext_name, 'ext', extension, 'darwin');
                 return;
             // match pre-release versions. For example - xdebug-beta
@@ -3024,14 +3026,14 @@ async function addExtensionLinux(extension_csv, version) {
             // match pdo_oci and oci8
             // match 5.3ioncube...7.4ioncube, 7.0ioncube...7.4ioncube
             // match 7.0phalcon3...7.3phalcon3 and 7.2phalcon4...7.4phalcon4
-            // match 5.6gearman..7.4gearman
+            // match 5.6gearman...7.4gearman, 5.6couchbase...7.4couchbase
             case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(version_extension):
             case /^((5\.[3-6])|(7\.[0-2]))pdo_cubrid$|^((5\.[3-6])|(7\.[0-4]))cubrid$/.test(version_extension):
             case /^pdo_oci$|^oci8$/.test(extension):
             case /^5\.6intl-[\d]+\.[\d]+$|^7\.[0-4]intl-[\d]+\.[\d]+$/.test(version_extension):
             case /^5\.[3-6]ioncube$|^7\.[0-4]ioncube$/.test(version_extension):
             case /^7\.[0-3]phalcon3$|^7\.[2-4]phalcon4$/.test(version_extension):
-            case /^((5\.6)|(7\.[0-4]))gearman$/.test(version_extension):
+            case /^((5\.6)|(7\.[0-4]))(gearman|couchbase)$/.test(version_extension):
                 add_script += await utils.customPackage(ext_name, 'ext', extension, 'linux');
                 return;
             // match pre-release versions. For example - xdebug-beta

--- a/dist/index.js
+++ b/dist/index.js
@@ -2047,22 +2047,17 @@ exports.addComposer = addComposer;
  * @param version
  */
 async function getComposerUrl(version) {
-    const cache_url = 'https://github.com/shivammathur/composer-cache/releases/latest/download/composer-' +
-        version.replace('latest', 'stable') +
-        '.phar,';
-    switch (version) {
-        case 'snapshot':
-            return cache_url + 'https://getcomposer.org/composer.phar';
-        case 'preview':
-        case '1':
-        case '2':
-            return (cache_url + 'https://getcomposer.org/composer-' + version + '.phar');
+    let cache_url = `https://github.com/shivammathur/composer-cache/releases/latest/download/composer-${version.replace('latest', 'stable')}.phar`;
+    switch (true) {
+        case /^snapshot$/.test(version):
+            return `${cache_url},https://getcomposer.org/composer.phar`;
+        case /^preview$|^[1-2]$/.test(version):
+            return `${cache_url},https://getcomposer.org/composer-${version}.phar`;
+        case /^\d+\.\d+\.\d+[\w-]*$/.test(version):
+            cache_url = `https://github.com/composer/composer/releases/download/${version}/composer.phar`;
+            return `${cache_url},https://getcomposer.org/composer-${version}.phar`;
         default:
-            if (/^\d+\.\d+\.\d+[\w-]*$/.test(version)) {
-                return (cache_url +
-                    `https://github.com/composer/composer/releases/download/${version}/composer.phar`);
-            }
-            return cache_url + 'https://getcomposer.org/composer-stable.phar';
+            return `${cache_url},https://getcomposer.org/composer-stable.phar`;
     }
 }
 exports.getComposerUrl = getComposerUrl;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1764,7 +1764,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.addTools = exports.addPackage = exports.addDevTools = exports.addArchive = exports.getCleanedToolsList = exports.getComposerUrl = exports.addComposer = exports.getWpCliUrl = exports.getSymfonyUri = exports.getDeployerUrl = exports.getPharUrl = exports.addPhive = exports.getCodeceptionUri = exports.getCodeceptionUriBuilder = exports.getUri = exports.parseTool = exports.getToolVersion = void 0;
+exports.addTools = exports.addPackage = exports.addDevTools = exports.addArchive = exports.getCleanedToolsList = exports.getComposerUrl = exports.addComposer = exports.getWpCliUrl = exports.getSymfonyUri = exports.getDeployerUrl = exports.getBlackfirePlayerUrl = exports.getPharUrl = exports.addPhive = exports.getCodeceptionUri = exports.getCodeceptionUriBuilder = exports.getUri = exports.parseTool = exports.getToolVersion = void 0;
 const utils = __importStar(__webpack_require__(163));
 /**
  * Function to get tool version
@@ -1942,6 +1942,23 @@ async function getPharUrl(domain, tool, prefix, version) {
     }
 }
 exports.getPharUrl = getPharUrl;
+/**
+ * Function to get blackfire player url for a PHP version.
+ *
+ * @param version
+ * @param php_version
+ */
+async function getBlackfirePlayerUrl(version, php_version) {
+    switch (true) {
+        case /5\.[5-6]|7\.0/.test(php_version) && version == 'latest':
+            version = '1.9.3';
+            break;
+        default:
+            break;
+    }
+    return await getPharUrl('https://get.blackfire.io', 'blackfire-player', 'v', version);
+}
+exports.getBlackfirePlayerUrl = getBlackfirePlayerUrl;
 /**
  * Function to get the Deployer url
  *
@@ -2136,7 +2153,7 @@ async function addTools(tools_csv, php_version, os_version) {
                 script += await addPackage(tool, release, tool + '/', os_version);
                 break;
             case 'blackfire-player':
-                url = await getPharUrl('https://get.blackfire.io', tool, 'v', version);
+                url = await getBlackfirePlayerUrl(version, php_version);
                 script += await addArchive(tool, url, os_version, '"-V"');
                 break;
             case 'codeception':

--- a/dist/index.js
+++ b/dist/index.js
@@ -2006,11 +2006,15 @@ exports.getWpCliUrl = getWpCliUrl;
 async function addComposer(tools_list) {
     const regex_any = /^composer($|:.*)/;
     const regex_valid = /^composer:?($|preview$|snapshot$|v?[1-2]$)/;
+    const regex_composer1_tools = /hirak|prestissimo|narrowspark|composer-prefetcher/;
     const matches = tools_list.filter(tool => regex_valid.test(tool));
     let composer = 'composer';
     tools_list = tools_list.filter(tool => !regex_any.test(tool));
-    switch (matches[0]) {
-        case undefined:
+    switch (true) {
+        case regex_composer1_tools.test(tools_list.join(' ')):
+            composer = 'composer:1';
+            break;
+        case matches[0] == undefined:
             break;
         default:
             composer = matches[matches.length - 1].replace(/v([1-2])/, '$1');

--- a/examples/bedrock.yml
+++ b/examples/bedrock.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/cakephp-mysql.yml
+++ b/examples/cakephp-mysql.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Start mysql service
         run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -70,12 +70,12 @@ jobs:
           php-version: '7.3'
           extensions: mbstring, intl
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -98,12 +98,12 @@ jobs:
           extensions: mbstring, intl
           tools: phpstan
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/cakephp-postgres.yml
+++ b/examples/cakephp-postgres.yml
@@ -35,12 +35,12 @@ jobs:
           extensions: mbstring, intl, redis, pdo_pgsql
           coverage: pcov
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -68,12 +68,12 @@ jobs:
           php-version: '7.3'
           extensions: mbstring, intl
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -96,12 +96,12 @@ jobs:
           extensions: mbstring, intl
           tools: phpstan
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/cakephp.yml
+++ b/examples/cakephp.yml
@@ -19,12 +19,12 @@ jobs:
           extensions: mbstring, intl, pdo_sqlite, pdo_mysql
           coverage: pcov #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -48,12 +48,12 @@ jobs:
           php-version: '7.3'
           extensions: mbstring, intl
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -76,12 +76,12 @@ jobs:
           extensions: mbstring, intl
           tools: phpstan
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/codeigniter.yml
+++ b/examples/codeigniter.yml
@@ -18,12 +18,12 @@ jobs:
           extensions: mbstring, intl, curl, dom
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/laravel-mysql.yml
+++ b/examples/laravel-mysql.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Start mysql service
         run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/laravel-postgres.yml
+++ b/examples/laravel-postgres.yml
@@ -44,12 +44,12 @@ jobs:
           extensions: mbstring, dom, fileinfo, pgsql
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/laravel.yml
+++ b/examples/laravel.yml
@@ -20,12 +20,12 @@ jobs:
           extensions: mbstring, dom, fileinfo
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/lumen-mysql.yml
+++ b/examples/lumen-mysql.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Start mysql service
         run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/lumen-postgres.yml
+++ b/examples/lumen-postgres.yml
@@ -44,12 +44,12 @@ jobs:
           extensions: mbstring, dom, fileinfo, pgsql
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/lumen.yml
+++ b/examples/lumen.yml
@@ -20,12 +20,12 @@ jobs:
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/phalcon-mysql.yml
+++ b/examples/phalcon-mysql.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Start mysql service
         run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/phalcon-postgres.yml
+++ b/examples/phalcon-postgres.yml
@@ -43,12 +43,12 @@ jobs:
           extensions: mbstring, dom, zip, phalcon4, pgsql #use phalcon3 for the phalcon 3.x
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/sage.yml
+++ b/examples/sage.yml
@@ -33,12 +33,12 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/slim-framework.yml
+++ b/examples/slim-framework.yml
@@ -18,12 +18,12 @@ jobs:
           extensions: mbstring, simplexml, dom
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/symfony-mysql.yml
+++ b/examples/symfony-mysql.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Start mysql service
         run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/symfony-postgres.yml
+++ b/examples/symfony-postgres.yml
@@ -29,12 +29,12 @@ jobs:
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, pgsql
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/symfony.yml
+++ b/examples/symfony.yml
@@ -20,12 +20,12 @@ jobs:
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/yii2-mysql.yml
+++ b/examples/yii2-mysql.yml
@@ -41,12 +41,12 @@ jobs:
       - name: Start mysql service
         run: sudo /etc/init.d/mysql start
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/yii2-postgres.yml
+++ b/examples/yii2-postgres.yml
@@ -39,12 +39,12 @@ jobs:
           extensions: mbstring, intl, gd, imagick, zip, dom, pgsql
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/examples/zend-framework.yml
+++ b/examples/zend-framework.yml
@@ -18,12 +18,12 @@ jobs:
           extensions: mbstring, bcmath, curl, intl
           coverage: xdebug #optional
       - name: Get composer cache directory
-        id: composercache
+        id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composercache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           # Use composer.json for key, if composer.lock is not committed.
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -79,12 +79,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
-      "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.1",
+        "@babel/types": "^7.12.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -127,12 +127,12 @@
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
-      "integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.1"
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/helper-module-transforms": {
@@ -168,15 +168,15 @@
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
-      "integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+      "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.12.1",
         "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1"
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/helper-simple-access": {
@@ -204,14 +204,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.1.tgz",
-      "integrity": "sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1"
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/highlight": {
@@ -278,9 +278,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
-      "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
+      "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -382,6 +382,15 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+      "integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/template": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -394,17 +403,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
-      "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
+      "integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.1",
+        "@babel/generator": "^7.12.5",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.1",
-        "@babel/types": "^7.12.1",
+        "@babel/parser": "^7.12.5",
+        "@babel/types": "^7.12.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -419,9 +428,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
-      "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+      "version": "7.12.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
+      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -446,9 +455,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-      "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+      "integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -548,82 +557,48 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.0.tgz",
-      "integrity": "sha512-ArGcZWAEYMWmWnc/QvxLDvFmGRPvmHeulhS7FUUAlUGR5vS/SqMfArsGaYmIFEThSotCMnEihwx1h62I1eg5lg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+      "integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^26.6.0",
-        "jest-util": "^26.6.0",
+        "jest-message-util": "^26.6.2",
+        "jest-util": "^26.6.2",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "@jest/core": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.0.tgz",
-      "integrity": "sha512-7wbunxosnC5zXjxrEtTQSblFjRVOT8qz1eSytw8riEeWgegy3ct91NLPEP440CDuWrmW3cOLcEGxIf9q2u6O9Q==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+      "integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.6.0",
-        "@jest/reporters": "^26.6.0",
-        "@jest/test-result": "^26.6.0",
-        "@jest/transform": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/console": "^26.6.2",
+        "@jest/reporters": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^26.6.0",
-        "jest-config": "^26.6.0",
-        "jest-haste-map": "^26.6.0",
-        "jest-message-util": "^26.6.0",
+        "jest-changed-files": "^26.6.2",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.6.0",
-        "jest-resolve-dependencies": "^26.6.0",
-        "jest-runner": "^26.6.0",
-        "jest-runtime": "^26.6.0",
-        "jest-snapshot": "^26.6.0",
-        "jest-util": "^26.6.0",
-        "jest-validate": "^26.6.0",
-        "jest-watcher": "^26.6.0",
+        "jest-resolve": "^26.6.2",
+        "jest-resolve-dependencies": "^26.6.3",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "jest-watcher": "^26.6.2",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -631,38 +606,6 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -675,155 +618,53 @@
       }
     },
     "@jest/environment": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.0.tgz",
-      "integrity": "sha512-l+5MSdiC4rUUrz8xPdj0TwHBwuoqMcAbFnsYDTn5FkenJl8b+lvC5NdJl1tVICGHWnx0fnjdd1luRZ7u3U4xyg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+      "integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
-        "jest-mock": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
+        "jest-mock": "^26.6.2"
       }
     },
     "@jest/fake-timers": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.0.tgz",
-      "integrity": "sha512-7VQpjChrwlwvGNysS10lDBLOVLxMvMtpx0Xo6aIotzNVyojYk0NN0CR8R4T6h/eu7Zva/LB3P71jqwGdtADoag==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+      "integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "@sinonjs/fake-timers": "^6.0.1",
         "@types/node": "*",
-        "jest-message-util": "^26.6.0",
-        "jest-mock": "^26.6.0",
-        "jest-util": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
       }
     },
     "@jest/globals": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.0.tgz",
-      "integrity": "sha512-rs3a/a8Lq8FgTx11SxbqIU2bDjsFU2PApl2oK2oUVlo84RSF76afFm2nLojW93AGssr715GHUwhq5b6mpCI5BQ==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+      "integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.6.0",
-        "@jest/types": "^26.6.0",
-        "expect": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
+        "@jest/environment": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "expect": "^26.6.2"
       }
     },
     "@jest/reporters": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.0.tgz",
-      "integrity": "sha512-PXbvHhdci5Rj1VFloolgLb+0kkdtzswhG8MzVENKJRI3O1ndwr52G6E/2QupjwrRcYnApZOelFf4nNpf5+SDxA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+      "integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^26.6.0",
-        "@jest/test-result": "^26.6.0",
-        "@jest/transform": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/console": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -834,56 +675,22 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^26.6.0",
-        "jest-resolve": "^26.6.0",
-        "jest-util": "^26.6.0",
-        "jest-worker": "^26.5.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
         "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
-        "v8-to-istanbul": "^6.0.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
+        "v8-to-istanbul": "^7.0.0"
       }
     },
     "@jest/source-map": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
-      "integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+      "integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -892,131 +699,64 @@
       }
     },
     "@jest/test-result": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.0.tgz",
-      "integrity": "sha512-LV6X1ry+sKjseQsIFz3e6XAZYxwidvmeJFnVF08fq98q08dF1mJYI0lDq/LmH/jas+R4s0pwnNGiz1hfC4ZUBw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+      "integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/console": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "@jest/test-sequencer": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.0.tgz",
-      "integrity": "sha512-rWPTMa+8rejvePZnJmnKkmKWh0qILFDPpN0qbSif+KNGvFxqqDGafMo4P2Y8+I9XWrZQBeXL9IxPL4ZzDgRlbw==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+      "integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.6.0",
+        "@jest/test-result": "^26.6.2",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.6.0",
-        "jest-runner": "^26.6.0",
-        "jest-runtime": "^26.6.0"
+        "jest-haste-map": "^26.6.2",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3"
       }
     },
     "@jest/transform": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.0.tgz",
-      "integrity": "sha512-NUNA1NMCyVV9g5NIQF1jzW7QutQhB/HAocteCiUyH0VhmLXnGMTfPYQu1G6IjPk+k1SWdh2PD+Zs1vMqbavWzg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+      "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.6.0",
+        "jest-haste-map": "^26.6.2",
         "jest-regex-util": "^26.0.0",
-        "jest-util": "^26.6.0",
+        "jest-util": "^26.6.2",
         "micromatch": "^4.0.2",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
         "source-map": "^0.6.1",
         "write-file-atomic": "^3.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "@jest/types": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
         "@types/yargs": "^15.0.0",
-        "chalk": "^3.0.0"
+        "chalk": "^4.0.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -1064,9 +804,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
-      "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
+      "integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1086,9 +826,9 @@
       }
     },
     "@types/babel__template": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
-      "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+      "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1105,9 +845,9 @@
       }
     },
     "@types/graceful-fs": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
-      "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+      "integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1129,23 +869,22 @@
       }
     },
     "@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
     },
     "@types/jest": {
-      "version": "26.0.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.14.tgz",
-      "integrity": "sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==",
+      "version": "26.0.15",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.15.tgz",
+      "integrity": "sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==",
       "dev": true,
       "requires": {
-        "jest-diff": "^25.2.1",
-        "pretty-format": "^25.2.1"
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
       }
     },
     "@types/json-schema": {
@@ -1161,9 +900,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
-      "integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1206,13 +945,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.4.1.tgz",
-      "integrity": "sha512-O+8Utz8pb4OmcA+Nfi5THQnQpHSD2sDUNw9AxNHpuYOo326HZTtG8gsfT+EAYuVrFNaLyNb2QnUNkmTRDskuRA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.7.0.tgz",
+      "integrity": "sha512-li9aiSVBBd7kU5VlQlT1AqP0uWGDK6JYKUQ9cVDnOg34VNnd9t4jr0Yqc/bKxJr/tDCPDaB4KzoSFN9fgVxe/Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.4.1",
-        "@typescript-eslint/scope-manager": "4.4.1",
+        "@typescript-eslint/experimental-utils": "4.7.0",
+        "@typescript-eslint/scope-manager": "4.7.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1221,55 +960,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.4.1.tgz",
-      "integrity": "sha512-Nt4EVlb1mqExW9cWhpV6pd1a3DkUbX9DeyYsdoeziKOpIJ04S2KMVDO+SEidsXRH/XHDpbzXykKcMTLdTXH6cQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.7.0.tgz",
+      "integrity": "sha512-cymzovXAiD4EF+YoHAB5Oh02MpnXjvyaOb+v+BdpY7lsJXZQN34oIETeUwVT2XfV9rSNpXaIcknDLfupO/tUoA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.4.1",
-        "@typescript-eslint/types": "4.4.1",
-        "@typescript-eslint/typescript-estree": "4.4.1",
+        "@typescript-eslint/scope-manager": "4.7.0",
+        "@typescript-eslint/types": "4.7.0",
+        "@typescript-eslint/typescript-estree": "4.7.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.4.1.tgz",
-      "integrity": "sha512-S0fuX5lDku28Au9REYUsV+hdJpW/rNW0gWlc4SXzF/kdrRaAVX9YCxKpziH7djeWT/HFAjLZcnY7NJD8xTeUEg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.7.0.tgz",
+      "integrity": "sha512-+meGV8bMP1sJHBI2AFq1GeTwofcGiur8LoIr6v+rEmD9knyCqDlrQcFHR0KDDfldHIFDU/enZ53fla6ReF4wRw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.4.1",
-        "@typescript-eslint/types": "4.4.1",
-        "@typescript-eslint/typescript-estree": "4.4.1",
+        "@typescript-eslint/scope-manager": "4.7.0",
+        "@typescript-eslint/types": "4.7.0",
+        "@typescript-eslint/typescript-estree": "4.7.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.4.1.tgz",
-      "integrity": "sha512-2oD/ZqD4Gj41UdFeWZxegH3cVEEH/Z6Bhr/XvwTtGv66737XkR4C9IqEkebCuqArqBJQSj4AgNHHiN1okzD/wQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.7.0.tgz",
+      "integrity": "sha512-ILITvqwDJYbcDCROj6+Ob0oCKNg3SH46iWcNcTIT9B5aiVssoTYkhKjxOMNzR1F7WSJkik4zmuqve5MdnA0DyA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.4.1",
-        "@typescript-eslint/visitor-keys": "4.4.1"
+        "@typescript-eslint/types": "4.7.0",
+        "@typescript-eslint/visitor-keys": "4.7.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.4.1.tgz",
-      "integrity": "sha512-KNDfH2bCyax5db+KKIZT4rfA8rEk5N0EJ8P0T5AJjo5xrV26UAzaiqoJCxeaibqc0c/IvZxp7v2g3difn2Pn3w==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.7.0.tgz",
+      "integrity": "sha512-uLszFe0wExJc+I7q0Z/+BnP7wao/kzX0hB5vJn4LIgrfrMLgnB2UXoReV19lkJQS1a1mHWGGODSxnBx6JQC3Sg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.4.1.tgz",
-      "integrity": "sha512-wP/V7ScKzgSdtcY1a0pZYBoCxrCstLrgRQ2O9MmCUZDtmgxCO/TCqOTGRVwpP4/2hVfqMz/Vw1ZYrG8cVxvN3g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.7.0.tgz",
+      "integrity": "sha512-5XZRQznD1MfUmxu1t8/j2Af4OxbA7EFU2rbo0No7meb46eHgGkSieFdfV6omiC/DGIBhH9H9gXn7okBbVOm8jw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.4.1",
-        "@typescript-eslint/visitor-keys": "4.4.1",
+        "@typescript-eslint/types": "4.7.0",
+        "@typescript-eslint/visitor-keys": "4.7.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -1279,12 +1018,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.4.1.tgz",
-      "integrity": "sha512-H2JMWhLaJNeaylSnMSQFEhT/S/FsJbebQALmoJxMPMxLtlVAMy2uJP/Z543n9IizhjRayLSqoInehCeNW9rWcw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.7.0.tgz",
+      "integrity": "sha512-aDJDWuCRsf1lXOtignlfiPODkzSxxop7D0rZ91L6ZuMlcMCSh0YyK+gAfo5zN/ih6WxMwhoXgJWC3cWQdaKC+A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.4.1",
+        "@typescript-eslint/types": "4.7.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -1494,59 +1233,25 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
     "babel-jest": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.0.tgz",
-      "integrity": "sha512-JI66yILI7stzjHccAoQtRKcUwJrJb4oMIxLTirL3GdAjGpaUBQSjZDFi9LsPkN4gftsS4R2AThAJwOjJxadwbg==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+      "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/babel__core": "^7.1.7",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^26.5.0",
+        "babel-preset-jest": "^26.6.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "babel-plugin-istanbul": {
@@ -1563,9 +1268,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
-      "integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+      "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -1575,9 +1280,9 @@
       }
     },
     "babel-preset-current-node-syntax": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
-      "integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz",
+      "integrity": "sha512-mGkvkpocWJes1CmMKtgGUwCeeq0pOhALyymozzDWYomHTbDLwueDYG6p4TK1YOeYHCzBzYPsWkgTto10JubI1Q==",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -1590,17 +1295,18 @@
         "@babel/plugin-syntax-numeric-separator": "^7.8.3",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
       }
     },
     "babel-preset-jest": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
-      "integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+      "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^26.5.0",
-        "babel-preset-current-node-syntax": "^0.1.3"
+        "babel-plugin-jest-hoist": "^26.6.2",
+        "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
     "balanced-match": {
@@ -1739,6 +1445,16 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1767,9 +1483,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -1786,6 +1502,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "cjs-module-lexer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+      "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
       "dev": true
     },
     "class-utils": {
@@ -2127,9 +1849,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "25.2.6",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-      "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
       "dev": true
     },
     "dir-glob": {
@@ -2307,13 +2029,13 @@
       }
     },
     "eslint": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
-      "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz",
+      "integrity": "sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.1.3",
+        "@eslint/eslintrc": "^0.2.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2351,16 +2073,6 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2370,9 +2082,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.13.0.tgz",
-      "integrity": "sha512-LcT0i0LSmnzqK2t764pyIt7kKH2AuuqKRTtJTdddWxOiUja9HdG5GXBVF2gmCTvVYWVsTu8J2MhJLVGRh+pj8w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -2481,9 +2193,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.0.tgz",
-      "integrity": "sha512-827YJ+E8B9PvXu/0eiVSNFfxxndbKv+qE/3GSMhdorCaeaOehtqHGX2YDW9B85TEOre9n/zscledkFW/KbnyGg==",
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz",
+      "integrity": "sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
@@ -2731,57 +2443,17 @@
       }
     },
     "expect": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.0.tgz",
-      "integrity": "sha512-EzhbZ1tbwcaa5Ok39BI11flIMeIUSlg1QsnXOrleaMvltwHsvIQPBtL710l+ma+qDFLUgktCXK4YuQzmHdm7cg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+      "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "ansi-styles": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-matcher-utils": "^26.6.0",
-        "jest-message-util": "^26.6.0",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
         "jest-regex-util": "^26.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        }
       }
     },
     "extend": {
@@ -2921,9 +2593,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3035,9 +2707,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
       "dev": true,
       "optional": true
     },
@@ -3054,9 +2726,9 @@
       "dev": true
     },
     "gensync": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
     "get-caller-file": {
@@ -3064,6 +2736,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -3305,16 +2988,6 @@
         "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3391,9 +3064,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -3543,6 +3216,15 @@
       "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-data-descriptor": {
@@ -3792,65 +3474,33 @@
       }
     },
     "jest": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.0.tgz",
-      "integrity": "sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+      "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.6.0",
+        "@jest/core": "^26.6.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.6.0"
+        "jest-cli": "^26.6.3"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "jest-cli": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.0.tgz",
-          "integrity": "sha512-lJAMZGpmML+y3Kfln6L5DGRTfKGQ+n1JDM1RQstojSLUhe/EaXWR8vmcx70v4CyJKvFZs7c/0QDkPX5ra/aDew==",
+          "version": "26.6.3",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+          "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.6.0",
-            "@jest/test-result": "^26.6.0",
-            "@jest/types": "^26.6.0",
+            "@jest/core": "^26.6.3",
+            "@jest/test-result": "^26.6.2",
+            "@jest/types": "^26.6.2",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.6.0",
-            "jest-util": "^26.6.0",
-            "jest-validate": "^26.6.0",
+            "jest-config": "^26.6.3",
+            "jest-util": "^26.6.2",
+            "jest-validate": "^26.6.2",
             "prompts": "^2.0.1",
             "yargs": "^15.4.1"
           }
@@ -3858,52 +3508,20 @@
       }
     },
     "jest-changed-files": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.0.tgz",
-      "integrity": "sha512-k8PZzlp3cRWDe0fDc/pYs+c4w36+hiWXe1PpW/pW1UJmu1TNTAcQfZUrVYleij+uEqlY6z4mPv7Iff3kY0o5SQ==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+      "integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "execa": "^4.0.0",
         "throat": "^5.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "execa": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -3944,168 +3562,70 @@
       }
     },
     "jest-circus": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.6.0.tgz",
-      "integrity": "sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.6.3.tgz",
+      "integrity": "sha512-ACrpWZGcQMpbv13XbzRzpytEJlilP/Su0JtNCi5r/xLpOUhnaIJr8leYYpLEMgPFURZISEHrnnpmB54Q/UziPw==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^26.6.0",
-        "@jest/test-result": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/environment": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/babel__traverse": "^7.0.4",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^26.6.0",
+        "expect": "^26.6.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.6.0",
-        "jest-matcher-utils": "^26.6.0",
-        "jest-message-util": "^26.6.0",
-        "jest-runner": "^26.6.0",
-        "jest-runtime": "^26.6.0",
-        "jest-snapshot": "^26.6.0",
-        "jest-util": "^26.6.0",
-        "pretty-format": "^26.6.0",
+        "jest-each": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2",
         "stack-utils": "^2.0.2",
         "throat": "^5.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "pretty-format": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.0.tgz",
-          "integrity": "sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        }
       }
     },
     "jest-config": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.0.tgz",
-      "integrity": "sha512-RCR1Kf7MGJ5waVCvrj/k3nCAJKquWZlzs8rkskzj0KlG392hNBOaYd5FQ4cCac08j6pwfIDOwNvMcy0/FqguJg==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+      "integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^26.6.0",
-        "@jest/types": "^26.6.0",
-        "babel-jest": "^26.6.0",
+        "@jest/test-sequencer": "^26.6.3",
+        "@jest/types": "^26.6.2",
+        "babel-jest": "^26.6.3",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-environment-jsdom": "^26.6.0",
-        "jest-environment-node": "^26.6.0",
+        "jest-environment-jsdom": "^26.6.2",
+        "jest-environment-node": "^26.6.2",
         "jest-get-type": "^26.3.0",
-        "jest-jasmine2": "^26.6.0",
+        "jest-jasmine2": "^26.6.3",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.6.0",
-        "jest-util": "^26.6.0",
-        "jest-validate": "^26.6.0",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
         "micromatch": "^4.0.2",
-        "pretty-format": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.0.tgz",
-          "integrity": "sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        }
+        "pretty-format": "^26.6.2"
       }
     },
     "jest-diff": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-      "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
-        "diff-sequences": "^25.2.6",
-        "jest-get-type": "^25.2.6",
-        "pretty-format": "^25.5.0"
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
       }
     },
     "jest-docblock": {
@@ -4118,180 +3638,60 @@
       }
     },
     "jest-each": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.0.tgz",
-      "integrity": "sha512-7LzSNwNviYnm4FWK46itIE03NqD/8O8/7tVQ5rwTdTNrmPMQoQ1Z7hEFQ1uzRReluOFislpurpnQ0QsclSiDkA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+      "integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-util": "^26.6.0",
-        "pretty-format": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.0.tgz",
-          "integrity": "sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        }
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2"
       }
     },
     "jest-environment-jsdom": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.0.tgz",
-      "integrity": "sha512-bXO9IG7a3YlyiHxwfKF+OWoTA+GIw4FrD+Y0pb6CC+nKs5JuSRZmR2ovEX6PWo6KY42ka3JoZOp3KEnXiFPPCg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+      "integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.6.0",
-        "@jest/fake-timers": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
-        "jest-mock": "^26.6.0",
-        "jest-util": "^26.6.0",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2",
         "jsdom": "^16.4.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "jest-environment-node": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.0.tgz",
-      "integrity": "sha512-kWU6ZD1h6fs7sIl6ufuK0sXW/3d6WLaj48iow0NxhgU6eY89d9K+0MVmE0cRcVlh53yMyxTK6b+TnhLOnlGp/A==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+      "integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.6.0",
-        "@jest/fake-timers": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
-        "jest-mock": "^26.6.0",
-        "jest-util": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
       }
     },
     "jest-get-type": {
-      "version": "25.2.6",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-      "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.0.tgz",
-      "integrity": "sha512-RpNqAGMR58uG9E9vWITorX2/R7he/tSbHWldX5upt1ymEcmCaXczqXxjqI6xOtRR8Ev6ZEYDfgSA5Fy7WHUL5w==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+      "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -4299,356 +3699,87 @@
         "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
-        "jest-serializer": "^26.5.0",
-        "jest-util": "^26.6.0",
-        "jest-worker": "^26.5.0",
+        "jest-serializer": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
         "micromatch": "^4.0.2",
         "sane": "^4.0.3",
         "walker": "^1.0.7"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "jest-jasmine2": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.0.tgz",
-      "integrity": "sha512-2E3c+0A9y2OIK5caw5qlcm3b4doaf8FSfXKTX3xqKTUJoR4zXh0xvERBNWxZP9xMNXEi/2Z3LVsZpR2hROgixA==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+      "integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^26.6.0",
-        "@jest/source-map": "^26.5.0",
-        "@jest/test-result": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/environment": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^26.6.0",
+        "expect": "^26.6.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.6.0",
-        "jest-matcher-utils": "^26.6.0",
-        "jest-message-util": "^26.6.0",
-        "jest-runtime": "^26.6.0",
-        "jest-snapshot": "^26.6.0",
-        "jest-util": "^26.6.0",
-        "pretty-format": "^26.6.0",
+        "jest-each": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2",
         "throat": "^5.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "pretty-format": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.0.tgz",
-          "integrity": "sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        }
       }
     },
     "jest-leak-detector": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.0.tgz",
-      "integrity": "sha512-3oMv34imWTl1/nwKnmE/DxYo3QqHnZeF3nO6UzldppkhW0Za7OY2DYyWiamqVzwdUrjhoQkY5g+aF6Oc3alYEQ==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+      "integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
       "dev": true,
       "requires": {
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.0.tgz",
-          "integrity": "sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        }
+        "pretty-format": "^26.6.2"
       }
     },
     "jest-matcher-utils": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.0.tgz",
-      "integrity": "sha512-BUy/dQYb7ELGRazmK4ZVkbfPYCaNnrMtw1YljVhcKzWUxBM0xQ+bffrfnMLdRZp4wUUcT4ahaVnA3VWZtXWP9Q==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+      "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^26.6.0",
+        "jest-diff": "^26.6.2",
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "diff-sequences": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
-          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.0.tgz",
-          "integrity": "sha512-IH09rKsdWY8YEY7ii2BHlSq59oXyF2pK3GoK+hOK9eD/x6009eNB5Jv1shLMKgxekodPzLlV7eZP1jPFQYds8w==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^26.5.0",
-            "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.6.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.0.tgz",
-          "integrity": "sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        }
+        "pretty-format": "^26.6.2"
       }
     },
     "jest-message-util": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.0.tgz",
-      "integrity": "sha512-WPAeS38Kza29f04I0iOIQrXeiebRXjmn6cFehzI7KKJOgT0NmqYAcLgjWnIAfKs5FBmEQgje1kXab0DaLKCl2w==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+      "integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.2",
+        "pretty-format": "^26.6.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.2"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "jest-mock": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.0.tgz",
-      "integrity": "sha512-HsNmL8vVIn1rL1GWA21Drpy9Cl+7GImwbWz/0fkWHrUXVzuaG7rP0vwLtE+/n70Mt0U8nPkz8fxioi3SC0wqhw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+      "integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "jest-pnp-resolver": {
@@ -4664,53 +3795,21 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.0.tgz",
-      "integrity": "sha512-tRAz2bwraHufNp+CCmAD8ciyCpXCs1NQxB5EJAmtCFy6BN81loFEGWKzYu26Y62lAJJe4X4jg36Kf+NsQyiStQ==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+      "integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^26.6.0",
+        "jest-util": "^26.6.2",
         "read-pkg-up": "^7.0.1",
-        "resolve": "^1.17.0",
+        "resolve": "^1.18.1",
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4806,178 +3905,79 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.0.tgz",
-      "integrity": "sha512-4di+XUT7LwJJ8b8qFEEDQssC5+aeVjLhvRICCaS4alh/EVS9JCT1armfJ3pnSS8t4o6659WbMmKVo82H4LuUVw==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+      "integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "jest-regex-util": "^26.0.0",
-        "jest-snapshot": "^26.6.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
+        "jest-snapshot": "^26.6.2"
       }
     },
     "jest-runner": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.0.tgz",
-      "integrity": "sha512-QpeN6pje8PQvFgT+wYOlzeycKd67qAvSw5FgYBiX2cTW+QTiObTzv/k09qRvT09rcCntFxUhy9VB1mgNGFLYIA==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+      "integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.6.0",
-        "@jest/environment": "^26.6.0",
-        "@jest/test-result": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.7.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.6.0",
+        "jest-config": "^26.6.3",
         "jest-docblock": "^26.0.0",
-        "jest-haste-map": "^26.6.0",
-        "jest-leak-detector": "^26.6.0",
-        "jest-message-util": "^26.6.0",
-        "jest-resolve": "^26.6.0",
-        "jest-runtime": "^26.6.0",
-        "jest-util": "^26.6.0",
-        "jest-worker": "^26.5.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-leak-detector": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "jest-runtime": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.0.tgz",
-      "integrity": "sha512-JEz4YGnybFvtN4NLID6lsZf0bcd8jccwjWcG5TRE3fYVnxoX1egTthPjnC4btIwWJ6QaaHhtOQ/E3AGn8iClAw==",
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+      "integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.6.0",
-        "@jest/environment": "^26.6.0",
-        "@jest/fake-timers": "^26.6.0",
-        "@jest/globals": "^26.6.0",
-        "@jest/source-map": "^26.5.0",
-        "@jest/test-result": "^26.6.0",
-        "@jest/transform": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/globals": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0",
+        "cjs-module-lexer": "^0.6.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.6.0",
-        "jest-haste-map": "^26.6.0",
-        "jest-message-util": "^26.6.0",
-        "jest-mock": "^26.6.0",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.6.0",
-        "jest-snapshot": "^26.6.0",
-        "jest-util": "^26.6.0",
-        "jest-validate": "^26.6.0",
+        "jest-resolve": "^26.6.2",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
         "yargs": "^15.4.1"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -4987,9 +3987,9 @@
       }
     },
     "jest-serializer": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
-      "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+      "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -4997,272 +3997,84 @@
       }
     },
     "jest-snapshot": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.0.tgz",
-      "integrity": "sha512-mcqJZeIZqxomvBcsaiIbiEe2g7K1UxnUpTwjMoHb+DX4uFGnuZoZ6m28YOYRyCfZsdU9mmq73rNBnEH2atTR4Q==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+      "integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.0.0",
         "chalk": "^4.0.0",
-        "expect": "^26.6.0",
+        "expect": "^26.6.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^26.6.0",
+        "jest-diff": "^26.6.2",
         "jest-get-type": "^26.3.0",
-        "jest-haste-map": "^26.6.0",
-        "jest-matcher-utils": "^26.6.0",
-        "jest-message-util": "^26.6.0",
-        "jest-resolve": "^26.6.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^26.6.0",
+        "pretty-format": "^26.6.2",
         "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "diff-sequences": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
-          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
-          "dev": true
-        },
-        "jest-diff": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.0.tgz",
-          "integrity": "sha512-IH09rKsdWY8YEY7ii2BHlSq59oXyF2pK3GoK+hOK9eD/x6009eNB5Jv1shLMKgxekodPzLlV7eZP1jPFQYds8w==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^26.5.0",
-            "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.6.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.0.tgz",
-          "integrity": "sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        }
       }
     },
     "jest-util": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.0.tgz",
-      "integrity": "sha512-/cUGqcnKeZMjvTQLfJo65nBOEZ/k0RB/8usv2JpfYya05u0XvBmKkIH5o5c4nCh9DD61B1YQjMGGqh1Ha0aXdg==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+      "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "is-ci": "^2.0.0",
         "micromatch": "^4.0.2"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "jest-validate": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.0.tgz",
-      "integrity": "sha512-FKHNqvh1Pgs4NWas56gsTPmjcIoGAAzSVUCK1+g8euzuCGbmdEr8LRTtOEFjd29uMZUk0PhzmzKGlHPe6j3UWw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+      "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.6.0",
+        "@jest/types": "^26.6.2",
         "camelcase": "^6.0.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
         "leven": "^3.1.0",
-        "pretty-format": "^26.6.0"
+        "pretty-format": "^26.6.2"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
         "camelcase": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
-          "integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.0.tgz",
-          "integrity": "sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
         }
       }
     },
     "jest-watcher": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.0.tgz",
-      "integrity": "sha512-gw5BvcgPi0PKpMlNWQjUet5C5A4JOYrT7gexdP6+DR/f7mRm7wE0o1GqwPwcTsTwo0/FNf9c/kIDXTRaSAYwlw==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+      "integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.6.0",
-        "@jest/types": "^26.6.0",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^26.6.0",
+        "jest-util": "^26.6.2",
         "string-length": "^4.0.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "26.6.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.0.tgz",
-          "integrity": "sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "jest-worker": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
-      "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -5764,37 +4576,15 @@
       }
     },
     "object.assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.0",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "object.pick": {
@@ -6025,15 +4815,15 @@
       }
     },
     "pretty-format": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^25.5.0",
+        "@jest/types": "^26.6.2",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^4.0.0",
-        "react-is": "^16.12.0"
+        "react-is": "^17.0.1"
       }
     },
     "progress": {
@@ -6043,13 +4833,13 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
-        "sisteransi": "^1.0.4"
+        "sisteransi": "^1.0.5"
       }
     },
     "psl": {
@@ -6081,9 +4871,9 @@
       "dev": true
     },
     "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+      "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
       "dev": true
     },
     "read-pkg": {
@@ -6243,11 +5033,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -6308,9 +5099,9 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "safe-buffer": {
@@ -6836,9 +5627,9 @@
       }
     },
     "stack-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
-      "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -6918,23 +5709,67 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+      "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+      "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "strip-ansi": {
@@ -7114,9 +5949,9 @@
       }
     },
     "ts-jest": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.1.tgz",
-      "integrity": "sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==",
+      "version": "26.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
+      "integrity": "sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==",
       "dev": true,
       "requires": {
         "@types/jest": "26.x",
@@ -7148,9 +5983,9 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "20.2.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
-          "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
           "dev": true
         }
       }
@@ -7228,9 +6063,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
     },
     "union-value": {
@@ -7314,15 +6149,15 @@
       "optional": true
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
-      "integrity": "sha512-PzM1WlqquhBvsV+Gco6WSFeg1AGdD53ccMRkFeyHRE/KRZaVacPOmQYP3EeVgDBtKD2BJ8kgynBQ5OtKiHCH+w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.0.0.tgz",
+      "integrity": "sha512-fLL2rFuQpMtm9r8hrAV2apXX/WqHJ6+IC4/eQVdMDGBUgH/YMV4Gv3duk3kjmyg6uiQWBAA9nJwue4iJUOkHeA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -7509,9 +6344,9 @@
       }
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",
@@ -30,22 +30,22 @@
     "fs": "0.0.1-security"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.14",
-    "@types/node": "^14.11.10",
-    "@typescript-eslint/eslint-plugin": "^4.4.1",
-    "@typescript-eslint/parser": "^4.4.1",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^14.14.7",
+    "@typescript-eslint/eslint-plugin": "^4.7.0",
+    "@typescript-eslint/parser": "^4.7.0",
     "@zeit/ncc": "^0.22.3",
-    "eslint": "^7.11.0",
-    "eslint-config-prettier": "^6.13.0",
+    "eslint": "^7.13.0",
+    "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.1.0",
+    "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.3.0",
-    "jest": "^26.6.0",
-    "jest-circus": "^26.6.0",
+    "jest": "^26.6.3",
+    "jest-circus": "^26.6.3",
     "prettier": "^2.1.2",
-    "ts-jest": "^26.4.1",
-    "typescript": "^4.0.3"
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.0.5"
   },
   "husky": {
     "skipCI": true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint **/*.ts --cache",
+    "lint": "eslint **/*.ts --cache --fix",
     "format": "prettier --write **/*.ts && git add .",
     "format-check": "prettier --check **/*.ts",
     "release": "ncc build src/install.ts -o dist && git add -f dist/",

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -27,12 +27,14 @@ export async function addExtensionDarwin(
       // match pdo_oci and oci8
       // match 5.3ioncube...7.4ioncube, 7.0ioncube...7.4ioncube
       // match 7.0phalcon3...7.3phalcon3 and 7.2phalcon4...7.4phalcon4
+      // match 5.6couchbase...7.4couchbase
       case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(
         version_extension
       ):
       case /^pdo_oci$|^oci8$/.test(extension):
       case /^5\.[3-6]ioncube$|^7\.[0-4]ioncube$/.test(version_extension):
       case /^7\.[0-3]phalcon3$|^7\.[2-4]phalcon4$/.test(version_extension):
+      case /^5\.6couchbase$|^7\.[0-4]couchbase$/.test(version_extension):
         add_script += await utils.customPackage(
           ext_name,
           'ext',
@@ -219,7 +221,7 @@ export async function addExtensionLinux(
       // match pdo_oci and oci8
       // match 5.3ioncube...7.4ioncube, 7.0ioncube...7.4ioncube
       // match 7.0phalcon3...7.3phalcon3 and 7.2phalcon4...7.4phalcon4
-      // match 5.6gearman..7.4gearman
+      // match 5.6gearman...7.4gearman, 5.6couchbase...7.4couchbase
       case /^(5\.[3-6]|7\.[0-4])blackfire(-\d+\.\d+\.\d+)?$/.test(
         version_extension
       ):
@@ -232,7 +234,7 @@ export async function addExtensionLinux(
       ):
       case /^5\.[3-6]ioncube$|^7\.[0-4]ioncube$/.test(version_extension):
       case /^7\.[0-3]phalcon3$|^7\.[2-4]phalcon4$/.test(version_extension):
-      case /^((5\.6)|(7\.[0-4]))gearman$/.test(version_extension):
+      case /^((5\.6)|(7\.[0-4]))(gearman|couchbase)$/.test(version_extension):
         add_script += await utils.customPackage(
           ext_name,
           'ext',

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -164,16 +164,14 @@ export async function addExtensionWindows(
         );
         break;
       // match semver with state
-      case /.*-(\d+\.\d+\.\d)(beta|alpha|devel|snapshot)\d*/.test(
-        version_extension
-      ):
-        matches = /.*-(\d+\.\d+\.\d)(beta|alpha|devel|snapshot)\d*/.exec(
+      case /.*-(\d+\.\d+\.\d)([a-zA-Z+]+)\d*/.test(version_extension):
+        matches = /.*-(\d+\.\d+\.\d)([a-zA-Z+]+)\d*/.exec(
           version_extension
         ) as RegExpExecArray;
         add_script += await utils.joins(
           '\nAdd-Extension',
           ext_name,
-          matches[2],
+          matches[2].replace('preview', 'devel'),
           matches[1]
         );
         break;

--- a/src/install.ts
+++ b/src/install.ts
@@ -21,6 +21,7 @@ export async function getScript(
   const name = 'setup-php';
   const url = 'https://setup-php.com/support';
   // taking inputs
+  process.env['fail_fast'] = await utils.getInput('fail-fast', false);
   const extension_csv: string = await utils.getInput('extensions', false);
   const ini_values_csv: string = await utils.getInput('ini-values', false);
   const coverage_driver: string = await utils.getInput('coverage', false);
@@ -60,10 +61,7 @@ export async function run(): Promise<void> {
     const tool = await utils.scriptTool(os_version);
     const script = os_version + (await utils.scriptExtension(os_version));
     const location = await getScript(script, version, os_version);
-    const fail_fast = await utils.readEnv('fail-fast');
-    await exec(
-      await utils.joins(tool, location, version, __dirname, fail_fast)
-    );
+    await exec(await utils.joins(tool, location, version, __dirname));
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/scripts/common.sh
+++ b/src/scripts/common.sh
@@ -1,0 +1,215 @@
+# Variables
+export tick="✓"
+export cross="✗"
+export curl_opts=(-sL)
+export nightly_versions="8.[0-1]"
+export old_versions="5.[3-5]"
+export tool_path_dir="/usr/local/bin"
+export composer_bin="$HOME/.composer/vendor/bin"
+export composer_json="$HOME/.composer/composer.json"
+export github="https://github.com/shivammathur"
+
+# Function to log start of a operation.
+step_log() {
+  message=$1
+  printf "\n\033[90;1m==> \033[0m\033[37;1m%s\033[0m\n" "$message"
+}
+
+# Function to log result of a operation.
+add_log() {
+  mark=$1
+  subject=$2
+  message=$3
+  if [ "$mark" = "$tick" ]; then
+    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+  else
+    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
+    [ "$fail_fast" = "true" ] && exit 1;
+  fi
+}
+
+# Function to log result of installing extension.
+add_extension_log() {
+  extension=$1
+  status=$2
+  extension_name=$(echo "$extension" | cut -d '-' -f 1)
+  (
+    check_extension "$extension_name" && add_log "$tick" "$extension_name" "$status"
+  ) || add_log "$cross" "$extension_name" "Could not install $extension on PHP ${semver:?}"
+}
+
+# Function to read env inputs.
+read_env() {
+  [[ -z "${update}" ]] && update='false' && UPDATE='false' || update="${update}"
+  [ "$update" = false ] && [[ -n ${UPDATE} ]] && update="${UPDATE}"
+  [[ -z "${runner}" ]] && runner='github' && RUNNER='github' || runner="${runner}"
+  [ "$runner" = false ] && [[ -n ${RUNNER} ]] && runner="${RUNNER}"
+  [[ -z "${fail_fast}" ]] && fail_fast='false' || fail_fast="${fail_fast}"
+}
+
+# Function to install required packages on self-hosted runners.
+self_hosted_setup() {
+  if [ "$runner" = "self-hosted" ]; then
+    if [[ "${version:?}" =~ $old_versions ]]; then
+      add_log "$cross" "PHP" "PHP $version is not supported on self-hosted runner"
+      exit 1
+    else
+      self_hosted_helper >/dev/null 2>&1
+    fi
+  fi
+}
+
+# Function to test if extension is loaded.
+check_extension() {
+  extension=$1
+  if [ "$extension" != "mysql" ]; then
+    php -m | grep -i -q -w "$extension"
+  else
+    php -m | grep -i -q "$extension"
+  fi
+}
+
+# Function to enable existing extensions.
+enable_extension() {
+  if ! check_extension "$1" && [ -e "${ext_dir:?}/$1.so" ]; then
+    echo "$2=${ext_dir:?}/$1.so" >>"${pecl_file:-$ini_file}"
+  fi
+}
+
+# Function to configure PECL.
+configure_pecl() {
+  if ! [ -e /tmp/pecl_config ] && command -v pecl >/dev/null; then
+    for script in pear pecl; do
+      sudo "$script" config-set php_ini "${pecl_file:-$ini_file}"
+      sudo "$script" channel-update "$script".php.net
+    done
+    echo '' | sudo tee /tmp/pecl_config >/dev/null 2>&1
+  fi
+}
+
+# Function to get the PECL version of an extension.
+get_pecl_version() {
+  extension=$1
+  stability="$(echo "$2" | grep -m 1 -Eio "(alpha|beta|rc|snapshot|preview)")"
+  pecl_rest='https://pecl.php.net/rest/r/'
+  response=$(curl "${curl_opts[@]}" "$pecl_rest$extension"/allreleases.xml)
+  pecl_version=$(echo "$response" | grep -m 1 -Pio "(\d*\.\d*\.\d*$stability\d*)")
+  if [ ! "$pecl_version" ]; then
+    pecl_version=$(echo "$response" | grep -m 1 -Po "(\d*\.\d*\.\d*)")
+  fi
+  echo "$pecl_version"
+}
+
+# Function to install PECL extensions and accept default options
+pecl_install() {
+  local extension=$1
+  yes '' 2>/dev/null | sudo pecl install -f "$extension" >/dev/null 2>&1
+}
+
+# Function to setup pre-release extensions using PECL.
+add_unstable_extension() {
+  extension=$1
+  stability=$2
+  prefix=$3
+  pecl_version=$(get_pecl_version "$extension" "$stability")
+  add_pecl_extension "$extension" "$pecl_version" "$prefix"
+}
+
+# Function to extract tool version.
+get_tool_version() {
+  tool=$1
+  param=$2
+  version_regex="[0-9]+((\.{1}[0-9]+)+)(\.{0})(-[a-zA-Z0-9]+){0,1}"
+  if [ "$tool" = "composer" ]; then
+    if [ "$param" != "snapshot" ]; then
+      grep -Ea "const\sVERSION" "$tool_path_dir/composer" | grep -Eo "$version_regex"
+    else
+      trunk=$(grep -Ea "const\sBRANCH_ALIAS_VERSION" "$tool_path_dir/composer" | grep -Eo "$version_regex")
+      commit=$(grep -Ea "const\sVERSION" "$tool_path_dir/composer" | grep -Eo "[a-zA-z0-9]+" | tail -n 1)
+      echo "$trunk+$commit"
+    fi
+  else
+    $tool "$param" 2>/dev/null | sed -Ee "s/[Cc]omposer(.)?$version_regex//g" | grep -Eo "$version_regex" | head -n 1
+  fi
+}
+
+# Function to configure composer
+configure_composer() {
+  tool_path=$1
+  sudo ln -sf "$tool_path" "$tool_path.phar"
+  php -r "try {\$p=new Phar('$tool_path.phar', 0);exit(0);} catch(Exception \$e) {exit(1);}"
+  if [ $? -eq 1 ]; then
+    add_log "$cross" "composer" "Could not download composer"
+    exit 1
+  fi
+  composer -q global config process-timeout 0
+  echo "$composer_bin" >> "$GITHUB_PATH"
+  if [ -n "$COMPOSER_TOKEN" ]; then
+    composer -q global config github-oauth.github.com "$COMPOSER_TOKEN"
+  fi
+}
+
+# Function to setup a remote tool.
+add_tool() {
+  url=$1
+  tool=$2
+  ver_param=$3
+  tool_path="$tool_path_dir/$tool"
+  if [ ! -e "$tool_path" ]; then
+    rm -rf "$tool_path"
+  fi
+  if [ "$tool" = "composer" ]; then
+    IFS="," read -r -a urls <<< "$url"
+    status_code=$(sudo curl -f -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "${urls[0]}") ||
+    status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "${urls[1]}")
+  else
+    status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
+    if [ "$status_code" != "200" ] && [[ "$url" =~ .*github.com.*releases.*latest.* ]]; then
+      url="${url//releases\/latest\/download/releases\/download/$(curl "${curl_opts[@]}" "$(echo "$url" | cut -d '/' -f '1-5')/releases" | grep -Eo -m 1 "([0-9]+\.[0-9]+\.[0-9]+)/$(echo "$url" | sed -e "s/.*\///")" | cut -d '/' -f 1)}"url="${url//releases\/latest\/download/releases\/download/$(curl "${curl_opts[@]}" "$(echo "$url" | cut -d '/' -f '1-5')/releases" | grep -Eo -m 1 "([0-9]+\.[0-9]+\.[0-9]+)/$(echo "$url" | sed -e "s/.*\///")" | cut -d '/' -f 1)}"
+      status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
+    fi
+  fi
+  if [ "$status_code" = "200" ]; then
+    sudo chmod a+x "$tool_path"
+    if [ "$tool" = "composer" ]; then
+      configure_composer "$tool_path"
+    elif [ "$tool" = "cs2pr" ]; then
+      sudo sed -i 's/\r$//; s/exit(9)/exit(0)/' "$tool_path" 2>/dev/null ||
+      sudo sed -i '' 's/\r$//; s/exit(9)/exit(0)/' "$tool_path"
+    elif [ "$tool" = "phan" ]; then
+      add_extension fileinfo extension >/dev/null 2>&1
+      add_extension ast extension >/dev/null 2>&1
+    elif [ "$tool" = "phive" ]; then
+      add_extension curl extension >/dev/null 2>&1
+      add_extension mbstring extension >/dev/null 2>&1
+      add_extension xml extension >/dev/null 2>&1
+    elif [ "$tool" = "wp-cli" ]; then
+      sudo cp -p "$tool_path" "$tool_path_dir"/wp
+    fi
+    tool_version=$(get_tool_version "$tool" "$ver_param")
+    add_log "$tick" "$tool" "Added $tool $tool_version"
+  else
+    add_log "$cross" "$tool" "Could not setup $tool"
+  fi
+}
+
+# Function to setup a tool using composer.
+add_composertool() {
+  tool=$1
+  release=$2
+  prefix=$3
+  (
+    composer global require "$prefix$release" >/dev/null 2>&1 &&
+    json=$(grep "$prefix$tool" "$composer_json") &&
+    tool_version=$(get_tool_version 'echo' "$json") &&
+    add_log "$tick" "$tool" "Added $tool $tool_version"
+  ) || add_log "$cross" "$tool" "Could not setup $tool"
+  if [ -e "$composer_bin/composer" ]; then
+    sudo cp -p "$tool_path_dir/composer" "$composer_bin"
+  fi
+}
+
+# Function to get PHP version in semver format.
+php_semver() {
+  php"$version" -v | grep -Eo -m 1 "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1
+}

--- a/src/scripts/common.sh
+++ b/src/scripts/common.sh
@@ -103,6 +103,9 @@ check_extension() {
 
 # Function to enable existing extensions.
 enable_extension() {
+  if [ -e /tmp/setup_php_dismod ] && grep -q "$1" /tmp/setup_php_dismod; then
+    sudo phpenmod -v "$version" "$1" >/dev/null 2>&1
+  fi
   if ! check_extension "$1" && [ -e "${ext_dir:?}/$1.so" ]; then
     echo "$2=${ext_dir:?}/$1.so" >>"${pecl_file:-$ini_file}"
   fi

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -1,46 +1,9 @@
-# Function to log start of a operation.
-step_log() {
-  message=$1
-  printf "\n\033[90;1m==> \033[0m\033[37;1m%s\033[0m\n" "$message"
-}
-
-# Function to log result of a operation.
-add_log() {
-  mark=$1
-  subject=$2
-  message=$3
-  if [ "$mark" = "$tick" ]; then
-    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
-  else
-    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
-    [ "$fail_fast" = "true" ] && exit 1;
-  fi
-}
-
-# Function to log result of installing extension.
-add_extension_log() {
-  extension=$1
-  status=$2
-  extension_name=$(echo "$extension" | cut -d '-' -f 1)
-  (
-    check_extension "$extension_name" && add_log "$tick" "$extension_name" "$status"
-  ) || add_log "$cross" "$extension_name" "Could not install $extension on PHP $semver"
-}
-
-# Function to read env inputs.
-read_env() {
-  [[ -z "${update}" ]] && update='false' && UPDATE='false' || update="${update}"
-  [ "$update" = false ] && [[ -n ${UPDATE} ]] && update="${UPDATE}"
-  [[ -z "${runner}" ]] && runner='github' && RUNNER='github' || runner="${runner}"
-  [ "$runner" = false ] && [[ -n ${RUNNER} ]] && runner="${RUNNER}"
-}
-
 # Function to setup environment for self-hosted runners.
-self_hosted_setup() {
-  if [[ $(command -v brew) == "" ]]; then
+self_hosted_helper() {
+  if ! command -v brew >/dev/null; then
     step_log "Setup Brew"
-    curl "${curl_opts[@]}" https://raw.githubusercontent.com/Homebrew/install/master/install.sh | bash -s >/dev/null 2>&1
-    add_log "$tick" "Brew" "Installed Homebrew"
+    curl "${curl_opts[@]:?}" https://raw.githubusercontent.com/Homebrew/install/master/install.sh | bash -s >/dev/null 2>&1
+    add_log "${tick:?}" "Brew" "Installed Homebrew"
   fi
 }
 
@@ -48,43 +11,13 @@ self_hosted_setup() {
 remove_extension() {
   extension=$1
   if check_extension "$extension"; then
-    sudo sed -i '' "/$extension/d" "$ini_file"
-    sudo rm -rf "$scan_dir"/*"$extension"* >/dev/null 2>&1
-    sudo rm -rf "$ext_dir"/"$extension".so >/dev/null 2>&1
-    (! check_extension "$extension" && add_log "$tick" ":$extension" "Removed") ||
-      add_log "$cross" ":$extension" "Could not remove $extension on PHP $semver"
+    sudo sed -i '' "/$extension/d" "${ini_file:?}"
+    sudo rm -rf "${scan_dir:?}"/*"$extension"* "${ext_dir:?}"/"$extension".so >/dev/null 2>&1
+    (! check_extension "$extension" && add_log "${tick:?}" ":$extension" "Removed") ||
+      add_log "${cross:?}" ":$extension" "Could not remove $extension on PHP ${semver:?}"
   else
-    add_log "$tick" ":$extension" "Could not find $extension on PHP $semver"
+    add_log "${tick:?}" ":$extension" "Could not find $extension on PHP $semver"
   fi
-}
-
-# Function to test if extension is loaded.
-check_extension() {
-  extension=$1
-  if [ "$extension" != "mysql" ]; then
-    php -m | grep -i -q -w "$extension"
-  else
-    php -m | grep -i -q "$extension"
-  fi
-}
-
-# Function to get the PECL version.
-get_pecl_version() {
-  extension=$1
-  stability="$(echo "$2" | grep -m 1 -Eio "(alpha|beta|rc|snapshot|preview)")"
-  pecl_rest='https://pecl.php.net/rest/r/'
-  response=$(curl "${curl_opts[@]}" "$pecl_rest$extension"/allreleases.xml)
-  pecl_version=$(echo "$response" | grep -m 1 -Eio "(\d*\.\d*\.\d*$stability\d*)")
-  if [ ! "$pecl_version" ]; then
-    pecl_version=$(echo "$response" | grep -m 1 -Eo "(\d*\.\d*\.\d*)")
-  fi
-  echo "$pecl_version"
-}
-
-# Function to install PECL extensions and accept default options
-pecl_install() {
-  local extension=$1
-  yes '' | sudo pecl install -f "$extension" >/dev/null 2>&1
 }
 
 # Function to install a specific version of PECL extension.
@@ -92,15 +25,13 @@ add_pecl_extension() {
   extension=$1
   pecl_version=$2
   prefix=$3
+  enable_extension "$extension" "$prefix"
   if [[ $pecl_version =~ .*(alpha|beta|rc|snapshot|preview).* ]]; then
     pecl_version=$(get_pecl_version "$extension" "$pecl_version")
   fi
-  if ! check_extension "$extension" && [ -e "$ext_dir/$extension.so" ]; then
-    echo "$prefix=$ext_dir/$extension.so" >>"$ini_file"
-  fi
   ext_version=$(php -r "echo phpversion('$extension');")
   if [ "$ext_version" = "$pecl_version" ]; then
-    add_log "$tick" "$extension" "Enabled"
+    add_log "${tick:?}" "$extension" "Enabled"
   else
     remove_extension "$extension" >/dev/null 2>&1
     pecl_install "$extension-$pecl_version"
@@ -111,169 +42,65 @@ add_pecl_extension() {
 # Function to install a php extension from shivammathur/extensions tap.
 add_brew_extension() {
   extension=$1
-  if ! brew tap | grep shivammathur/extensions; then
-    brew tap --shallow shivammathur/extensions
+  prefix=$2
+  enable_extension "$extension" "$prefix"
+  if check_extension "$extension"; then
+    add_log "${tick:?}" "$extension" "Enabled"
+  else
+    if ! brew tap | grep -q shivammathur/extensions; then
+      brew tap --shallow shivammathur/extensions >/dev/null 2>&1
+    fi
+    brew install "$extension@$version" >/dev/null 2>&1
+    sudo cp "$(brew --prefix)/opt/$extension@$version/$extension.so" "$ext_dir"
+    add_extension_log "$extension" "Installed and enabled"
   fi
-  brew install "$extension@$version"
-  sudo cp "$(brew --prefix)/opt/$extension@$version/$extension.so" "$ext_dir"
 }
 
 # Function to setup extensions
 add_extension() {
   extension=$1
-  install_command=$2
-  prefix=$3
-  if ! check_extension "$extension" && [ -e "$ext_dir/$extension.so" ]; then
-    echo "$prefix=$ext_dir/$extension.so" >>"$ini_file" && add_log "$tick" "$extension" "Enabled"
-  elif check_extension "$extension"; then
-    add_log "$tick" "$extension" "Enabled"
-  elif ! check_extension "$extension"; then
-    eval "$install_command" >/dev/null 2>&1 &&
-      if [[ "$version" =~ $old_versions ]]; then echo "$prefix=$ext_dir/$extension.so" >>"$ini_file"; fi
+  prefix=$2
+  enable_extension "$extension" "$prefix"
+  if check_extension "$extension"; then
+    add_log "${tick:?}" "$extension" "Enabled"
+  else
+    [[ "$version" =~ 5.[4-5] ]] && [ "$extension" = "imagick" ] && brew install pkg-config imagemagick >/dev/null 2>&1
+    pecl_install "$extension" >/dev/null 2>&1 &&
+      if [[ "$version" =~ ${old_versions:?} ]]; then echo "$prefix=$ext_dir/$extension.so" >>"$ini_file"; fi
     add_extension_log "$extension" "Installed and enabled"
-  fi
-}
-
-# Function to setup pre-release extensions using PECL.
-add_unstable_extension() {
-  extension=$1
-  stability=$2
-  prefix=$3
-  pecl_version=$(get_pecl_version "$extension" "$stability")
-  add_pecl_extension "$extension" "$pecl_version" "$prefix"
-}
-
-# Function to configure composer
-configure_composer() {
-  tool_path=$1
-  sudo ln -sf "$tool_path" "$tool_path.phar"
-  php -r "try {\$p=new Phar('$tool_path.phar', 0);exit(0);} catch(Exception \$e) {exit(1);}"
-  if [ $? -eq 1 ]; then
-    add_log "$cross" "composer" "Could not download composer"
-    exit 1
-  fi
-  composer -q global config process-timeout 0
-  echo "$composer_bin" >> "$GITHUB_PATH"
-  if [ -n "$COMPOSER_TOKEN" ]; then
-    composer -q global config github-oauth.github.com "$COMPOSER_TOKEN"
-  fi
-}
-
-# Function to extract tool version.
-get_tool_version() {
-  tool=$1
-  param=$2
-  version_regex="[0-9]+((\.{1}[0-9]+)+)(\.{0})(-[a-zA-Z0-9]+){0,1}"
-  if [ "$tool" = "composer" ]; then
-    if [ "$param" != "snapshot" ]; then
-      grep -Ea "const\sVERSION" "$tool_path_dir/composer" | grep -Eo "$version_regex"
-    else
-      trunk=$(grep -Ea "const\sBRANCH_ALIAS_VERSION" "$tool_path_dir/composer" | grep -Eo "$version_regex")
-      commit=$(grep -Ea "const\sVERSION" "$tool_path_dir/composer" | grep -Eo "[a-zA-z0-9]+" | tail -n 1)
-      echo "$trunk+$commit"
-    fi
-  else
-    $tool "$param" 2>/dev/null | sed -Ee "s/[Cc]omposer(.)?$version_regex//g" | grep -Eo "$version_regex" | head -n 1
-  fi
-}
-
-# Function to setup a remote tool.
-add_tool() {
-  url=$1
-  tool=$2
-  ver_param=$3
-  tool_path="$tool_path_dir/$tool"
-  if [ ! -e "$tool_path" ]; then
-    rm -rf "$tool_path"
-  fi
-  if [ "$tool" = "composer" ]; then
-    IFS="," read -r -a urls <<< "$url"
-    status_code=$(sudo curl -f -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "${urls[0]}") ||
-    status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "${urls[1]}")
-  else
-    status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
-    if [ "$status_code" != "200" ] && [[ "$url" =~ .*github.com.*releases.*latest.* ]]; then
-      url=$(echo $url | sed -e "s|releases/latest/download|releases/download/$(curl "${curl_opts[@]}" "$(echo "$url" | cut -d '/' -f '1-5')/releases" | grep -Eo -m 1 "([0-9]+\.[0-9]+\.[0-9]+)/$(echo "$url" | sed -e "s/.*\///")" | cut -d '/' -f 1)|")
-      status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
-    fi
-  fi
-  if [ "$status_code" = "200" ]; then
-    sudo chmod a+x "$tool_path"
-    if [ "$tool" = "composer" ]; then
-      configure_composer "$tool_path"
-    elif [ "$tool" = "phan" ]; then
-      add_extension fileinfo "pecl_install fileinfo" extension >/dev/null 2>&1
-      add_extension ast "pecl_install ast" extension >/dev/null 2>&1
-    elif [ "$tool" = "phive" ]; then
-      add_extension curl "pecl_install curl" extension >/dev/null 2>&1
-      add_extension mbstring "pecl_install mbstring" extension >/dev/null 2>&1
-      add_extension xml "pecl_install xml" extension >/dev/null 2>&1
-    elif [ "$tool" = "cs2pr" ]; then
-      sudo sed -i '' 's/exit(9)/exit(0)/' "$tool_path"
-      tr -d '\r' <"$tool_path" | sudo tee "$tool_path.tmp" >/dev/null 2>&1 && sudo mv "$tool_path.tmp" "$tool_path"
-      sudo chmod a+x "$tool_path"
-    elif [ "$tool" = "wp-cli" ]; then
-      sudo cp -p "$tool_path" "$tool_path_dir"/wp
-    fi
-    tool_version=$(get_tool_version "$tool" "$ver_param")
-    add_log "$tick" "$tool" "Added $tool $tool_version"
-  else
-    add_log "$cross" "$tool" "Could not setup $tool"
-  fi
-}
-
-# Function to add a tool using composer.
-add_composertool() {
-  tool=$1
-  release=$2
-  prefix=$3
-  (
-    composer global require "$prefix$release" >/dev/null 2>&1 &&
-    json=$(grep "$prefix$tool" /Users/"$USER"/.composer/composer.json) &&
-    tool_version=$(get_tool_version 'echo' "$json") &&
-    add_log "$tick" "$tool" "Added $tool $tool_version"
-  ) || add_log "$cross" "$tool" "Could not setup $tool"
-  if [ -e "$composer_bin/composer" ]; then
-    sudo cp -p "$tool_path_dir/composer" "$composer_bin"
   fi
 }
 
 # Function to handle request to add phpize and php-config.
 add_devtools() {
   tool=$1
-  add_log "$tick" "$tool" "Added $tool $semver"
-}
-
-# Function to configure PECL
-configure_pecl() {
-  for tool in pear pecl; do
-    sudo "$tool" config-set php_ini "$ini_file"
-    sudo "$tool" channel-update "$tool".php.net
-  done
+  add_log "${tick:?}" "$tool" "Added $tool $semver"
 }
 
 # Function to handle request to add PECL.
 add_pecl() {
   pecl_version=$(get_tool_version "pecl" "version")
-  add_log "$tick" "PECL" "Found PECL $pecl_version"
+  add_log "${tick:?}" "PECL" "Found PECL $pecl_version"
 }
 
 # Function to update dependencies.
 update_dependencies() {
-  if [[ "$version" =~ $nightly_versions ]] && [ "$runner" != "self-hosted" ]; then
+  if [[ "$version" =~ ${nightly_versions:?} ]] && [ "${runner:?}" != "self-hosted" ]; then
+    tap_dir="$(brew --prefix)/Homebrew/Library/Taps"
     while read -r formula; do
-      curl -o "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/$formula.rb" "${curl_opts[@]}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/$formula.rb" &
-      to_wait+=( $! )
-    done < "$(brew --prefix)/Homebrew/Library/Taps/shivammathur/homebrew-php/.github/deps/${ImageOS:?}_${ImageVersion:?}"
+      curl -o "$tap_dir/homebrew/homebrew-core/Formula/$formula.rb" "${curl_opts[@]:?}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/$formula.rb" &
+      to_wait+=($!)
+    done <"$tap_dir/shivammathur/homebrew-php/.github/deps/${ImageOS:?}_${ImageVersion:?}"
     wait "${to_wait[@]}"
   fi
 }
 
-# Function to setup PHP 5.6 and newer.
-setup_php() {
+# Function to setup PHP 5.6 and newer using Homebrew.
+add_php() {
   action=$1
-  export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
-  brew tap --shallow shivammathur/homebrew-php
+  if ! brew tap | grep -q shivammathur/php; then
+    brew tap --shallow shivammathur/php
+  fi
   update_dependencies
   if brew list php@"$version" 2>/dev/null | grep -q "Error" && [ "$action" != "upgrade" ]; then
     brew unlink php@"$version"
@@ -283,51 +110,42 @@ setup_php() {
   brew link --force --overwrite php@"$version"
 }
 
+# Function to Setup PHP
+setup_php() {
+  step_log "Setup PHP"
+  existing_version=$(php-config --version 2>/dev/null | cut -c 1-3)
+  if [[ "$version" =~ ${old_versions:?} ]]; then
+    curl "${curl_opts[@]:?}" "${github:?}/php5-darwin/releases/latest/download/install.sh" | bash -s "${version/./}" >/dev/null 2>&1
+    status="Installed"
+  elif [ "$existing_version" != "$version" ]; then
+    add_php "install" >/dev/null 2>&1
+    status="Installed"
+  elif [ "$existing_version" = "$version" ] && [ "${update:?}" = "true" ]; then
+    add_php "upgrade" >/dev/null 2>&1
+    status="Updated to"
+  else
+    status="Found"
+  fi
+  ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+  sudo chmod 777 "$ini_file" "${tool_path_dir:?}"
+  echo -e "date.timezone=UTC\nmemory_limit=-1" >>"$ini_file"
+  ext_dir=$(php -i | grep -Ei "extension_dir => /" | sed -e "s|.*=> s*||")
+  scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
+  sudo mkdir -m 777 -p "$ext_dir" "$HOME/.composer"
+  semver=$(php -v | head -n 1 | cut -f 2 -d ' ')
+  if [[ ! "$version" =~ $old_versions ]]; then configure_pecl >/dev/null 2>&1; fi
+  sudo cp "$dist"/../src/configs/*.json "$RUNNER_TOOL_CACHE/"
+  add_log "$tick" "PHP" "$status PHP $semver"
+}
+
 # Variables
-tick="✓"
-cross="✗"
 version=$1
 dist=$2
-fail_fast=$3
-nodot_version=${1/./}
-nightly_versions="8.[0-1]"
-old_versions="5.[3-5]"
-composer_bin="/Users/$USER/.composer/vendor/bin"
-tool_path_dir="/usr/local/bin"
-curl_opts=(-sL)
-existing_version=$(php-config --version 2>/dev/null | cut -c 1-3)
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+export HOMEBREW_NO_AUTO_UPDATE=1
 
+# shellcheck source=.
+. "${dist}"/../src/scripts/common.sh
 read_env
-if [ "$runner" = "self-hosted" ]; then
-  if [[ "$version" =~ $old_versions ]]; then
-    add_log "$cross" "PHP" "PHP $version is not supported on self-hosted runner"
-    exit 1
-  else
-    self_hosted_setup >/dev/null 2>&1
-  fi
-fi
-
-# Setup PHP
-step_log "Setup PHP"
-if [[ "$version" =~ $old_versions ]]; then
-  curl "${curl_opts[@]}" https://github.com/shivammathur/php5-darwin/releases/latest/download/install.sh | bash -s "$nodot_version" >/dev/null 2>&1
-  status="Installed"
-elif [ "$existing_version" != "$version" ]; then
-  setup_php "install" >/dev/null 2>&1
-  status="Installed"
-elif [ "$existing_version" = "$version" ] && [ "$update" = "true" ]; then
-  setup_php "upgrade" >/dev/null 2>&1
-  status="Updated to"
-else
-  status="Found"
-fi
-ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
-sudo chmod 777 "$ini_file" "$tool_path_dir"
-echo -e "date.timezone=UTC\nmemory_limit=-1" >>"$ini_file"
-ext_dir=$(php -i | grep -Ei "extension_dir => /" | sed -e "s|.*=> s*||")
-scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
-sudo mkdir -m 777 -p "$ext_dir" "/Users/$USER/.composer"
-semver=$(php -v | head -n 1 | cut -f 2 -d ' ')
-if [[ ! "$version" =~ $old_versions ]]; then configure_pecl >/dev/null 2>&1; fi
-sudo cp "$dist"/../src/configs/*.json "$RUNNER_TOOL_CACHE/"
-add_log "$tick" "PHP" "$status PHP $semver"
+self_hosted_setup
+setup_php

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -2,7 +2,7 @@
 self_hosted_helper() {
   if ! command -v brew >/dev/null; then
     step_log "Setup Brew"
-    curl "${curl_opts[@]:?}" https://raw.githubusercontent.com/Homebrew/install/master/install.sh | bash -s >/dev/null 2>&1
+    get -q -e "/tmp/install.sh" "https://raw.githubusercontent.com/Homebrew/install/master/install.sh" && /tmp/install.sh >/dev/null 2>&1
     add_log "${tick:?}" "Brew" "Installed Homebrew"
   fi
 }
@@ -88,7 +88,7 @@ update_dependencies() {
   if [[ "$version" =~ ${nightly_versions:?} ]] && [ "${runner:?}" != "self-hosted" ]; then
     tap_dir="$(brew --prefix)/Homebrew/Library/Taps"
     while read -r formula; do
-      curl -o "$tap_dir/homebrew/homebrew-core/Formula/$formula.rb" "${curl_opts[@]:?}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/$formula.rb" &
+      get -q -n "$tap_dir/homebrew/homebrew-core/Formula/$formula.rb" "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/$formula.rb" &
       to_wait+=($!)
     done <"$tap_dir/shivammathur/homebrew-php/.github/deps/${ImageOS:?}_${ImageVersion:?}"
     wait "${to_wait[@]}"
@@ -115,7 +115,7 @@ setup_php() {
   step_log "Setup PHP"
   existing_version=$(php-config --version 2>/dev/null | cut -c 1-3)
   if [[ "$version" =~ ${old_versions:?} ]]; then
-    curl "${curl_opts[@]:?}" "${github:?}/php5-darwin/releases/latest/download/install.sh" | bash -s "${version/./}" >/dev/null 2>&1
+    run_script "php5-darwin" "${version/./}" >/dev/null 2>&1
     status="Installed"
   elif [ "$existing_version" != "$version" ]; then
     add_php "install" >/dev/null 2>&1

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -71,7 +71,7 @@ check_extension() {
 # Function to get the PECL version.
 get_pecl_version() {
   extension=$1
-  stability="$(echo "$2" | grep -m 1 -Eio "(alpha|beta|rc|snapshot)")"
+  stability="$(echo "$2" | grep -m 1 -Eio "(alpha|beta|rc|snapshot|preview)")"
   pecl_rest='https://pecl.php.net/rest/r/'
   response=$(curl "${curl_opts[@]}" "$pecl_rest$extension"/allreleases.xml)
   pecl_version=$(echo "$response" | grep -m 1 -Eio "(\d*\.\d*\.\d*$stability\d*)")
@@ -92,7 +92,7 @@ add_pecl_extension() {
   extension=$1
   pecl_version=$2
   prefix=$3
-  if [[ $pecl_version =~ .*(alpha|beta|rc|snapshot).* ]]; then
+  if [[ $pecl_version =~ .*(alpha|beta|rc|snapshot|preview).* ]]; then
     pecl_version=$(get_pecl_version "$extension" "$pecl_version")
   fi
   if ! check_extension "$extension" && [ -e "$ext_dir/$extension.so" ]; then

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -192,6 +192,10 @@ add_tool() {
     status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "${urls[1]}")
   else
     status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
+    if [ "$status_code" != "200" ] && [[ "$url" =~ .*github.com.*releases.*latest.* ]]; then
+      url=$(echo $url | sed -e "s|releases/latest/download|releases/download/$(curl "${curl_opts[@]}" "$(echo "$url" | cut -d '/' -f '1-5')/releases" | grep -Eo -m 1 "([0-9]+\.[0-9]+\.[0-9]+)/$(echo "$url" | sed -e "s/.*\///")" | cut -d '/' -f 1)|")
+      status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
+    fi
   fi
   if [ "$status_code" = "200" ]; then
     sudo chmod a+x "$tool_path"

--- a/src/scripts/ext/blackfire.ps1
+++ b/src/scripts/ext/blackfire.ps1
@@ -17,7 +17,7 @@ Function Add-Blackfire() {
         $status="Enabled"
     } else {
         $nts = if (!$installed.ThreadSafe) { "_nts" } else { "" }
-        Invoke-WebRequest -UseBasicParsing -Uri "https://packages.blackfire.io/binaries/blackfire-php/${extension_version}/blackfire-php-windows_${arch}-php-${no_dot_version}${nts}.dll" -OutFile $ext_dir\blackfire.dll > $null 2>&1
+        Invoke-WebRequest -Uri "https://packages.blackfire.io/binaries/blackfire-php/${extension_version}/blackfire-php-windows_${arch}-php-${no_dot_version}${nts}.dll" -OutFile $ext_dir\blackfire.dll > $null 2>&1
         Enable-PhpExtension -Extension blackfire -Path $php_dir
         $status="Installed and enabled"
     }

--- a/src/scripts/ext/blackfire.sh
+++ b/src/scripts/ext/blackfire.sh
@@ -8,9 +8,9 @@ add_blackfire() {
   blackfire_ini_file="${scan_dir:?}/50-blackfire.ini"
   if [ ! -e "${ext_dir:?}/blackfire.so" ]; then
     if [ "$extension_version" = "blackfire" ]; then
-      extension_version=$(curl -sSL https://blackfire.io/api/v1/releases | grep -Eo 'php":"([0-9]+.[0-9]+.[0-9]+)' | cut -d '"' -f 3)
+      extension_version=$(get -s -n "" https://blackfire.io/api/v1/releases | grep -Eo 'php":"([0-9]+.[0-9]+.[0-9]+)' | cut -d '"' -f 3)
     fi
-    sudo curl -o "${ext_dir:?}/blackfire.so" "${curl_opts[@]:?}" https://packages.blackfire.io/binaries/blackfire-php/"$extension_version"/blackfire-php-"$platform"_amd64-php-"$no_dot_version".so >/dev/null 2>&1
+    get -q -n "${ext_dir:?}/blackfire.so" https://packages.blackfire.io/binaries/blackfire-php/"$extension_version"/blackfire-php-"$platform"_amd64-php-"$no_dot_version".so >/dev/null 2>&1
   fi
   echo "extension=blackfire.so" | sudo tee -a "$blackfire_ini_file" >/dev/null 2>&1
   add_extension_log "$extension-$extension_version" "Installed and enabled"

--- a/src/scripts/ext/couchbase.sh
+++ b/src/scripts/ext/couchbase.sh
@@ -1,0 +1,40 @@
+# Function to install libraries required by couchbase
+add_couchbase_libs() {
+  if [ "$(uname -s)" = "Linux" ]; then
+    if [[ ${version:?} =~ 5.6|7.[0-1] ]]; then
+      trunk="http://packages.couchbase.com/ubuntu"
+      list="deb $trunk ${DISTRIB_CODENAME:?} ${DISTRIB_CODENAME:?}/main"
+    else
+      trunk="http://packages.couchbase.com/clients/c/repos/deb"
+      list="deb $trunk/ubuntu${DISTRIB_RELEASE/./} ${DISTRIB_CODENAME:?} ${DISTRIB_CODENAME:?}/main"
+    fi
+    add_pecl
+    get -s -n "" "$trunk/couchbase.key" | sudo apt-key add
+    echo "$list" | sudo tee /etc/apt/sources.list.d/couchbase.list
+    sudo apt-get update
+    ${apt_install:?} libcouchbase-dev
+  else
+    if [[ ${version:?} =~ 5.6|7.[0-1] ]]; then
+      brew install libcouchbase@2
+      brew link --overwrite --force libcouchbase@2
+    else
+      brew install libcouchbase
+    fi
+  fi
+}
+
+# Function to add couchbase.
+add_couchbase() {
+  add_couchbase_libs >/dev/null 2>&1
+  enable_extension "couchbase" "extension"
+  if check_extension "couchbase"; then
+    add_log "${tick:?}" "couchbase" "Enabled"
+  else
+    if [[ ${version:?} =~ 5.6|7.[0-1] ]]; then
+      pecl_install couchbase-2.6.2 >/dev/null 2>&1
+    else
+      pecl_install couchbase >/dev/null 2>&1
+    fi
+    add_extension_log "couchbase" "Installed and enabled"
+  fi
+}

--- a/src/scripts/ext/intl.sh
+++ b/src/scripts/ext/intl.sh
@@ -2,7 +2,7 @@
 install_icu() {
   icu=$1
   if [ "$(php -i | grep "ICU version =>" | sed -e "s|.*=> s*||")" != "$icu" ]; then
-    sudo curl -o /tmp/icu.tar.zst -sL "https://dl.bintray.com/shivammathur/icu4c/icu4c-$icu.tar.zst"
+    get -q -n /tmp/icu.tar.zst "https://dl.bintray.com/shivammathur/icu4c/icu4c-$icu.tar.zst"
     sudo tar -I zstd -xf /tmp/icu.tar.zst -C /usr/local
     sudo cp -r /usr/local/icu/lib/* /usr/lib/x86_64-linux-gnu/
   fi
@@ -11,12 +11,12 @@ install_icu() {
 # Function to add ext-intl with the given version of ICU
 add_intl() {
   icu=$(echo "$1" | cut -d'-' -f 2)
-  supported_version=$(curl "${curl_opts[@]:?}" https://api.bintray.com/packages/shivammathur/icu4c/icu4c | grep -Po "$icu" | head -n 1)
+  supported_version=$(get -s -n "" https://api.bintray.com/packages/shivammathur/icu4c/icu4c | grep -Po "$icu" | head -n 1)
   if [ "$icu" != "$supported_version" ]; then
     add_log "${cross:?}" "intl" "ICU $icu is not supported"
   else
     install_icu "$icu" >/dev/null 2>&1
-    sudo curl "${curl_opts[@]:?}" -o "${ext_dir:?}/intl.so" "https://dl.bintray.com/shivammathur/icu4c/php${version:?}-intl-$icu.so"
+    get -q -n "${ext_dir:?}/intl.so" "https://dl.bintray.com/shivammathur/icu4c/php${version:?}-intl-$icu.so"
     enable_extension intl extension
     add_extension_log intl "Installed and enabled with ICU $icu"
   fi

--- a/src/scripts/ext/ioncube.ps1
+++ b/src/scripts/ext/ioncube.ps1
@@ -19,7 +19,7 @@ Function Add-Ioncube() {
       if (-not($installed.ThreadSafe)) {
         $ts_part = "_nonts"
       }
-      Invoke-WebRequest -UseBasicParsing -Uri "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_win$ts_part`_vc$vc`_$arch_part.zip" -OutFile $ext_dir\ioncube.zip
+      Invoke-WebRequest -Uri "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_win$ts_part`_vc$vc`_$arch_part.zip" -OutFile $ext_dir\ioncube.zip
       Expand-Archive -Path $ext_dir\ioncube.zip -DestinationPath $ext_dir -Force
       Copy-Item $ext_dir\ioncube\ioncube_loader_win_$version.dll $ext_dir\php_ioncube.dll
     }

--- a/src/scripts/ext/ioncube.sh
+++ b/src/scripts/ext/ioncube.sh
@@ -10,7 +10,7 @@ add_ioncube() {
   if [ ! -e "${ext_dir:?}/ioncube.so" ]; then
     status='Installed and enabled'
     os_name='lin' && [ "$(uname -s)" = "Darwin" ] && os_name='mac'
-    curl "${curl_opts[@]:?}" https://downloads.ioncube.com/loader_downloads/ioncube_loaders_"$os_name"_x86-64.tar.gz | tar -xzf - -C /tmp
+    get -s -n "" https://downloads.ioncube.com/loader_downloads/ioncube_loaders_"$os_name"_x86-64.tar.gz | tar -xzf - -C /tmp
     sudo mv /tmp/ioncube/ioncube_loader_"$os_name"_"${version:?}".so "$ext_dir/ioncube.so"
   fi
   echo "zend_extension=$ext_dir/ioncube.so" | sudo tee "${scan_dir:?}/00-ioncube.ini" >/dev/null 2>&1

--- a/src/scripts/ext/oci.ps1
+++ b/src/scripts/ext/oci.ps1
@@ -14,7 +14,7 @@ Function Add-InstantClient() {
     if ($arch -eq 'x86') {
       $suffix = 'nt'
     }
-    Invoke-WebRequest -UseBasicParsing -Uri https://download.oracle.com/otn_software/nt/instantclient/instantclient-basiclite-$suffix.zip -OutFile $php_dir\instantclient.zip
+    Invoke-WebRequest -Uri https://download.oracle.com/otn_software/nt/instantclient/instantclient-basiclite-$suffix.zip -OutFile $php_dir\instantclient.zip
     Expand-Archive -Path $php_dir\instantclient.zip -DestinationPath $php_dir -Force
     Copy-Item $php_dir\instantclient*\* $php_dir
   }
@@ -44,7 +44,7 @@ Function Add-Oci() {
           $ociVersion = '2.0.12'
         }
         $ociUrl = Get-PeclArchiveUrl oci8 $ociVersion $installed
-        Invoke-WebRequest -UseBasicParsing -Uri $ociUrl -OutFile $php_dir\oci8.zip
+        Invoke-WebRequest -Uri $ociUrl -OutFile $php_dir\oci8.zip
         Expand-Archive -Path $php_dir\oci8.zip -DestinationPath $ext_dir -Force
 
       }

--- a/src/scripts/ext/oci.sh
+++ b/src/scripts/ext/oci.sh
@@ -34,7 +34,7 @@ add_client() {
         arch='macos'
         lib_ext='dylib'
       fi
-      curl -o "/opt/oracle/$package.zip" "${curl_opts[@]:?}" "https://download.oracle.com/otn_software/$os_name/instantclient/instantclient-$package-$arch.zip"
+      get -q -n "/opt/oracle/$package.zip" "https://download.oracle.com/otn_software/$os_name/instantclient/instantclient-$package-$arch.zip"
       unzip "/opt/oracle/$package.zip" -d "$oracle_home"
     done
     sudo ln -sf /opt/oracle/instantclient*/*.$lib_ext* $libs
@@ -44,7 +44,7 @@ add_client() {
 
 # Function to get PHP source.
 get_php() {
-  [ ! -d "/opt/oracle/php-src-$tag" ] && curl "${curl_opts[@]}" "https://github.com/php/php-src/archive/$tag.tar.gz" | tar xzf - -C "$oracle_home/"
+  [ ! -d "/opt/oracle/php-src-$tag" ] && get -s -n "" "https://github.com/php/php-src/archive/$tag.tar.gz" | tar xzf - -C "$oracle_home/"
 }
 
 # Function to get phpize location on darwin.
@@ -73,7 +73,7 @@ restore_phpize() {
 
 # Function to patch pdo_oci.
 patch_pdo_oci_config() {
-  curl -O "${curl_opts[@]}" https://raw.githubusercontent.com/php/php-src/PHP-8.0/ext/pdo_oci/config.m4
+  get -q -n config.m4 https://raw.githubusercontent.com/php/php-src/PHP-8.0/ext/pdo_oci/config.m4
   if [[ ${version:?} =~ 5.[3-6] ]]; then
     sudo sed -i '' "/PHP_CHECK_PDO_INCLUDES/d" config.m4 2>/dev/null || sudo sed -i "/PHP_CHECK_PDO_INCLUDES/d" config.m4
   fi

--- a/src/scripts/ext/oci.sh
+++ b/src/scripts/ext/oci.sh
@@ -83,16 +83,9 @@ patch_pdo_oci_config() {
 add_dependencies() {
   if [ "$os" = 'Linux' ]; then
     if [ "${runner:?}" = "self-hosted" ]; then
-      if ! [[ ${version:?} =~ $nightly_versions ]]; then
-        ${apt_install:?} --no-upgrade --no-install-recommends autoconf automake libaio-dev gcc g++ php"$version"-dev
-      else
-        ${apt_install:?} --no-upgrade --no-install-recommends autoconf automake libaio-dev gcc g++
-      fi
-    else
-      ! [[ ${version:?} =~ $nightly_versions ]] && update_lists && ${apt_install:?} --no-upgrade --no-install-recommends php"$version"-dev
+      ${apt_install:?} --no-upgrade --no-install-recommends autoconf automake libaio-dev gcc g++
     fi
-    sudo update-alternatives --set php-config /usr/bin/php-config"$version"
-    sudo update-alternatives --set phpize /usr/bin/phpize"$version"
+    ! [[ ${version:?} =~ $nightly_versions ]] && add_devtools phpize
   fi
 }
 

--- a/src/scripts/ext/phalcon.ps1
+++ b/src/scripts/ext/phalcon.ps1
@@ -5,9 +5,9 @@ Function Add-PhalconHelper() {
   } else {
     $domain = 'https://github.com'
     $nts = if (!$installed.ThreadSafe) { "_nts" } else { "" }
-    $match = Invoke-WebRequest -UseBasicParsing -Uri $domain/phalcon/cphalcon/releases | Select-String -Pattern "href=`"(.*phalcon_x64_.*_php${version}_${extension_version}.*[0-9]${nts}.zip)`""
+    $match = Invoke-WebRequest -Uri $domain/phalcon/cphalcon/releases | Select-String -Pattern "href=`"(.*phalcon_x64_.*_php${version}_${extension_version}.*[0-9]${nts}.zip)`""
     $zip_file = $match.Matches[0].Groups[1].Value
-    Invoke-WebRequest -UseBasicParsing -Uri $domain/$zip_file -OutFile $ENV:RUNNER_TOOL_CACHE\phalcon.zip > $null 2>&1
+    Invoke-WebRequest -Uri $domain/$zip_file -OutFile $ENV:RUNNER_TOOL_CACHE\phalcon.zip > $null 2>&1
     Expand-Archive -Path $ENV:RUNNER_TOOL_CACHE\phalcon.zip -DestinationPath $ENV:RUNNER_TOOL_CACHE\phalcon -Force > $null 2>&1
     Copy-Item -Path "$ENV:RUNNER_TOOL_CACHE\phalcon\php_phalcon.dll" -Destination "$ext_dir\php_phalcon.dll"
     Enable-PhpExtension -Extension phalcon -Path $php_dir

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -273,8 +273,8 @@ setup_php() {
 version=$1
 dist=$2
 debconf_fix="DEBIAN_FRONTEND=noninteractive"
-apt_install="sudo $debconf_fix apt-get install -y"
-apt_remove="sudo $debconf_fix apt-get remove -y"
+apt_install="sudo $debconf_fix apt-fast install -y"
+apt_remove="sudo $debconf_fix apt-fast remove -y"
 
 # shellcheck source=.
 . "${dist}"/../src/scripts/common.sh

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -1,39 +1,10 @@
-# Function to log start of a operation.
-step_log() {
-  message=$1
-  printf "\n\033[90;1m==> \033[0m\033[37;1m%s\033[0m\n" "$message"
-}
-
-# Function to log result of a operation.
-add_log() {
-  mark=$1
-  subject=$2
-  message=$3
-  if [ "$mark" = "$tick" ]; then
-    printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
-  else
-    printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s\033[0m\n" "$mark" "$subject" "$message"
-    [ "$fail_fast" = "true" ] && exit 1;
+# Function to setup environment for self-hosted runners.
+self_hosted_helper() {
+  if ! command -v apt-fast >/dev/null; then
+    sudo ln -sf /usr/bin/apt-get /usr/bin/apt-fast
   fi
-}
-
-# Function to log result of installing extension.
-add_extension_log() {
-  extension=$1
-  status=$2
-  extension_name=$(echo "$extension" | cut -d '-' -f 1)
-  (
-    check_extension "$extension_name" && add_log "$tick" "$extension_name" "$status"
-  ) || add_log "$cross" "$extension_name" "Could not install $extension on PHP $semver"
-}
-
-# Function to read env inputs.
-read_env() {
-  . /etc/lsb-release
-  [[ -z "${update}" ]] && update='false' && UPDATE='false' || update="${update}"
-  [ "$update" = false ] && [[ -n ${UPDATE} ]] && update="${UPDATE}"
-  [[ -z "${runner}" ]] && runner='github' && RUNNER='github' || runner="${runner}"
-  [ "$runner" = false ] && [[ -n ${RUNNER} ]] && runner="${RUNNER}"
+  install_packages curl make software-properties-common unzip
+  add_ppa
 }
 
 # Function to backup and cleanup package lists.
@@ -64,70 +35,24 @@ update_lists() {
     [ "$DISTRIB_RELEASE" = "20.04" ] && add_ppa >/dev/null 2>&1
     cleanup_lists
     sudo "$debconf_fix" apt-get update >/dev/null 2>&1
-    echo '' | sudo tee "/tmp/setup_php" >/dev/null 2>&1
+    echo '' | sudo tee /tmp/setup_php >/dev/null 2>&1
   fi
 }
 
-# Function to setup environment for self-hosted runners.
-self_hosted_setup() {
-  if ! command -v apt-fast >/dev/null; then
-    sudo ln -sf /usr/bin/apt-get /usr/bin/apt-fast
-  fi
-  update_lists && $apt_install curl make software-properties-common unzip
-  add_ppa
-}
-
-# Function to configure PECL.
-configure_pecl() {
-  if [ "$pecl_config" = "false" ] && [ -e /usr/bin/pecl ]; then
-
-    for tool in pear pecl; do
-      sudo "$tool" config-set php_ini "$scan_dir"/99-pecl.ini
-      sudo "$tool" channel-update "$tool".php.net
-    done
-    pecl_config="true"
-  fi
-}
-
-# Function to get the PECL version of an extension.
-get_pecl_version() {
-  extension=$1
-  stability="$(echo "$2" | grep -m 1 -Eio "(alpha|beta|rc|snapshot|preview)")"
-  pecl_rest='https://pecl.php.net/rest/r/'
-  response=$(curl "${curl_opts[@]}" "$pecl_rest$extension"/allreleases.xml)
-  pecl_version=$(echo "$response" | grep -m 1 -Pio "(\d*\.\d*\.\d*$stability\d*)")
-  if [ ! "$pecl_version" ]; then
-    pecl_version=$(echo "$response" | grep -m 1 -Po "(\d*\.\d*\.\d*)")
-  fi
-  echo "$pecl_version"
-}
-
-# Function to install PECL extensions and accept default options
-pecl_install() {
-  local extension=$1
-  yes '' | sudo pecl install -f "$extension" >/dev/null 2>&1
-}
-
-# Function to check if an extension is loaded.
-check_extension() {
-  extension=$1
-  if [ "$extension" != "mysql" ]; then
-    php -m | grep -i -q -w "$extension"
-  else
-    php -m | grep -i -q "$extension"
-  fi
+# Function to install a package
+install_packages() {
+  packages=("$@")
+  $apt_install "${packages[@]}" >/dev/null 2>&1 || update_lists && $apt_install "${packages[@]}" >/dev/null 2>&1
 }
 
 # Function to delete extensions.
 delete_extension() {
   extension=$1
-  sudo sed -i "/$extension/d" "$ini_file"
-  sudo sed -i "/$extension/d" "$pecl_file"
-  sudo rm -rf "$scan_dir"/*"$extension"* >/dev/null 2>&1
-  sudo rm -rf "$ext_dir"/"$extension".so >/dev/null 2>&1
-  if [ "$runner" = "self-hosted" ]; then
-    $apt_remove "php-$extension" >/dev/null 2>&1 || true
-    $apt_remove "php$version-$extension" >/dev/null 2>&1 || true
+  sudo sed -i "/$extension/d" "${ini_file:?}"
+  sudo sed -i "/$extension/d" "${pecl_file:?}"
+  sudo rm -rf "${scan_dir:?}"/*"$extension"* "${ext_dir:?}"/"$extension".so >/dev/null 2>&1
+  if [ "${runner:?}" = "self-hosted" ]; then
+    $apt_remove "php-$extension" "php$version-$extension" >/dev/null 2>&1 || true
   fi
 }
 
@@ -135,21 +60,14 @@ delete_extension() {
 remove_extension() {
   extension=$1
   if check_extension "$extension"; then
-    if [[ ! "$version" =~ $old_versions ]] && [ -e /etc/php/"$version"/mods-available/"$extension".ini ]; then
+    if [[ ! "$version" =~ ${old_versions:?} ]] && [ -e /etc/php/"$version"/mods-available/"$extension".ini ]; then
       sudo phpdismod -v "$version" "$extension" >/dev/null 2>&1
     fi
     delete_extension "$extension"
-    (! check_extension "$extension" && add_log "$tick" ":$extension" "Removed") ||
-    add_log "$cross" ":$extension" "Could not remove $extension on PHP $semver"
+    (! check_extension "$extension" && add_log "${tick:?}" ":$extension" "Removed") ||
+      add_log "${cross:?}" ":$extension" "Could not remove $extension on PHP ${semver:?}"
   else
-    add_log "$tick" ":$extension" "Could not find $extension on PHP $semver"
-  fi
-}
-
-# Function to enable existing extensions.
-enable_extension() {
-  if ! check_extension "$1" && [ -e "$ext_dir/$1.so" ]; then
-    echo "$2=$1.so" >>"$pecl_file"
+    add_log "${tick:?}" ":$extension" "Could not find $extension on PHP $semver"
   fi
 }
 
@@ -157,19 +75,19 @@ enable_extension() {
 add_pdo_extension() {
   pdo_ext="pdo_$1"
   if check_extension "$pdo_ext"; then
-    add_log "$tick" "$pdo_ext" "Enabled"
+    add_log "${tick:?}" "$pdo_ext" "Enabled"
   else
-    read -r ext ext_name <<< "$1 $1"
+    ext=$1; ext_name=$1;
     sudo rm -rf "$scan_dir"/*pdo.ini >/dev/null 2>&1
-    if ! check_extension "pdo" 2>/dev/null; then echo "extension=pdo.so" >> "$ini_file"; fi
+    if ! check_extension "pdo" 2>/dev/null; then echo "extension=pdo.so" >>"$ini_file"; fi
     if [ "$ext" = "mysql" ]; then
       enable_extension "mysqlnd" "extension"
       ext_name="mysqli"
     elif [ "$ext" = "sqlite" ]; then
-      read -r ext ext_name <<< "sqlite3 sqlite3"
+      ext="sqlite3"; ext_name="sqlite3";
     fi
-    add_extension "$ext_name" "$apt_install php$version-$ext" "extension" >/dev/null 2>&1
-    add_extension "$pdo_ext" "pecl_install $pdo_ext" "extension" >/dev/null 2>&1
+    add_extension "$ext_name" "extension" >/dev/null 2>&1
+    add_extension "$pdo_ext" "extension" >/dev/null 2>&1
     add_extension_log "$pdo_ext" "Enabled"
   fi
 }
@@ -177,20 +95,17 @@ add_pdo_extension() {
 # Function to add extensions.
 add_extension() {
   extension=$1
-  install_command=$2
-  prefix=$3
+  prefix=$2
   enable_extension "$extension" "$prefix"
   if check_extension "$extension"; then
-    add_log "$tick" "$extension" "Enabled"
+    add_log "${tick:?}" "$extension" "Enabled"
   else
     if [[ "$version" =~ 5.[4-5] ]]; then
-      install_command="update_lists && ${install_command/5\.[4-5]-$extension/5-$extension=$release_version}"
-    fi
-    if [[ "$version" =~ $nightly_versions ]]; then
+      install_packages "php5-$extension=$release_version"
+    elif [[ "$version" =~ ${nightly_versions:?} ]]; then
       pecl_install "$extension"
     else
-      eval "$install_command" >/dev/null 2>&1 ||
-      (update_lists && eval "$install_command" >/dev/null 2>&1) || pecl_install "$extension"
+      install_packages "php$version-$extension" || pecl_install "$extension"
     fi
     add_extension_log "$extension" "Installed and enabled"
   fi
@@ -205,26 +120,15 @@ add_pecl_extension() {
   if [[ $pecl_version =~ .*(alpha|beta|rc|snapshot|preview).* ]]; then
     pecl_version=$(get_pecl_version "$extension" "$pecl_version")
   fi
-  if ! check_extension "$extension" && [ -e "$ext_dir/$extension.so" ]; then
-    echo "$prefix=$ext_dir/$extension.so" >>"$pecl_file"
-  fi
+  enable_extension "$extension" "$prefix"
   ext_version=$(php -r "echo phpversion('$extension');")
   if [ "$ext_version" = "$pecl_version" ]; then
-    add_log "$tick" "$extension" "Enabled"
+    add_log "${tick:?}" "$extension" "Enabled"
   else
     delete_extension "$extension"
     pecl_install "$extension-$pecl_version"
     add_extension_log "$extension-$pecl_version" "Installed and enabled"
   fi
-}
-
-# Function to pre-release extensions using PECL.
-add_unstable_extension() {
-  extension=$1
-  stability=$2
-  prefix=$3
-  pecl_version=$(get_pecl_version "$extension" "$stability")
-  add_pecl_extension "$extension" "$pecl_version" "$prefix"
 }
 
 # Function to install extension from source
@@ -237,128 +141,37 @@ add_extension_from_source() {
   (
     add_devtools phpize
     delete_extension "$extension"
-    curl -o /tmp/"$extension".tar.gz  "${curl_opts[@]}" https://github.com/"$repo"/archive/"$release".tar.gz
+    curl -o /tmp/"$extension".tar.gz "${curl_opts[@]:?}" https://github.com/"$repo"/archive/"$release".tar.gz
     tar xf /tmp/"$extension".tar.gz -C /tmp
     cd /tmp/"$extension-$release" || exit 1
-    phpize  && ./configure "$args" && make && sudo make install
+    phpize && ./configure "$args" && make -j"$(nproc)" && sudo make install
     enable_extension "$extension" "$prefix"
   ) >/dev/null 2>&1
   add_extension_log "$extension-$release" "Installed and enabled"
 }
 
-# Function to configure composer
-configure_composer() {
-  tool_path=$1
-  sudo ln -sf "$tool_path" "$tool_path.phar"
-  php -r "try {\$p=new Phar('$tool_path.phar', 0);exit(0);} catch(Exception \$e) {exit(1);}"
-  if [ $? -eq 1 ]; then
-    add_log "$cross" "composer" "Could not download composer"
-    exit 1;
-  fi
-  composer -q global config process-timeout 0
-  echo "$composer_bin" >> "$GITHUB_PATH"
-  if [ -n "$COMPOSER_TOKEN" ]; then
-    composer -q global config github-oauth.github.com "$COMPOSER_TOKEN"
-  fi
-}
-
-# Function to extract tool version.
-get_tool_version() {
-  tool=$1
-  param=$2
-  version_regex="[0-9]+((\.{1}[0-9]+)+)(\.{0})(-[a-zA-Z0-9]+){0,1}"
-  if [ "$tool" = "composer" ]; then
-    if [ "$param" != "snapshot" ]; then
-      grep -Ea "const\sVERSION" "$tool_path_dir/composer" | grep -Eo "$version_regex"
-    else
-      trunk=$(grep -Ea "const\sBRANCH_ALIAS_VERSION" "$tool_path_dir/composer" | grep -Eo "$version_regex")
-      commit=$(grep -Ea "const\sVERSION" "$tool_path_dir/composer" | grep -Eo "[a-zA-z0-9]+" | tail -n 1)
-      echo "$trunk+$commit"
-    fi
-  else
-    $tool "$param" 2>/dev/null | sed -Ee "s/[Cc]omposer(.)?$version_regex//g" | grep -Eo "$version_regex" | head -n 1
-  fi
-}
-
-# Function to setup a remote tool.
-add_tool() {
-  url=$1
-  tool=$2
-  ver_param=$3
-  tool_path="$tool_path_dir/$tool"
-  if [ ! -e "$tool_path" ]; then
-    rm -rf "$tool_path"
-  fi
-  if [ "$tool" = "composer" ]; then
-    IFS="," read -r -a urls <<< "$url"
-    status_code=$(sudo curl -f -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "${urls[0]}") ||
-    status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "${urls[1]}")
-  else
-    status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
-    if [ "$status_code" != "200" ] && [[ "$url" =~ .*github.com.*releases.*latest.* ]]; then
-      url=$(echo $url | sed -e "s|releases/latest/download|releases/download/$(curl "${curl_opts[@]}" "$(echo "$url" | cut -d '/' -f '1-5')/releases" | grep -Eo -m 1 "([0-9]+\.[0-9]+\.[0-9]+)/$(echo "$url" | sed -e "s/.*\///")" | cut -d '/' -f 1)|")
-      status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
-    fi
-  fi
-  if [ "$status_code" = "200" ]; then
-    sudo chmod a+x "$tool_path"
-    if [ "$tool" = "composer" ]; then
-      configure_composer "$tool_path"
-    elif [ "$tool" = "cs2pr" ]; then
-      sudo sed -i 's/\r$//; s/exit(9)/exit(0)/' "$tool_path"
-    elif [ "$tool" = "phan" ]; then
-      add_extension fileinfo "$apt_install php$version-fileinfo" extension >/dev/null 2>&1
-      add_extension ast "$apt_install php-ast" extension >/dev/null 2>&1
-    elif [ "$tool" = "phive" ]; then
-      add_extension curl "$apt_install php$version-curl" extension >/dev/null 2>&1
-      add_extension mbstring "$apt_install php$version-mbstring" extension >/dev/null 2>&1
-      add_extension xml "$apt_install php$version-xml" extension >/dev/null 2>&1
-    elif [ "$tool" = "wp-cli" ]; then
-      sudo cp -p "$tool_path" "$tool_path_dir"/wp
-    fi
-    tool_version=$(get_tool_version "$tool" "$ver_param")
-    add_log "$tick" "$tool" "Added $tool $tool_version"
-  else
-    add_log "$cross" "$tool" "Could not setup $tool"
-  fi
-}
-
-# Function to setup a tool using composer.
-add_composertool() {
-  tool=$1
-  release=$2
-  prefix=$3
-  (
-    composer global require "$prefix$release" >/dev/null 2>&1 &&
-    json=$(grep "$prefix$tool" /home/"$USER"/.composer/composer.json) &&
-    tool_version=$(get_tool_version 'echo' "$json") &&
-    add_log "$tick" "$tool" "Added $tool $tool_version"
-  ) || add_log "$cross" "$tool" "Could not setup $tool"
-  if [ -e "$composer_bin/composer" ]; then
-    sudo cp -p "$tool_path_dir/composer" "$composer_bin"
-  fi
-}
-
 # Function to setup phpize and php-config.
 add_devtools() {
   tool=$1
-  if ! [ -e "/usr/bin/phpize$version" ] || ! [ -e "/usr/bin/php-config$version" ]; then
-    update_lists && $apt_install php"$version"-dev php"$version"-xml >/dev/null 2>&1
+  if ! command -v "$tool$version" >/dev/null; then
+    install_packages "php$version-dev" "php$version-xml"
   fi
   sudo update-alternatives --set php-config /usr/bin/php-config"$version" >/dev/null 2>&1
   sudo update-alternatives --set phpize /usr/bin/phpize"$version" >/dev/null 2>&1
-  configure_pecl >/dev/null 2>&1
-  add_log "$tick" "$tool" "Added $tool $semver"
+  if command -v pecl >/dev/null; then
+    configure_pecl >/dev/null 2>&1
+  fi
+  add_log "${tick:?}" "$tool" "Added $tool $semver"
 }
 
 # Function to setup the nightly build from shivammathur/php-builder
 setup_nightly() {
-  curl "${curl_opts[@]}" "$github"/php-builder/releases/latest/download/install.sh | bash -s "$runner" "$version"
+  curl "${curl_opts[@]:?}" "${github:?}"/php-builder/releases/latest/download/install.sh | bash -s "$runner" "$version"
 }
 
 # Function to setup PHP 5.3, PHP 5.4 and PHP 5.5.
 setup_old_versions() {
-  curl "${curl_opts[@]}" "$github"/php5-ubuntu/releases/latest/download/install.sh | bash -s "$version"
+  curl "${curl_opts[@]:?}" "${github:?}"/php5-ubuntu/releases/latest/download/install.sh | bash -s "$version"
   configure_pecl
   release_version=$(php -v | head -n 1 | cut -d' ' -f 2)
 }
@@ -366,48 +179,40 @@ setup_old_versions() {
 # Function to add PECL.
 add_pecl() {
   add_devtools phpize >/dev/null 2>&1
-  if [ ! -e /usr/bin/pecl ]; then
-    $apt_install php-pear >/dev/null 2>&1 || update_lists && $apt_install php-pear >/dev/null 2>&1
+  if ! command -v pecl >/dev/null; then
+    install_packages php-pear
   fi
   configure_pecl >/dev/null 2>&1
   pecl_version=$(get_tool_version "pecl" "version")
-  add_log "$tick" "PECL" "Added PECL $pecl_version"
+  add_log "${tick:?}" "PECL" "Added PECL $pecl_version"
 }
 
 # Function to switch versions of PHP binaries.
 switch_version() {
   for tool in pear pecl php phar phar.phar php-cgi php-config phpize phpdbg; do
     if [ -e "/usr/bin/$tool$version" ]; then
-      sudo update-alternatives --set $tool /usr/bin/"$tool$version"
+      sudo update-alternatives --set $tool /usr/bin/"$tool$version" &
+      to_wait+=( $! )
     fi
   done
-}
-
-# Function to get PHP version in semver format.
-php_semver() {
-  if ! [[ "$version" =~ $nightly_versions ]]; then
-    php"$version" -v | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '-'
-  else
-    php -v | head -n 1 | cut -f 2 -d ' '
-  fi
+  wait "${to_wait[@]}"
 }
 
 # Function to install packaged PHP
 add_packaged_php() {
   if [ "$runner" = "self-hosted" ] || [ "${use_package_cache:-true}" = "false" ]; then
     update_lists
-    IFS=' ' read -r -a packages <<< "$(echo "cli curl mbstring xml intl" | sed "s/[^ ]*/php$version-&/g")"
+    IFS=' ' read -r -a packages <<<"$(echo "cli curl mbstring xml intl" | sed "s/[^ ]*/php$version-&/g")"
     $apt_install "${packages[@]}"
   else
-    curl "${curl_opts[@]}" "$github"/php-ubuntu/releases/latest/download/install.sh | bash -s "$version"
+    curl "${curl_opts[@]:?}" "${github:?}"/php-ubuntu/releases/latest/download/install.sh | bash -s "$version"
   fi
 }
 
 # Function to update PHP.
 update_php() {
   initial_version=$(php_semver)
-  use_package_cache="false"
-  add_packaged_php
+  use_package_cache="false" add_packaged_php
   updated_version=$(php_semver)
   if [ "$updated_version" != "$initial_version" ]; then
     status="Updated to"
@@ -418,9 +223,9 @@ update_php() {
 
 # Function to install PHP.
 add_php() {
-  if [[ "$version" =~ $nightly_versions ]]; then
+  if [[ "$version" =~ ${nightly_versions:?} ]]; then
     setup_nightly
-  elif [[ "$version" =~ $old_versions ]]; then
+  elif [[ "$version" =~ ${old_versions:?} ]]; then
     setup_old_versions
   else
     add_packaged_php
@@ -428,68 +233,52 @@ add_php() {
   status="Installed"
 }
 
-# Variables
-tick="✓"
-cross="✗"
-pecl_config="false"
-version=$1
-dist=$2
-fail_fast=$3
-nightly_versions="8.[0-1]"
-old_versions="5.[3-5]"
-debconf_fix="DEBIAN_FRONTEND=noninteractive"
-github="https://github.com/shivammathur"
-apt_install="sudo $debconf_fix apt-get install -y"
-apt_remove="sudo $debconf_fix apt-get remove -y"
-composer_bin="/home/$USER/.composer/vendor/bin"
-tool_path_dir="/usr/local/bin"
-curl_opts=(-sL)
-existing_version=$(php-config --version 2>/dev/null | cut -c 1-3)
-
-read_env
-if [ "$runner" = "self-hosted" ]; then
-  if [[ "$version" =~ $old_versions ]]; then
-    add_log "$cross" "PHP" "PHP $version is not supported on self-hosted runner"
-    exit 1
-  else
-    self_hosted_setup >/dev/null 2>&1
-  fi
-fi
-
-# Setup PHP
-step_log "Setup PHP"
-sudo mkdir -m 777 -p /home/"$USER"/.composer /var/run /run/php
-if [ "$existing_version" != "$version" ]; then
-  if [ ! -e "/usr/bin/php$version" ]; then
-    add_php >/dev/null 2>&1
+# Function to Setup PHP
+setup_php() {
+  step_log "Setup PHP"
+  sudo mkdir -m 777 -p /var/run /run/php
+  if [ "$(php-config --version 2>/dev/null | cut -c 1-3)" != "$version" ]; then
+    if [ ! -e "/usr/bin/php$version" ]; then
+      add_php >/dev/null 2>&1
+    else
+      if [ "${update:?}" = "true" ]; then
+        update_php >/dev/null 2>&1
+      else
+        status="Switched to"
+      fi
+    fi
+    if ! [[ "$version" =~ ${old_versions:?}|${nightly_versions:?} ]]; then
+      switch_version >/dev/null 2>&1
+    fi
   else
     if [ "$update" = "true" ]; then
       update_php >/dev/null 2>&1
     else
-      status="Switched to"
+      status="Found"
     fi
   fi
-  if ! [[ "$version" =~ $old_versions ]]; then
-    switch_version >/dev/null 2>&1
-  fi
-else
-  if [ "$update" = "true" ]; then
-    update_php >/dev/null 2>&1
-  else
-    status="Found"
-    if [[ "$version" =~ $nightly_versions ]]; then
-      switch_version >/dev/null 2>&1
-    fi
-  fi
-fi
+  semver=$(php_semver)
+  ext_dir=$(php -i | grep "extension_dir => /" | sed -e "s|.*=> s*||")
+  scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
+  ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
+  pecl_file="$scan_dir"/99-pecl.ini
+  echo '' | sudo tee "$pecl_file" >/dev/null 2>&1
+  sudo rm -rf /usr/local/bin/phpunit >/dev/null 2>&1
+  sudo chmod 777 "$ini_file" "$pecl_file" "${tool_path_dir:?}"
+  sudo cp "$dist"/../src/configs/*.json "$RUNNER_TOOL_CACHE/"
+  add_log "${tick:?}" "PHP" "$status PHP $semver"
+}
 
-semver=$(php_semver)
-ext_dir=$(php -i | grep "extension_dir => /" | sed -e "s|.*=> s*||")
-scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
-ini_file=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
-pecl_file="$scan_dir"/99-pecl.ini
-echo '' | sudo tee "$pecl_file" >/dev/null 2>&1
-sudo rm -rf /usr/local/bin/phpunit >/dev/null 2>&1
-sudo chmod 777 "$ini_file" "$pecl_file" "$tool_path_dir"
-sudo cp "$dist"/../src/configs/*.json "$RUNNER_TOOL_CACHE/"
-add_log "$tick" "PHP" "$status PHP $semver"
+# Variables
+version=$1
+dist=$2
+debconf_fix="DEBIAN_FRONTEND=noninteractive"
+apt_install="sudo $debconf_fix apt-get install -y"
+apt_remove="sudo $debconf_fix apt-get remove -y"
+
+# shellcheck source=.
+. "${dist}"/../src/scripts/common.sh
+. /etc/lsb-release
+read_env
+self_hosted_setup
+setup_php

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -141,7 +141,7 @@ add_extension_from_source() {
   (
     add_devtools phpize
     delete_extension "$extension"
-    curl -o /tmp/"$extension".tar.gz "${curl_opts[@]:?}" https://github.com/"$repo"/archive/"$release".tar.gz
+    get -q -n "/tmp/$extension.tar.gz" "https://github.com/$repo/archive/$release.tar.gz"
     tar xf /tmp/"$extension".tar.gz -C /tmp
     cd /tmp/"$extension-$release" || exit 1
     phpize && ./configure "$args" && make -j"$(nproc)" && sudo make install
@@ -166,12 +166,12 @@ add_devtools() {
 
 # Function to setup the nightly build from shivammathur/php-builder
 setup_nightly() {
-  curl "${curl_opts[@]:?}" "${github:?}"/php-builder/releases/latest/download/install.sh | bash -s "$runner" "$version"
+  run_script "php-builder" "$runner" "$version"
 }
 
 # Function to setup PHP 5.3, PHP 5.4 and PHP 5.5.
 setup_old_versions() {
-  curl "${curl_opts[@]:?}" "${github:?}"/php5-ubuntu/releases/latest/download/install.sh | bash -s "$version"
+  run_script "php5-ubuntu" "$version"
   configure_pecl
   release_version=$(php -v | head -n 1 | cut -d' ' -f 2)
 }
@@ -205,7 +205,7 @@ add_packaged_php() {
     IFS=' ' read -r -a packages <<<"$(echo "cli curl mbstring xml intl" | sed "s/[^ ]*/php$version-&/g")"
     $apt_install "${packages[@]}"
   else
-    curl "${curl_opts[@]:?}" "${github:?}"/php-ubuntu/releases/latest/download/install.sh | bash -s "$version"
+    run_script "php-ubuntu" "$version"
   fi
 }
 

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -295,6 +295,10 @@ add_tool() {
     status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "${urls[1]}")
   else
     status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
+    if [ "$status_code" != "200" ] && [[ "$url" =~ .*github.com.*releases.*latest.* ]]; then
+      url=$(echo $url | sed -e "s|releases/latest/download|releases/download/$(curl "${curl_opts[@]}" "$(echo "$url" | cut -d '/' -f '1-5')/releases" | grep -Eo -m 1 "([0-9]+\.[0-9]+\.[0-9]+)/$(echo "$url" | sed -e "s/.*\///")" | cut -d '/' -f 1)|")
+      status_code=$(sudo curl -w "%{http_code}" -o "$tool_path" "${curl_opts[@]}" "$url")
+    fi
   fi
   if [ "$status_code" = "200" ]; then
     sudo chmod a+x "$tool_path"

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -186,8 +186,12 @@ add_extension() {
     if [[ "$version" =~ 5.[4-5] ]]; then
       install_command="update_lists && ${install_command/5\.[4-5]-$extension/5-$extension=$release_version}"
     fi
-    eval "$install_command" >/dev/null 2>&1 ||
-    (update_lists && eval "$install_command" >/dev/null 2>&1) || pecl_install "$extension"
+    if [[ "$version" =~ $nightly_versions ]]; then
+      pecl_install "$extension"
+    else
+      eval "$install_command" >/dev/null 2>&1 ||
+      (update_lists && eval "$install_command" >/dev/null 2>&1) || pecl_install "$extension"
+    fi
     add_extension_log "$extension" "Installed and enabled"
   fi
   sudo chmod 777 "$ini_file"

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -62,11 +62,13 @@ remove_extension() {
   if check_extension "$extension"; then
     if [[ ! "$version" =~ ${old_versions:?} ]] && [ -e /etc/php/"$version"/mods-available/"$extension".ini ]; then
       sudo phpdismod -v "$version" "$extension" >/dev/null 2>&1
+      echo "$extension" | sudo tee -a /tmp/setup_php_dismod >/dev/null 2>&1
     fi
     delete_extension "$extension"
     (! check_extension "$extension" && add_log "${tick:?}" ":$extension" "Removed") ||
       add_log "${cross:?}" ":$extension" "Could not remove $extension on PHP ${semver:?}"
   else
+    delete_extension "$extension"
     add_log "${tick:?}" ":$extension" "Could not find $extension on PHP $semver"
   fi
 }

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -92,7 +92,7 @@ configure_pecl() {
 # Function to get the PECL version of an extension.
 get_pecl_version() {
   extension=$1
-  stability="$(echo "$2" | grep -m 1 -Eio "(alpha|beta|rc|snapshot)")"
+  stability="$(echo "$2" | grep -m 1 -Eio "(alpha|beta|rc|snapshot|preview)")"
   pecl_rest='https://pecl.php.net/rest/r/'
   response=$(curl "${curl_opts[@]}" "$pecl_rest$extension"/allreleases.xml)
   pecl_version=$(echo "$response" | grep -m 1 -Pio "(\d*\.\d*\.\d*$stability\d*)")
@@ -202,7 +202,7 @@ add_pecl_extension() {
   extension=$1
   pecl_version=$2
   prefix=$3
-  if [[ $pecl_version =~ .*(alpha|beta|rc|snapshot).* ]]; then
+  if [[ $pecl_version =~ .*(alpha|beta|rc|snapshot|preview).* ]]; then
     pecl_version=$(get_pecl_version "$extension" "$pecl_version")
   fi
   if ! check_extension "$extension" && [ -e "$ext_dir/$extension.so" ]; then

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -252,7 +252,7 @@ configure_composer() {
     exit 1;
   fi
   composer -q global config process-timeout 0
-  echo "/home/$USER/.composer/vendor/bin" >> "$GITHUB_PATH"
+  echo "$composer_bin" >> "$GITHUB_PATH"
   if [ -n "$COMPOSER_TOKEN" ]; then
     composer -q global config github-oauth.github.com "$COMPOSER_TOKEN"
   fi
@@ -326,6 +326,9 @@ add_composertool() {
     tool_version=$(get_tool_version 'echo' "$json") &&
     add_log "$tick" "$tool" "Added $tool $tool_version"
   ) || add_log "$cross" "$tool" "Could not setup $tool"
+  if [ -e "$composer_bin/composer" ]; then
+    sudo cp -p "$tool_path_dir/composer" "$composer_bin"
+  fi
 }
 
 # Function to setup phpize and php-config.
@@ -430,6 +433,7 @@ debconf_fix="DEBIAN_FRONTEND=noninteractive"
 github="https://github.com/shivammathur"
 apt_install="sudo $debconf_fix apt-get install -y"
 apt_remove="sudo $debconf_fix apt-get remove -y"
+composer_bin="/home/$USER/.composer/vendor/bin"
 tool_path_dir="/usr/local/bin"
 curl_opts=(-sL)
 existing_version=$(php-config --version 2>/dev/null | cut -c 1-3)
@@ -446,7 +450,7 @@ fi
 
 # Setup PHP
 step_log "Setup PHP"
-sudo mkdir -p /var/run /run/php
+sudo mkdir -m 777 -p /home/"$USER"/.composer /var/run /run/php
 if [ "$existing_version" != "$version" ]; then
   if [ ! -e "/usr/bin/php$version" ]; then
     add_php >/dev/null 2>&1

--- a/src/scripts/tools/blackfire.ps1
+++ b/src/scripts/tools/blackfire.ps1
@@ -6,7 +6,7 @@ Function Add-Blackfire() {
   }
   $agent_version = (Invoke-RestMethod https://blackfire.io/api/v1/releases).agent
   $url = "https://packages.blackfire.io/binaries/blackfire-agent/${agent_version}/blackfire-agent-windows_${arch_name}.zip"
-  Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $bin_dir\blackfire.zip >$null 2>&1
+  Invoke-WebRequest -Uri $url -OutFile $bin_dir\blackfire.zip >$null 2>&1
   Expand-Archive -Path $bin_dir\blackfire.zip -DestinationPath $bin_dir -Force >$null 2>&1
   Add-ToProfile $current_profile 'blackfire' "New-Alias blackfire $bin_dir\blackfire.exe"
   Add-ToProfile $current_profile 'blackfire-agent' "New-Alias blackfire-agent $bin_dir\blackfire-agent.exe"

--- a/src/scripts/tools/blackfire.sh
+++ b/src/scripts/tools/blackfire.sh
@@ -1,6 +1,6 @@
 add_blackfire_linux() {
   sudo mkdir -p /var/run/blackfire
-  sudo curl "${curl_opts[@]:?}" https://packages.blackfire.io/gpg.key | sudo apt-key add -
+  get -s -n "" https://packages.blackfire.io/gpg.key | sudo apt-key add -
   echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list
   sudo "${debconf_fix:?}" apt-get update
   ${apt_install:?} blackfire-agent

--- a/src/scripts/tools/grpc_php_plugin.sh
+++ b/src/scripts/tools/grpc_php_plugin.sh
@@ -3,7 +3,7 @@ add_bazel() {
     os=$(uname -s)
     if [ "$os" = "Linux" ]; then
       ${apt_install:?} curl gnupg
-      curl "${curl_opts[@]:?}" https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+      get -s -n "" https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
       echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
       sudo "${debconf_fix:?}" apt-get update -y
       ${apt_install:?} bazel
@@ -15,13 +15,13 @@ add_bazel() {
 
 get_grpc_tag() {
   if [ "$grpc_tag" = "latest" ]; then
-    grpc_tag=$(curl "${curl_opts[@]:?}" https://grpc.io/release)
+    grpc_tag=$(get -s -n "" https://grpc.io/release)
   else
-    status_code=$(sudo curl -s -w "%{http_code}" -o /tmp/grpc.tmp "${curl_opts[@]:?}" "https://github.com/grpc/grpc/releases/tag/v$grpc_tag")
+    status_code=$(get -v -n /tmp/grpc.tmp "https://github.com/grpc/grpc/releases/tag/v$grpc_tag")
     if [ "$status_code" = "200" ]; then
       grpc_tag="v$grpc_tag"
     else
-      grpc_tag=$(curl "${curl_opts[@]:?}" https://grpc.io/release)
+      grpc_tag=$(get -s -n "" https://grpc.io/release)
     fi
   fi
 }
@@ -30,7 +30,7 @@ add_grpc_php_plugin() {
   grpc_tag=$1
   get_grpc_tag
   (
-    curl "${curl_opts[@]:?}" "https://github.com/grpc/grpc/archive/$grpc_tag.tar.gz" | tar -xz -C /tmp
+    get -s -n "" "https://github.com/grpc/grpc/archive/$grpc_tag.tar.gz" | tar -xz -C /tmp
     cd "/tmp/grpc-${grpc_tag:1}" || exit
     add_bazel
     echo "os: $os"

--- a/src/scripts/tools/grpc_php_plugin.sh
+++ b/src/scripts/tools/grpc_php_plugin.sh
@@ -1,13 +1,12 @@
 add_bazel() {
-  if [ ! "$(command -v bazel)" ]; then
-    os=$(uname -s)
-    if [ "$os" = "Linux" ]; then
+  if ! command -v bazel; then
+    if [ "$(uname -s)" = "Linux" ]; then
       ${apt_install:?} curl gnupg
       get -s -n "" https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
       echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
       sudo "${debconf_fix:?}" apt-get update -y
       ${apt_install:?} bazel
-    elif [ "$os" = "Darwin" ]; then
+    else
       brew install bazel
     fi
   fi
@@ -33,8 +32,7 @@ add_grpc_php_plugin() {
     get -s -n "" "https://github.com/grpc/grpc/archive/$grpc_tag.tar.gz" | tar -xz -C /tmp
     cd "/tmp/grpc-${grpc_tag:1}" || exit
     add_bazel
-    echo "os: $os"
-    echo "release: $DISTRIB_RELEASE"
+    [ "$(uname -s)" = "Darwin" ] && sudo xcode-select -s /Applications/Xcode_11.7.app
     if [ "$DISTRIB_RELEASE" = "16.04" ]; then
       CC="$(command -v gcc)" CXX="$(command -v g++)" ./tools/bazel build src/compiler:grpc_php_plugin
     else

--- a/src/scripts/tools/protoc.ps1
+++ b/src/scripts/tools/protoc.ps1
@@ -27,7 +27,7 @@ Function Add-Protoc() {
     $arch_num = '32'
   }
   $url = "https://github.com/protocolbuffers/protobuf/releases/download/$protobuf_tag/protoc-$($protobuf_tag -replace 'v', '')-win$arch_num.zip"
-  Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $bin_dir\protoc.zip >$null 2>&1
+  Invoke-WebRequest -Uri $url -OutFile $bin_dir\protoc.zip >$null 2>&1
   Expand-Archive -Path $bin_dir\protoc.zip -DestinationPath $bin_dir\protoc -Force >$null 2>&1
   Move-Item -Path $bin_dir\protoc\bin\protoc.exe -Destination $bin_dir\protoc.exe
   Add-ToProfile $current_profile 'protoc' "New-Alias protoc $bin_dir\protoc.exe"

--- a/src/scripts/tools/protoc.sh
+++ b/src/scripts/tools/protoc.sh
@@ -1,12 +1,12 @@
 get_protobuf_tag() {
   if [ "$protobuf_tag" = "latest" ]; then
-    protobuf_tag=$(curl "${curl_opts[@]:?}" https://github.com/protocolbuffers/protobuf/releases/latest 2<&1 | grep -m 1 -Eo "(v[0-9]+\.[0-9]+\.[0-9]+)" | head -n 1)
+    protobuf_tag=$(get -s -n "" https://github.com/protocolbuffers/protobuf/releases/latest 2<&1 | grep -m 1 -Eo "(v[0-9]+\.[0-9]+\.[0-9]+)" | head -n 1)
   else
-    status_code=$(sudo curl -s -w "%{http_code}" -o /tmp/protobuf.tmp "${curl_opts[@]:?}" "https://github.com/protocolbuffers/protobuf/releases/tag/v$protobuf_tag")
+    status_code=$(get -v -n /tmp/protobuf.tmp "https://github.com/protocolbuffers/protobuf/releases/tag/v$protobuf_tag")
     if [ "$status_code" = "200" ]; then
       protobuf_tag="v$protobuf_tag"
     else
-      protobuf_tag=$(curl "${curl_opts[@]:?}" https://github.com/protocolbuffers/protobuf/releases/latest 2<&1 | grep -m 1 -Eo "(v[0-9]+\.[0-9]+\.[0-9]+)" | head -n 1)
+      protobuf_tag=$(get -s -n "" https://github.com/protocolbuffers/protobuf/releases/latest 2<&1 | grep -m 1 -Eo "(v[0-9]+\.[0-9]+\.[0-9]+)" | head -n 1)
     fi
   fi
 }
@@ -17,7 +17,7 @@ add_protoc() {
   (
     platform='linux'
     [ "$(uname -s)" = "Darwin" ] && platform='osx'
-    curl -o /tmp/protobuf.zip "${curl_opts[@]:?}" "https://github.com/protocolbuffers/protobuf/releases/download/$protobuf_tag/protoc-${protobuf_tag:1}-$platform-x86_64.zip"
+    get -q -n /tmp/protobuf.zip "https://github.com/protocolbuffers/protobuf/releases/download/$protobuf_tag/protoc-${protobuf_tag:1}-$platform-x86_64.zip"
     sudo unzip /tmp/protobuf.zip -d /usr/local/
     sudo chmod 777 /usr/local/bin/protoc -R /usr/local/include/google
   ) >/dev/null 2>&1

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -79,7 +79,7 @@ Function Add-Printf {
     if(Test-Path "C:\msys64\usr\bin\printf.exe") {
       New-Item -Path $bin_dir\printf.exe -ItemType SymbolicLink -Value C:\msys64\usr\bin\printf.exe
     } else {
-      Invoke-WebRequest -UseBasicParsing -Uri "$github/shivammathur/printf/releases/latest/download/printf-x64.zip" -OutFile "$bin_dir\printf.zip"
+      Invoke-WebRequest -Uri "$github/shivammathur/printf/releases/latest/download/printf-x64.zip" -OutFile "$bin_dir\printf.zip"
       Expand-Archive -Path $bin_dir\printf.zip -DestinationPath $bin_dir -Force
     }
   } else {
@@ -109,7 +109,7 @@ Function Install-PSPackage() {
   $module_path = "$bin_dir\$psm1_path.psm1"
   if(-not (Test-Path $module_path -PathType Leaf)) {
     $zip_file = "$bin_dir\$package.zip"
-    Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $zip_file
+    Invoke-WebRequest -Uri $url -OutFile $zip_file
     Expand-Archive -Path $zip_file -DestinationPath $bin_dir -Force
   }
   Import-Module $module_path
@@ -250,16 +250,16 @@ Function Add-Tool() {
   }
   if($url.Count -gt 1) { $url = $url[0] }
   if ($tool -eq "symfony") {
-    Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $bin_dir\$tool.exe
+    Invoke-WebRequest -Uri $url -OutFile $bin_dir\$tool.exe
     Add-ToProfile $current_profile $tool "New-Alias $tool $bin_dir\$tool.exe" >$null 2>&1
   } else {
     try {
-      Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $bin_dir\$tool
+      Invoke-WebRequest -Uri $url -OutFile $bin_dir\$tool
     } catch {
       if($url -match '.*github.com.*releases.*latest.*') {
         try {
-          $url = $url.replace("releases/latest/download", "releases/download/" + ([regex]::match((Invoke-WebRequest -UseBasicParsing -Uri ($url.split('/release')[0] + "/releases")).Content, "([0-9]+\.[0-9]+\.[0-9]+)/" + ($url.Substring($url.LastIndexOf("/") + 1))).Groups[0].Value).split('/')[0])
-          Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $bin_dir\$tool
+          $url = $url.replace("releases/latest/download", "releases/download/" + ([regex]::match((Invoke-WebRequest -Uri ($url.split('/release')[0] + "/releases")).Content, "([0-9]+\.[0-9]+\.[0-9]+)/" + ($url.Substring($url.LastIndexOf("/") + 1))).Groups[0].Value).split('/')[0])
+          Invoke-WebRequest -Uri $url -OutFile $bin_dir\$tool
         } catch { }
       }
     }
@@ -342,7 +342,6 @@ $ProgressPreference = 'SilentlyContinue'
 $nightly_version = '8.[0-9]'
 $cert_source='CurrentUser'
 $enable_extensions = ('openssl', 'curl', 'mbstring')
-$wc = New-Object System.Net.WebClient
 
 $arch = 'x64'
 if(-not([Environment]::Is64BitOperatingSystem) -or $version -lt '7.0') {
@@ -397,7 +396,7 @@ if ($null -eq $installed -or -not("$($installed.Version).".StartsWith(($version 
     Install-PSPackage VcRedist VcRedist-main\VcRedist\VcRedist "$github/aaronparker/VcRedist/archive/main.zip" >$null 2>&1
   }
   if ($version -match $nightly_version) {
-    $wc.DownloadFile("$bintray/Get-PhpNightly.ps1", "$php_dir\Get-PhpNightly.ps1") > $null 2>&1
+    Invoke-WebRequest -Uri $bintray/Get-PhpNightly.ps1 -OutFile $php_dir\Get-PhpNightly.ps1 > $null 2>&1
     & $php_dir\Get-PhpNightly.ps1 -Architecture $arch -ThreadSafe $ts -Path $php_dir -Version $version > $null 2>&1
   } else {
     Install-Php -Version $version -Architecture $arch -ThreadSafe $ts -InstallVC -Path $php_dir -TimeZone UTC -InitialPhpIni Production -Force > $null 2>&1
@@ -414,7 +413,7 @@ if ($null -eq $installed -or -not("$($installed.Version).".StartsWith(($version 
 $installed = Get-Php -Path $php_dir
 ('date.timezone=UTC', 'memory_limit=-1') | foreach { $p=$_.split('='); Set-PhpIniKey -Key $p[0] -Value $p[1] -Path $php_dir }
 if($version -lt "5.5") {
-  ('libeay32.dll', 'ssleay32.dll') | ForEach { $wc.DownloadFile("$bintray/$_", "$php_dir\$_") >$null 2>&1 }
+  ('libeay32.dll', 'ssleay32.dll') | ForEach { Invoke-WebRequest -Uri $bintray/$_ -OutFile $php_dir\$_ >$null 2>&1 }
 } else {
   $enable_extensions += ('opcache')
 }

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -197,7 +197,7 @@ Function Edit-ComposerConfig() {
     exit 1;
   }
   composer -q global config process-timeout 0
-  Write-Output "$env:APPDATA\Composer\vendor\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+  Write-Output $composer_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
   if (Test-Path env:COMPOSER_TOKEN) {
     composer -q global config github-oauth.github.com $env:COMPOSER_TOKEN
   }
@@ -297,6 +297,9 @@ Function Add-Composertool() {
   )
   composer global require $prefix$release 2>&1 | out-null
   $json = findstr $prefix$tool $env:APPDATA\Composer\composer.json
+  if(Test-Path $composer_bin\composer) {
+    Copy-Item -Path "$bin_dir\composer" -Destination "$composer_bin\composer" -Force
+  }
   if($json) {
     $tool_version = Get-ToolVersion "Write-Output" "$json"
     Add-Log $tick $tool "Added $tool $tool_version"
@@ -316,6 +319,7 @@ $cross = ([char]10007)
 $php_dir = 'C:\tools\php'
 $ext_dir = "$php_dir\ext"
 $bin_dir = $php_dir
+$composer_bin = "$env:APPDATA\Composer\vendor\bin"
 $current_profile = "$env:TEMP\setup-php.ps1"
 $ProgressPreference = 'SilentlyContinue'
 $nightly_version = '8.[0-9]'
@@ -401,4 +405,5 @@ if($version -lt "5.5") {
 }
 Update-PhpCAInfo -Path $php_dir -Source $cert_source
 Copy-Item -Path $dist\..\src\configs\*.json -Destination $env:RUNNER_TOOL_CACHE
+New-Item -ItemType Directory -Path $composer_bin -Force 2>&1 | Out-Null
 Add-Log $tick "PHP" "$status PHP $($installed.FullVersion)"

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -281,11 +281,15 @@ export async function getWpCliUrl(version: string): Promise<string> {
 export async function addComposer(tools_list: string[]): Promise<string[]> {
   const regex_any = /^composer($|:.*)/;
   const regex_valid = /^composer:?($|preview$|snapshot$|v?[1-2]$)/;
+  const regex_composer1_tools = /hirak|prestissimo|narrowspark|composer-prefetcher/;
   const matches: string[] = tools_list.filter(tool => regex_valid.test(tool));
   let composer = 'composer';
   tools_list = tools_list.filter(tool => !regex_any.test(tool));
-  switch (matches[0]) {
-    case undefined:
+  switch (true) {
+    case regex_composer1_tools.test(tools_list.join(' ')):
+      composer = 'composer:1';
+      break;
+    case matches[0] == undefined:
       break;
     default:
       composer = matches[matches.length - 1].replace(/v([1-2])/, '$1');

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -204,6 +204,31 @@ export async function getPharUrl(
 }
 
 /**
+ * Function to get blackfire player url for a PHP version.
+ *
+ * @param version
+ * @param php_version
+ */
+export async function getBlackfirePlayerUrl(
+  version: string,
+  php_version: string
+): Promise<string> {
+  switch (true) {
+    case /5\.[5-6]|7\.0/.test(php_version) && version == 'latest':
+      version = '1.9.3';
+      break;
+    default:
+      break;
+  }
+  return await getPharUrl(
+    'https://get.blackfire.io',
+    'blackfire-player',
+    'v',
+    version
+  );
+}
+
+/**
  * Function to get the Deployer url
  *
  * @param version
@@ -454,7 +479,7 @@ export async function addTools(
         script += await addPackage(tool, release, tool + '/', os_version);
         break;
       case 'blackfire-player':
-        url = await getPharUrl('https://get.blackfire.io', tool, 'v', version);
+        url = await getBlackfirePlayerUrl(version, php_version);
         script += await addArchive(tool, url, os_version, '"-V"');
         break;
       case 'codeception':

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -330,27 +330,20 @@ export async function addComposer(tools_list: string[]): Promise<string[]> {
  * @param version
  */
 export async function getComposerUrl(version: string): Promise<string> {
-  const cache_url =
-    'https://github.com/shivammathur/composer-cache/releases/latest/download/composer-' +
-    version.replace('latest', 'stable') +
-    '.phar,';
-  switch (version) {
-    case 'snapshot':
-      return cache_url + 'https://getcomposer.org/composer.phar';
-    case 'preview':
-    case '1':
-    case '2':
-      return (
-        cache_url + 'https://getcomposer.org/composer-' + version + '.phar'
-      );
+  let cache_url = `https://github.com/shivammathur/composer-cache/releases/latest/download/composer-${version.replace(
+    'latest',
+    'stable'
+  )}.phar`;
+  switch (true) {
+    case /^snapshot$/.test(version):
+      return `${cache_url},https://getcomposer.org/composer.phar`;
+    case /^preview$|^[1-2]$/.test(version):
+      return `${cache_url},https://getcomposer.org/composer-${version}.phar`;
+    case /^\d+\.\d+\.\d+[\w-]*$/.test(version):
+      cache_url = `https://github.com/composer/composer/releases/download/${version}/composer.phar`;
+      return `${cache_url},https://getcomposer.org/composer-${version}.phar`;
     default:
-      if (/^\d+\.\d+\.\d+[\w-]*$/.test(version)) {
-        return (
-          cache_url +
-          `https://github.com/composer/composer/releases/download/${version}/composer.phar`
-        );
-      }
-      return cache_url + 'https://getcomposer.org/composer-stable.phar';
+      return `${cache_url},https://getcomposer.org/composer-stable.phar`;
   }
 }
 


### PR DESCRIPTION
- Add support to setup a specific `Composer` version.
For example to setup `Composer 2.0.6`.
```yml
- name: Setup PHP
  uses: shivammathur/setup-php@v2
  with:
    php-version: '7.4'
    tools: composer: 2.0.6
```
- Add support for `couchbase` extension for `PHP 5.6` to `PHP 7.4`.
```yml
- name: Setup PHP
  uses: shivammathur/setup-php@v2
  with:
    php-version: '7.4'
    extensions: couchbase
```
- Set `blackfire-player` to `v1.9.3` for `PHP 5.5` to `PHP 7.0`.
- Set `composer` version to `v1` when `prestissimo` or `composer-prefetcher` is specified in tools. It is recommended to stop using `prestissimo` as `Composer 2` is faster on its own.
- Document using `setup-php` on `i386` and `amd64` containers using [`spc`](https://github.com/shivammathur/spc). [Docs](https://github.com/shivammathur/setup-php#multi-arch-setup). Closes #326.
- Add workflow to document extensions that are enabled by default on [wiki](https://github.com/shivammathur/setup-php/wiki). (#327)
- Fix tools setup when latest release does not have the tool in release assets. Will now fetch tool from the previous release till it is added to the latest release.
- Improve regex for pre-release `PECL` extensions. (#325)
- Install `VcRedist` from GitHub on `Windows`.
- Update `PHP` dependencies as per GitHub Action runner version on `macOS`.
- Fix `grpc_php_plugin` setup. Now uses `XCode 11.7` as compiling it with `XCode 12` is flaky.
- Fix extension setup on `PHP 8.0` and `PHP 8.1` and all for version on self-hosted `Linux`.
- Fix `composer` setup when it is a dependency of a tool.
- Revert back to `apt-fast` as after `1.9.10` release it reports correct exit codes.
- Revert back to using dashes in step-ids as issue parsing them is fixed upstream (nektos/act#287).
- Use GitHub releases`(s3)` as primary source for builds and scripts with bintray only as fallback. This will scale `setup-php` better and avoid bintray's 2TB/month download limit.
- Refactor and dry `linux.sh` and `darwin.sh`.
- Fix contribution docs.
- Bump version to `2.8.0`.