### PR TITLE
fix: resolve issue with xdebug.mode not being set

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2332,14 +2332,7 @@ async function addCoverageXdebug(extension, version, os_version, pipe) {
         pipe;
     const ini = await config.addINIValues('xdebug.mode=coverage', os_version, true);
     const log = await utils.addLog('$tick', extension, 'Xdebug enabled as coverage driver', os_version);
-    switch (true) {
-        case /^xdebug3$/.test(extension):
-        case /^8\.\d$/.test(version):
-            return '\n' + xdebug + '\n' + ini + '\n' + log;
-        case /^xdebug$/.test(extension):
-        default:
-            return xdebug + '\n' + log;
-    }
+    return '\n' + xdebug + '\n' + ini + '\n' + log;
 }
 exports.addCoverageXdebug = addCoverageXdebug;
 /**

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -30,14 +30,8 @@ export async function addCoverageXdebug(
     'Xdebug enabled as coverage driver',
     os_version
   );
-  switch (true) {
-    case /^xdebug3$/.test(extension):
-    case /^8\.\d$/.test(version):
-      return '\n' + xdebug + '\n' + ini + '\n' + log;
-    case /^xdebug$/.test(extension):
-    default:
-      return xdebug + '\n' + log;
-  }
+
+  return '\n' + xdebug + '\n' + ini + '\n' + log;
 }
 
 /**


### PR DESCRIPTION
## A Pull Request should be associated with a Discussion.

Related discussion: https://github.com/pestphp/pest/issues/226

### Description

When using `coverage: xdebug` on macOS and Windows (Linux correctly uses Xdebug 2 for now on PHP `<=7.4`), it appears to fail on PHP 7.x as Xdebug 3 is being installed, rather than Xdebug 2.x. As this bit of code is expecting for `coverage: xdebug3` or PHP 8 to add the `xdebug.mode=coverage` line, this never gets set.

- [This workflow](https://github.com/owenvoke/pest-coverage-test/actions/runs/385570995) is with the current version of Setup PHP
- [This workflow](https://github.com/owenvoke/pest-coverage-test/actions/runs/385576621) is with the commit from this PR applied

I've created some workflows that tested against all PHP versions back to 5.3, and their compatible PHPUnit version.

- [With the current version](https://github.com/owenvoke/pest-coverage-test/actions/runs/385645905)
- [With the PR changes](https://github.com/owenvoke/pest-coverage-test/actions/runs/385648891)

On the current version, PHPUnit flags a warning that `xdebug.mode=coverage has to be set in php.ini`. I'm also not sure why `XDEBUG_CC_UNUSED` is undefined on PHP 7.2 for macOS and Windows.

> In case this PR introduced TypeScript/JavaScript code changes:

- [ ] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.

> In case this PR edits any scripts:

- [ ] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).

<!--
- Please target the develop branch when submitting the pull request.
-->