### PR TITLE
2.9.0

### DIFF
--- a/__tests__/coverage.test.ts
+++ b/__tests__/coverage.test.ts
@@ -28,11 +28,13 @@ describe('Config tests', () => {
   it('checking addCoverage with Xdebug on windows', async () => {
     const win32: string = await coverage.addCoverage('xdebug', '7.4', 'win32');
     expect(win32).toContain('Add-Extension xdebug');
+    expect(win32).toContain('xdebug.mode=coverage');
   });
 
   it('checking addCoverage with Xdebug on linux', async () => {
     const linux: string = await coverage.addCoverage('xdebug', '8.0', 'linux');
     expect(linux).toContain('add_extension xdebug');
+    expect(linux).toContain('echo "xdebug.mode=coverage"');
   });
 
   it('checking addCoverage with Xdebug3 on linux', async () => {

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -25,6 +25,9 @@ describe('Extension tests', () => {
       'Add-Log "$cross" "pcov" "pcov is not supported on PHP 5.6"'
     );
 
+    win32 = await extensions.addExtension('xdebug', '7.2', 'win32');
+    expect(win32).toContain('Add-Extension xdebug stable 2.9.8');
+
     win32 = await extensions.addExtension('mysql', '7.4', 'win32');
     expect(win32).toContain('Add-Extension mysqli');
     expect(win32).toContain('Add-Extension mysqlnd');
@@ -95,6 +98,9 @@ describe('Extension tests', () => {
     expect(linux).toContain('add_cubrid pdo_cubrid');
     linux = await extensions.addExtension('cubrid', '7.4', 'linux');
     expect(linux).toContain('add_cubrid cubrid');
+
+    linux = await extensions.addExtension('xdebug', '7.2', 'linux');
+    expect(linux).toContain('add_pecl_extension xdebug 2.9.8 zend_extension');
 
     linux = await extensions.addExtension('xdebug', '7.2', 'openbsd');
     expect(linux).toContain('Platform openbsd is not supported');

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -251,9 +251,6 @@ describe('Tools tests', () => {
     expect(
       await tools.addComposer(['a', 'b', 'c', 'composer:v2'])
     ).toStrictEqual(['composer:2', 'a', 'b', 'c']);
-    expect(
-      await tools.addComposer(['hirak', 'b', 'c', 'composer:v2'])
-    ).toStrictEqual(['composer:1', 'hirak', 'b', 'c']);
   });
 
   it('checking getComposerUrl', async () => {
@@ -629,6 +626,7 @@ describe('Tools tests', () => {
   });
   it('checking addTools with composer tool using user/tool as input', async () => {
     const listOfTools = [
+      'composer:v1',
       'hirak/prestissimo',
       'narrowspark/automatic-composer-prefetcher',
       'robmorgan/phinx'

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -42,11 +42,12 @@ describe('Utils tests', () => {
   it('checking asyncForEach', async () => {
     const array: Array<string> = ['a', 'b', 'c'];
     let concat = '';
-    await utils.asyncForEach(array, async function (
-      str: string
-    ): Promise<void> {
-      concat += str;
-    });
+    await utils.asyncForEach(
+      array,
+      async function (str: string): Promise<void> {
+        concat += str;
+      }
+    );
     expect(concat).toBe('abc');
   });
 
@@ -83,12 +84,12 @@ describe('Utils tests', () => {
     const runner_dir: string = process.env['RUNNER_TOOL_CACHE'] || '';
     const script_path: string = path.join(runner_dir, 'test.sh');
     await utils.writeScript('test.sh', testString);
-    await fs.readFile(script_path, function (
-      error: Error | null,
-      data: Buffer
-    ) {
-      expect(testString).toBe(data.toString());
-    });
+    await fs.readFile(
+      script_path,
+      function (error: Error | null, data: Buffer) {
+        expect(testString).toBe(data.toString());
+      }
+    );
     await cleanup(script_path);
   });
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Setup PHP Action'
 author: shivammathur
-description: 'Setup PHP with required extensions, php.ini configuration, code-coverage support and various tools like composer'
+description: 'GitHub Action for PHP'
 branding:
   color: 'purple'
   icon: 'play-circle'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2023,14 +2023,10 @@ exports.getWpCliUrl = getWpCliUrl;
 async function addComposer(tools_list) {
     const regex_any = /^composer($|:.*)/;
     const regex_valid = /^composer:?($|preview$|snapshot$|v?[1-2]$|v?\d+\.\d+\.\d+[\w-]*$)/;
-    const regex_composer1_tools = /hirak|prestissimo|narrowspark|composer-prefetcher/;
     const matches = tools_list.filter(tool => regex_valid.test(tool));
     let composer = 'composer';
     tools_list = tools_list.filter(tool => !regex_any.test(tool));
     switch (true) {
-        case regex_composer1_tools.test(tools_list.join(' ')):
-            composer = 'composer:1';
-            break;
         case matches[0] == undefined:
             break;
         default:

--- a/dist/index.js
+++ b/dist/index.js
@@ -2328,14 +2328,7 @@ async function addCoverageXdebug(extension, version, os_version, pipe) {
         pipe;
     const ini = await config.addINIValues('xdebug.mode=coverage', os_version, true);
     const log = await utils.addLog('$tick', extension, 'Xdebug enabled as coverage driver', os_version);
-    switch (true) {
-        case /^xdebug3$/.test(extension):
-        case /^8\.\d$/.test(version):
-            return '\n' + xdebug + '\n' + ini + '\n' + log;
-        case /^xdebug$/.test(extension):
-        default:
-            return xdebug + '\n' + log;
-    }
+    return [xdebug, ini, log].join('\n');
 }
 exports.addCoverageXdebug = addCoverageXdebug;
 /**
@@ -2968,6 +2961,9 @@ async function addExtensionWindows(extension_csv, version) {
                 add_script += await utils.joins('\nAdd-Extension', ext_name, matches[2].replace('preview', 'devel'), matches[1]);
                 break;
             // match 5.3pcov to 7.0pcov
+            case /7\.2xdebug/.test(version_extension):
+                add_script += '\nAdd-Extension xdebug stable 2.9.8';
+                break;
             case /(5\.[3-6]|7\.0)pcov/.test(version_extension):
                 add_script += await utils.getUnsupportedLog('pcov', version, 'win32');
                 break;
@@ -3049,6 +3045,10 @@ async function addExtensionLinux(extension_csv, version) {
                 add_script +=
                     '\nadd_extension_from_source xdebug xdebug/xdebug master --enable-xdebug zend_extension';
                 return;
+            // match 7.2xdebug
+            case /^7\.2xdebug$/.test(version_extension):
+                add_script += await utils.joins('\nadd_pecl_extension', ext_name, '2.9.8', ext_prefix);
+                break;
             // match 8.0xdebug3...8.9xdebug3
             case /^8\.[0-9]xdebug3$/.test(version_extension):
                 extension = 'xdebug';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -32,19 +32,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.12.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
-      "integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
+      "version": "7.12.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
+      "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.1",
+        "@babel/generator": "^7.12.5",
         "@babel/helper-module-transforms": "^7.12.1",
-        "@babel/helpers": "^7.12.1",
-        "@babel/parser": "^7.12.3",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1",
+        "@babel/helpers": "^7.12.5",
+        "@babel/parser": "^7.12.7",
+        "@babel/template": "^7.12.7",
+        "@babel/traverse": "^7.12.9",
+        "@babel/types": "^7.12.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -118,12 +118,12 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-      "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+      "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.1"
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/helper-module-imports": {
@@ -153,12 +153,12 @@
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
+      "integrity": "sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -278,9 +278,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-      "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+      "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -392,28 +392,28 @@
       }
     },
     "@babel/template": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-      "integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+      "version": "7.12.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
+      "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.12.5",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.5",
-        "@babel/types": "^7.12.5",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
@@ -428,9 +428,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -836,9 +836,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
-      "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.16.tgz",
+      "integrity": "sha512-S63Dt4CZOkuTmpLGGWtT/mQdVORJOpx6SZWGVaP56dda/0Nx5nEe82K7/LAm8zYr6SfMq+1N2OreIOrHAx656w==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -900,9 +900,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+      "version": "14.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -930,9 +930,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "15.0.9",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
-      "integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
+      "version": "15.0.10",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.10.tgz",
+      "integrity": "sha512-z8PNtlhrj7eJNLmrAivM7rjBESG6JwC5xP3RVk12i/8HVP7Xnx/sEmERnRImyEuUaJfO942X0qMOYsoupaJbZQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -945,13 +945,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.7.0.tgz",
-      "integrity": "sha512-li9aiSVBBd7kU5VlQlT1AqP0uWGDK6JYKUQ9cVDnOg34VNnd9t4jr0Yqc/bKxJr/tDCPDaB4KzoSFN9fgVxe/Q==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.8.2.tgz",
+      "integrity": "sha512-gQ06QLV5l1DtvYtqOyFLXD9PdcILYqlrJj2l+CGDlPtmgLUzc1GpqciJFIRvyfvgLALpnxYINFuw+n9AZhPBKQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.7.0",
-        "@typescript-eslint/scope-manager": "4.7.0",
+        "@typescript-eslint/experimental-utils": "4.8.2",
+        "@typescript-eslint/scope-manager": "4.8.2",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -960,55 +960,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.7.0.tgz",
-      "integrity": "sha512-cymzovXAiD4EF+YoHAB5Oh02MpnXjvyaOb+v+BdpY7lsJXZQN34oIETeUwVT2XfV9rSNpXaIcknDLfupO/tUoA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.2.tgz",
+      "integrity": "sha512-hpTw6o6IhBZEsQsjuw/4RWmceRyESfAiEzAEnXHKG1X7S5DXFaZ4IO1JO7CW1aQ604leQBzjZmuMI9QBCAJX8Q==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.7.0",
-        "@typescript-eslint/types": "4.7.0",
-        "@typescript-eslint/typescript-estree": "4.7.0",
+        "@typescript-eslint/scope-manager": "4.8.2",
+        "@typescript-eslint/types": "4.8.2",
+        "@typescript-eslint/typescript-estree": "4.8.2",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.7.0.tgz",
-      "integrity": "sha512-+meGV8bMP1sJHBI2AFq1GeTwofcGiur8LoIr6v+rEmD9knyCqDlrQcFHR0KDDfldHIFDU/enZ53fla6ReF4wRw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.8.2.tgz",
+      "integrity": "sha512-u0leyJqmclYr3KcXOqd2fmx6SDGBO0MUNHHAjr0JS4Crbb3C3d8dwAdlazy133PLCcPn+aOUFiHn72wcuc5wYw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.7.0",
-        "@typescript-eslint/types": "4.7.0",
-        "@typescript-eslint/typescript-estree": "4.7.0",
+        "@typescript-eslint/scope-manager": "4.8.2",
+        "@typescript-eslint/types": "4.8.2",
+        "@typescript-eslint/typescript-estree": "4.8.2",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.7.0.tgz",
-      "integrity": "sha512-ILITvqwDJYbcDCROj6+Ob0oCKNg3SH46iWcNcTIT9B5aiVssoTYkhKjxOMNzR1F7WSJkik4zmuqve5MdnA0DyA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.8.2.tgz",
+      "integrity": "sha512-qHQ8ODi7mMin4Sq2eh/6eu03uVzsf5TX+J43xRmiq8ujng7ViQSHNPLOHGw/Wr5dFEoxq/ubKhzClIIdQy5q3g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.7.0",
-        "@typescript-eslint/visitor-keys": "4.7.0"
+        "@typescript-eslint/types": "4.8.2",
+        "@typescript-eslint/visitor-keys": "4.8.2"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.7.0.tgz",
-      "integrity": "sha512-uLszFe0wExJc+I7q0Z/+BnP7wao/kzX0hB5vJn4LIgrfrMLgnB2UXoReV19lkJQS1a1mHWGGODSxnBx6JQC3Sg==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.2.tgz",
+      "integrity": "sha512-z1/AVcVF8ju5ObaHe2fOpZYEQrwHyZ7PTOlmjd3EoFeX9sv7UekQhfrCmgUO7PruLNfSHrJGQvrW3Q7xQ8EoAw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.7.0.tgz",
-      "integrity": "sha512-5XZRQznD1MfUmxu1t8/j2Af4OxbA7EFU2rbo0No7meb46eHgGkSieFdfV6omiC/DGIBhH9H9gXn7okBbVOm8jw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.2.tgz",
+      "integrity": "sha512-HToGNwI6fekH0dOw3XEVESUm71Onfam0AKin6f26S2FtUmO7o3cLlWgrIaT1q3vjB3wCTdww3Dx2iGq5wtUOCg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.7.0",
-        "@typescript-eslint/visitor-keys": "4.7.0",
+        "@typescript-eslint/types": "4.8.2",
+        "@typescript-eslint/visitor-keys": "4.8.2",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -1018,12 +1018,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.7.0.tgz",
-      "integrity": "sha512-aDJDWuCRsf1lXOtignlfiPODkzSxxop7D0rZ91L6ZuMlcMCSh0YyK+gAfo5zN/ih6WxMwhoXgJWC3cWQdaKC+A==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.2.tgz",
+      "integrity": "sha512-Vg+/SJTMZJEKKGHW7YC21QxgKJrSbxoYYd3MEUGtW7zuytHuEcksewq0DUmo4eh/CTNrVJGSdIY9AtRb6riWFw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.7.0",
+        "@typescript-eslint/types": "4.8.2",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -1155,13 +1155,15 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
+      "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0",
+        "es-abstract": "^1.18.0-next.1",
+        "get-intrinsic": "^1.0.1",
         "is-string": "^1.0.5"
       }
     },
@@ -1178,13 +1180,14 @@
       "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "asn1": {
@@ -1742,9 +1745,9 @@
       }
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1939,9 +1942,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -1949,6 +1952,7 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
         "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
         "is-regex": "^1.1.1",
         "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
@@ -2029,9 +2033,9 @@
       }
     },
     "eslint": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz",
-      "integrity": "sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.14.0.tgz",
+      "integrity": "sha512-5YubdnPXrlrYAFCKybPuHIAH++PINe1pmKNc5wQRB9HSbqIK1ywAnntE3Wwua4giKu0bjligf1gLF6qxMGOYRA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3219,9 +3223,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
-      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -4606,6 +4610,27 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "once": {
@@ -4647,9 +4672,9 @@
       }
     },
     "p-each-series": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-      "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true
     },
     "p-finally": {
@@ -4800,9 +4825,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
-      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.0.tgz",
+      "integrity": "sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -5709,67 +5734,23 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
-      "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
-      "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "strip-ansi": {
@@ -6063,9 +6044,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-php",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "dist/index.js",
@@ -31,11 +31,11 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",
-    "@types/node": "^14.14.7",
-    "@typescript-eslint/eslint-plugin": "^4.7.0",
-    "@typescript-eslint/parser": "^4.7.0",
+    "@types/node": "^14.14.10",
+    "@typescript-eslint/eslint-plugin": "^4.8.2",
+    "@typescript-eslint/parser": "^4.8.2",
     "@zeit/ncc": "^0.22.3",
-    "eslint": "^7.13.0",
+    "eslint": "^7.14.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
@@ -43,9 +43,9 @@
     "husky": "^4.3.0",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
-    "prettier": "^2.1.2",
+    "prettier": "^2.2.0",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.2"
   },
   "husky": {
     "skipCI": true,

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -30,14 +30,7 @@ export async function addCoverageXdebug(
     'Xdebug enabled as coverage driver',
     os_version
   );
-  switch (true) {
-    case /^xdebug3$/.test(extension):
-    case /^8\.\d$/.test(version):
-      return '\n' + xdebug + '\n' + ini + '\n' + log;
-    case /^xdebug$/.test(extension):
-    default:
-      return xdebug + '\n' + log;
-  }
+  return [xdebug, ini, log].join('\n');
 }
 
 /**

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -164,6 +164,9 @@ export async function addExtensionWindows(
         );
         break;
       // match 5.3pcov to 7.0pcov
+      case /7\.2xdebug/.test(version_extension):
+        add_script += '\nAdd-Extension xdebug stable 2.9.8';
+        break;
       case /(5\.[3-6]|7\.0)pcov/.test(version_extension):
         add_script += await utils.getUnsupportedLog('pcov', version, 'win32');
         break;
@@ -269,6 +272,15 @@ export async function addExtensionLinux(
         add_script +=
           '\nadd_extension_from_source xdebug xdebug/xdebug master --enable-xdebug zend_extension';
         return;
+      // match 7.2xdebug
+      case /^7\.2xdebug$/.test(version_extension):
+        add_script += await utils.joins(
+          '\nadd_pecl_extension',
+          ext_name,
+          '2.9.8',
+          ext_prefix
+        );
+        break;
       // match 8.0xdebug3...8.9xdebug3
       case /^8\.[0-9]xdebug3$/.test(version_extension):
         extension = 'xdebug';

--- a/src/scripts/common.sh
+++ b/src/scripts/common.sh
@@ -2,7 +2,6 @@
 export tick="✓"
 export cross="✗"
 export curl_opts=(-sL)
-export nightly_versions="8.[0-1]"
 export old_versions="5.[3-5]"
 export tool_path_dir="/usr/local/bin"
 export composer_bin="$HOME/.composer/vendor/bin"

--- a/src/scripts/common.sh
+++ b/src/scripts/common.sh
@@ -75,7 +75,7 @@ run_script() {
   repo=$1
   shift
   args=("$@")
-  get -q -e /tmp/install.sh "$github/$repo/$latest/install.sh" "$bintray/php/$repo.sh"
+  get -q -e /tmp/install.sh "$bintray/php/$repo.sh" "$github/$repo/$latest/install.sh"
   bash /tmp/install.sh "${args[@]}"
 }
 

--- a/src/scripts/common.sh
+++ b/src/scripts/common.sh
@@ -128,9 +128,9 @@ get_pecl_version() {
   stability="$(echo "$2" | grep -m 1 -Eio "(alpha|beta|rc|snapshot|preview)")"
   pecl_rest='https://pecl.php.net/rest/r/'
   response=$(get -s -n "" "$pecl_rest$extension"/allreleases.xml)
-  pecl_version=$(echo "$response" | grep -m 1 -Pio "(\d*\.\d*\.\d*$stability\d*)")
+  pecl_version=$(echo "$response" | grep -m 1 -Eio "([0-9]+\.[0-9]+\.[0-9]+${stability}[0-9]+)")
   if [ ! "$pecl_version" ]; then
-    pecl_version=$(echo "$response" | grep -m 1 -Po "(\d*\.\d*\.\d*)")
+    pecl_version=$(echo "$response" | grep -m 1 -Eo "([0-9]+\.[0-9]+\.[0-9]+)")
   fi
   echo "$pecl_version"
 }

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -11,7 +11,7 @@ self_hosted_helper() {
 remove_extension() {
   extension=$1
   if check_extension "$extension"; then
-    sudo sed -i '' "/$extension/d" "${ini_file:?}"
+    sudo sed -Ei '' "/=(.*\/)?\"?$extension/d" "${ini_file:?}"
     sudo rm -rf "${scan_dir:?}"/*"$extension"* "${ext_dir:?}"/"$extension".so >/dev/null 2>&1
     (! check_extension "$extension" && add_log "${tick:?}" ":$extension" "Removed") ||
       add_log "${cross:?}" ":$extension" "Could not remove $extension on PHP ${semver:?}"

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -39,6 +39,14 @@ add_pecl_extension() {
   fi
 }
 
+# Function to add a brew tap.
+add_brew_tap() {
+  tap=$1
+  if ! [ -d "$tap_dir/$tap" ]; then
+    brew tap --shallow "$tap" >/dev/null 2>&1
+  fi
+}
+
 # Function to install a php extension from shivammathur/extensions tap.
 add_brew_extension() {
   extension=$1
@@ -47,13 +55,10 @@ add_brew_extension() {
   if check_extension "$extension"; then
     add_log "${tick:?}" "$extension" "Enabled"
   else
-    if ! brew tap | grep -q shivammathur/extensions; then
-      brew tap --shallow shivammathur/extensions >/dev/null 2>&1
-    fi
-    tap_dir="$(brew --prefix)/Homebrew/Library/Taps"
+    add_brew_tap shivammathur/homebrew-extensions
     sudo mv "$tap_dir"/shivammathur/homebrew-extensions/.github/deps/"$extension"/* "$tap_dir/homebrew/homebrew-core/Formula/" 2>/dev/null || true
     brew install "$extension@$version" >/dev/null 2>&1
-    sudo cp "$(brew --prefix)/opt/$extension@$version/$extension.so" "$ext_dir"
+    sudo cp "$brew_prefix/opt/$extension@$version/$extension.so" "$ext_dir"
     add_extension_log "$extension" "Installed and enabled"
   fi
 }
@@ -88,7 +93,6 @@ add_pecl() {
 # Function to update dependencies.
 update_dependencies() {
   if [[ "$version" =~ ${nightly_versions:?} ]] && [ "${runner:?}" != "self-hosted" ]; then
-    tap_dir="$(brew --prefix)/Homebrew/Library/Taps"
     while read -r formula; do
       get -q -n "$tap_dir/homebrew/homebrew-core/Formula/$formula.rb" "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/$formula.rb" &
       to_wait+=($!)
@@ -100,16 +104,15 @@ update_dependencies() {
 # Function to setup PHP 5.6 and newer using Homebrew.
 add_php() {
   action=$1
-  if ! brew tap | grep -q shivammathur/php; then
-    brew tap --shallow shivammathur/php
-  fi
+  add_brew_tap shivammathur/homebrew-php
   update_dependencies
-  if brew list php@"$version" 2>/dev/null | grep -q "Error" && [ "$action" != "upgrade" ]; then
-    brew unlink php@"$version"
+  sudo rm -rf "$core_tap"/Formula/php@* "$core_tap"/Formula/php.rb
+  if brew list php@"$version" >/dev/null 2>&1 && [ "$action" != "upgrade" ]; then
+    brew unlink shivammathur/php/php@"$version"
   else
     brew "$action" shivammathur/php/php@"$version"
   fi
-  brew link --force --overwrite php@"$version"
+  brew link --force --overwrite shivammathur/php/php@"$version"
 }
 
 # Function to Setup PHP
@@ -131,6 +134,7 @@ setup_php() {
   ini_file=$(php -d "date.timezone=UTC" --ini | grep "Loaded Configuration" | sed -e "s|.*:s*||" | sed "s/ //g")
   sudo chmod 777 "$ini_file" "${tool_path_dir:?}"
   echo -e "date.timezone=UTC\nmemory_limit=-1" >>"$ini_file"
+  [[ "$version" =~ ${jit_versions:?} ]] && echo -e "opcache.enable=1\nopcache.jit_buffer_size=256M\nopcache.jit=1235" >>"$ini_file"
   ext_dir=$(php -i | grep -Ei "extension_dir => /" | sed -e "s|.*=> s*||")
   scan_dir=$(php --ini | grep additional | sed -e "s|.*: s*||")
   sudo mkdir -m 777 -p "$ext_dir" "$HOME/.composer"
@@ -143,6 +147,11 @@ setup_php() {
 # Variables
 version=$1
 dist=$2
+nightly_versions="8.1"
+jit_versions="8.[0-1]"
+brew_prefix="$(brew --prefix)"
+tap_dir="$brew_prefix"/Homebrew/Library/Taps
+core_tap="$tap_dir"/homebrew/homebrew-core
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 export HOMEBREW_NO_AUTO_UPDATE=1
 

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -50,6 +50,8 @@ add_brew_extension() {
     if ! brew tap | grep -q shivammathur/extensions; then
       brew tap --shallow shivammathur/extensions >/dev/null 2>&1
     fi
+    tap_dir="$(brew --prefix)/Homebrew/Library/Taps"
+    sudo mv "$tap_dir"/shivammathur/homebrew-extensions/.github/deps/"$extension"/* "$tap_dir/homebrew/homebrew-core/Formula/" 2>/dev/null || true
     brew install "$extension@$version" >/dev/null 2>&1
     sudo cp "$(brew --prefix)/opt/$extension@$version/$extension.so" "$ext_dir"
     add_extension_log "$extension" "Installed and enabled"

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -48,8 +48,8 @@ install_packages() {
 # Function to delete extensions.
 delete_extension() {
   extension=$1
-  sudo sed -i "/$extension/d" "${ini_file:?}"
-  sudo sed -i "/$extension/d" "${pecl_file:?}"
+  sudo sed -Ei "/=(.*\/)?\"?$extension/d" "${ini_file:?}"
+  sudo sed -Ei "/=(.*\/)?\"?$extension/d" "${pecl_file:?}"
   sudo rm -rf "${scan_dir:?}"/*"$extension"* "${ext_dir:?}"/"$extension".so >/dev/null 2>&1
   if [ "${runner:?}" = "self-hosted" ]; then
     $apt_remove "php-$extension" "php$version-$extension" >/dev/null 2>&1 || true

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -274,6 +274,7 @@ setup_php() {
 # Variables
 version=$1
 dist=$2
+nightly_versions="8.[0-1]"
 debconf_fix="DEBIAN_FRONTEND=noninteractive"
 apt_install="sudo $debconf_fix apt-fast install -y"
 apt_remove="sudo $debconf_fix apt-fast remove -y"

--- a/src/scripts/tools/grpc_php_plugin.sh
+++ b/src/scripts/tools/grpc_php_plugin.sh
@@ -14,13 +14,12 @@ add_bazel() {
 
 get_grpc_tag() {
   if [ "$grpc_tag" = "latest" ]; then
-    grpc_tag=$(get -s -n "" https://grpc.io/release)
+    grpc_tag=$(get -s -n "" https://github.com/grpc/grpc/releases/latest | grep -Eo -m 1 "v[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)
   else
-    status_code=$(get -v -n /tmp/grpc.tmp "https://github.com/grpc/grpc/releases/tag/v$grpc_tag")
-    if [ "$status_code" = "200" ]; then
-      grpc_tag="v$grpc_tag"
-    else
-      grpc_tag=$(get -s -n "" https://grpc.io/release)
+    if [[ ${grpc_tag:0:1} != "v" ]] ; then grpc_tag="v$grpc_tag"; fi
+    status_code=$(get -v -n /tmp/grpc.tmp "https://github.com/grpc/grpc/releases/tag/$grpc_tag")
+    if [ "$status_code" != "200" ]; then
+      grpc_tag=$(get -s -n "" https://github.com/grpc/grpc/releases/latest | grep -Eo -m 1 "v[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)
     fi
   fi
 }

--- a/src/scripts/win32.ps1
+++ b/src/scripts/win32.ps1
@@ -8,10 +8,7 @@ param (
   [ValidateNotNull()]
   [ValidateLength(1, [int]::MaxValue)]
   [string]
-  $dist,
-  [Parameter(Position = 2, Mandatory = $false)]
-  [string]
-  $fail_fast = 'false'
+  $dist
 )
 
 # Function to log start of a operation.
@@ -25,7 +22,7 @@ Function Add-Log($mark, $subject, $message) {
     printf "\033[32;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s \033[0m\n" $mark $subject $message
   } else {
     printf "\033[31;1m%s \033[0m\033[34;1m%s \033[0m\033[90;1m%s \033[0m\n" $mark $subject $message
-    if($fail_fast -eq 'true') {
+    if($env:fail_fast -eq 'true') {
       exit 1;
     }
   }
@@ -416,9 +413,9 @@ if ($null -eq $installed -or -not("$($installed.Version).".StartsWith(($version 
 }
 
 $installed = Get-Php -Path $php_dir
-('date.timezone=UTC', 'memory_limit=-1') | foreach { $p=$_.split('='); Set-PhpIniKey -Key $p[0] -Value $p[1] -Path $php_dir }
+('date.timezone=UTC', 'memory_limit=-1') | ForEach-Object { $p=$_.split('='); Set-PhpIniKey -Key $p[0] -Value $p[1] -Path $php_dir }
 if($version -lt "5.5") {
-  ('libeay32.dll', 'ssleay32.dll') | ForEach { Invoke-WebRequest -Uri $bintray/$_ -OutFile $php_dir\$_ >$null 2>&1 }
+  ('libeay32.dll', 'ssleay32.dll') | ForEach-Object { Invoke-WebRequest -Uri $bintray/$_ -OutFile $php_dir\$_ >$null 2>&1 }
 } else {
   $enable_extensions += ('opcache')
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -306,14 +306,10 @@ export async function getWpCliUrl(version: string): Promise<string> {
 export async function addComposer(tools_list: string[]): Promise<string[]> {
   const regex_any = /^composer($|:.*)/;
   const regex_valid = /^composer:?($|preview$|snapshot$|v?[1-2]$|v?\d+\.\d+\.\d+[\w-]*$)/;
-  const regex_composer1_tools = /hirak|prestissimo|narrowspark|composer-prefetcher/;
   const matches: string[] = tools_list.filter(tool => regex_valid.test(tool));
   let composer = 'composer';
   tools_list = tools_list.filter(tool => !regex_any.test(tool));
   switch (true) {
-    case regex_composer1_tools.test(tools_list.join(' ')):
-      composer = 'composer:1';
-      break;
     case matches[0] == undefined:
       break;
     default:


### PR DESCRIPTION
- PHP 8.0 is now stable `PHP 8.0.0` on `setup-php` for all supported OS. 🥳
- Add new JIT configuration section to the README. 

For example, to enable JIT on PHP 8.0.
```yml
- name: Setup PHP
  uses: shivammathur/setup-php@v2
  with:
    php-version: '8.0'
    ini-values: opcache.enable_cli=1
```
Refer to [JIT Configuration](https://github.com/shivammathur/setup-php#jit-configuration) for more details.
- Skip `prestissimo` and `composer-prefetcher` unless `composer:v1` is specified.

For example to setup `prestissimo`, use
```yml
- name: Setup PHP
  uses: shivammathur/setup-php@v2
  with:
    php-version: '8.0'
    tools: composer:v1, prestissimo
```
- Set `Xdebug` version to `2.9.8` on `PHP 7.2`. #345 
- Set `xdebug.mode=coverage` ini directive always #346 
- Sync dependencies from `shivammathur/extensions` tap in `add_brew_extension`.
- Fix `fail-fast` on Windows.
- Fix deleting extensions when one extension is a substring of the other. For example `pdo_sqlsrv` and `sqlsrv`.
- Fix fetching extension version from `PECL` on `macOS`.
- Fix fetching `grpc` latest tag. (grpc/grpc.io#79)
- Prioritize `Bintray` over `GitHub` releases for fetching scripts.
- Refactor `darwin.sh` script.
- Change project description in `actions.yml`.
- Bump version to 2.9.0

Thanks @owenvoke for the contribution 🎉