### PR TITLE
Allow extensions to be compiled from GitHub sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ On all supported OS/Platforms the following PHP versions are supported as per th
 
 PHP extensions can be setup using the `extensions` input. It accepts a `string` in csv-format.
 
-- On `Ubuntu`, extensions which are available as a package or available on `PECL` can be setup.
+- On `Ubuntu`, extensions which are available as a package, available on `PECL`, or hosted on GitHub can be setup.
 
 ```yaml
 - name: Setup PHP with PECL extension
@@ -129,7 +129,7 @@ PHP extensions can be setup using the `extensions` input. It accepts a `string` 
 
 - On `Windows`, extensions available on `PECL` which have the `DLL` binary can be setup.
 
-- On `macOS`, extensions available on `PECL` can be installed.
+- On `macOS`, extensions available on `PECL` or hosted on GitHub can be installed.
 
 - Extensions installed along with PHP if specified are enabled.
 
@@ -191,6 +191,18 @@ PHP extensions can be setup using the `extensions` input. It accepts a `string` 
   env:
     fail-fast: true
 ```
+
+- Extensions can be compiled from source if they are hosted on GitHub. In this case, the version specification contains the repository and branch/tag to clone: 
+
+```yaml
+- name: Setup PHP and remove shared extension
+  uses: shivammathur/setup-php@v2
+  with:
+    php-version: '7.4'  
+    extensions: mongodb-mongodb/mongo-php-driver@v1.9
+```
+
+The version can be a branch name or tag as supported by `git clone -b <name>`. The clone is performed recursively, i.e. submodules will be cloned as well.
 
 ## :wrench: Tools Support
 

--- a/__tests__/extensions.test.ts
+++ b/__tests__/extensions.test.ts
@@ -58,6 +58,15 @@ describe('Extension tests', () => {
 
     win32 = await extensions.addExtension('blackfire-1.31.0', '7.3', 'win32');
     expect(win32).toContain('Add-Blackfire blackfire-1.31.0');
+
+    win32 = await extensions.addExtension(
+      'mongodb-mongodb/mongo-php-driver@master',
+      '7.3',
+      'win32'
+    );
+    expect(win32).toContain(
+      'Add-Log "$cross" "mongodb-mongodb/mongo-php-driver@master" "mongodb-mongodb/mongo-php-driver@master is not supported on PHP 7.3"'
+    );
   });
 
   it('checking addExtensionOnLinux', async () => {
@@ -131,6 +140,15 @@ describe('Extension tests', () => {
 
     linux = await extensions.addExtension('intl-68.2', '8.0', 'linux');
     expect(linux).toContain('add_intl intl-68.2');
+
+    linux = await extensions.addExtension(
+      'mongodb-mongodb/mongo-php-driver@master',
+      '7.3',
+      'linux'
+    );
+    expect(linux).toContain(
+      'add_extension_from_github mongodb mongodb mongo-php-driver master'
+    );
   });
 
   it('checking addExtensionOnDarwin', async () => {
@@ -220,5 +238,14 @@ describe('Extension tests', () => {
 
     darwin = await extensions.addExtension('xdebug', '7.2', 'openbsd');
     expect(darwin).toContain('Platform openbsd is not supported');
+
+    darwin = await extensions.addExtension(
+      'mongodb-mongodb/mongo-php-driver@master',
+      '7.3',
+      'darwin'
+    );
+    expect(darwin).toContain(
+      'add_extension_from_github mongodb mongodb mongo-php-driver master'
+    );
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -2901,6 +2901,13 @@ async function addExtensionDarwin(extension_csv, version) {
         const version_extension = version + extension;
         const [ext_name, ext_version] = extension.split('-');
         const ext_prefix = await utils.getExtensionPrefix(ext_name);
+        // Install extensions from a GitHub tarball. This needs to be checked first
+        // as the version may also match the semver check below.
+        const urlMatches = extension.match(/.*-(.*)\/(.*)@(.*)/);
+        if (urlMatches != null) {
+            add_script += await utils.joins('\nadd_extension_from_github', ext_name, urlMatches[1], urlMatches[2], urlMatches[3], ext_prefix);
+            return;
+        }
         switch (true) {
             // match :extension
             case /^:/.test(ext_name):
@@ -2987,6 +2994,11 @@ async function addExtensionWindows(extension_csv, version) {
             case /.*-(stable|beta|alpha|devel|snapshot)/.test(version_extension):
                 add_script += await utils.joins('\nAdd-Extension', ext_name, ext_version.replace('stable', ''));
                 break;
+            // match extensions from GitHub. Do this before checking for semver as
+            // the version may match that as well
+            case /.*-(.*)\/(.*)@(.*)/.test(extension):
+                add_script += await utils.getUnsupportedLog(extension, version, 'win32');
+                break;
             // match semver without state
             case /.*-\d+\.\d+\.\d+$/.test(version_extension):
                 add_script += await utils.joins('\nAdd-Extension', ext_name, 'stable', ext_version);
@@ -3044,6 +3056,13 @@ async function addExtensionLinux(extension_csv, version) {
         const version_extension = version + extension;
         const [ext_name, ext_version] = extension.split('-');
         const ext_prefix = await utils.getExtensionPrefix(ext_name);
+        // Install extensions from a GitHub tarball. This needs to be checked first
+        // as the version may also match the semver check below.
+        const urlMatches = extension.match(/.*-(.*)\/(.*)@(.*)/);
+        if (urlMatches != null) {
+            add_script += await utils.joins('\nadd_extension_from_github', ext_name, urlMatches[1], urlMatches[2], urlMatches[3], ext_prefix);
+            return;
+        }
         switch (true) {
             // Match :extension
             case /^:/.test(ext_name):

--- a/dist/index.js
+++ b/dist/index.js
@@ -2901,13 +2901,7 @@ async function addExtensionDarwin(extension_csv, version) {
         const version_extension = version + extension;
         const [ext_name, ext_version] = extension.split('-');
         const ext_prefix = await utils.getExtensionPrefix(ext_name);
-        // Install extensions from a GitHub tarball. This needs to be checked first
-        // as the version may also match the semver check below.
-        const urlMatches = extension.match(/.*-(.*)\/(.*)@(.*)/);
-        if (urlMatches != null) {
-            add_script += await utils.joins('\nadd_extension_from_github', ext_name, urlMatches[1], urlMatches[2], urlMatches[3], ext_prefix);
-            return;
-        }
+        let matches;
         switch (true) {
             // match :extension
             case /^:/.test(ext_name):
@@ -2929,6 +2923,17 @@ async function addExtensionDarwin(extension_csv, version) {
             // match pre-release versions. For example - xdebug-beta
             case /.*-(stable|beta|alpha|devel|snapshot|rc|preview)/.test(version_extension):
                 add_script += await utils.joins('\nadd_unstable_extension', ext_name, ext_version, ext_prefix);
+                return;
+            // match extensions from GitHub. Do this before checking for semver as
+            // the version may match that as well
+            case /.*-(.*)\/(.*)@(.*)/.test(extension):
+                matches = /.*-(.*)\/(.*)@(.*)/.exec(extension);
+                if (matches == null) {
+                    // Shouldn't happen
+                    add_script += await utils.getUnsupportedLog(extension, version, 'darwin');
+                    return;
+                }
+                add_script += await utils.joins('\nadd_extension_from_github', ext_name, matches[1], matches[2], matches[3], ext_prefix);
                 return;
             // match semver
             case /.*-\d+\.\d+\.\d+.*/.test(version_extension):
@@ -3056,13 +3061,7 @@ async function addExtensionLinux(extension_csv, version) {
         const version_extension = version + extension;
         const [ext_name, ext_version] = extension.split('-');
         const ext_prefix = await utils.getExtensionPrefix(ext_name);
-        // Install extensions from a GitHub tarball. This needs to be checked first
-        // as the version may also match the semver check below.
-        const urlMatches = extension.match(/.*-(.*)\/(.*)@(.*)/);
-        if (urlMatches != null) {
-            add_script += await utils.joins('\nadd_extension_from_github', ext_name, urlMatches[1], urlMatches[2], urlMatches[3], ext_prefix);
-            return;
-        }
+        let matches;
         switch (true) {
             // Match :extension
             case /^:/.test(ext_name):
@@ -3087,6 +3086,17 @@ async function addExtensionLinux(extension_csv, version) {
             // match pre-release versions. For example - xdebug-beta
             case /.*-(stable|beta|alpha|devel|snapshot|rc|preview)/.test(version_extension):
                 add_script += await utils.joins('\nadd_unstable_extension', ext_name, ext_version, ext_prefix);
+                return;
+            // match extensions from GitHub. Do this before checking for semver as
+            // the version may match that as well
+            case /.*-(.*)\/(.*)@(.*)/.test(extension):
+                matches = /.*-(.*)\/(.*)@(.*)/.exec(extension);
+                if (matches == null) {
+                    // Shouldn't happen
+                    add_script += await utils.getUnsupportedLog(extension, version, 'linux');
+                    return;
+                }
+                add_script += await utils.joins('\nadd_extension_from_github', ext_name, matches[1], matches[2], matches[3], ext_prefix);
                 return;
             // match semver versions
             case /.*-\d+\.\d+\.\d+.*/.test(version_extension):

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -59,15 +59,6 @@ export async function addExtensionDarwin(
       // the version may match that as well
       case /.*-(.*)\/(.*)@(.*)/.test(extension):
         matches = /.*-(.*)\/(.*)@(.*)/.exec(extension) as RegExpExecArray;
-        if (matches == null) {
-          // Shouldn't happen
-          add_script += await utils.getUnsupportedLog(
-            extension,
-            version,
-            'darwin'
-          );
-          return;
-        }
         add_script += await utils.joins(
           '\nadd_extension_from_github',
           ext_name,
@@ -294,15 +285,6 @@ export async function addExtensionLinux(
       // the version may match that as well
       case /.*-(.*)\/(.*)@(.*)/.test(extension):
         matches = /.*-(.*)\/(.*)@(.*)/.exec(extension) as RegExpExecArray;
-        if (matches == null) {
-          // Shouldn't happen
-          add_script += await utils.getUnsupportedLog(
-            extension,
-            version,
-            'linux'
-          );
-          return;
-        }
         add_script += await utils.joins(
           '\nadd_extension_from_github',
           ext_name,

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -17,21 +17,7 @@ export async function addExtensionDarwin(
     const version_extension: string = version + extension;
     const [ext_name, ext_version]: string[] = extension.split('-');
     const ext_prefix = await utils.getExtensionPrefix(ext_name);
-
-    // Install extensions from a GitHub tarball. This needs to be checked first
-    // as the version may also match the semver check below.
-    const urlMatches = extension.match(/.*-(.*)\/(.*)@(.*)/);
-    if (urlMatches != null) {
-      add_script += await utils.joins(
-        '\nadd_extension_from_github',
-        ext_name,
-        urlMatches[1],
-        urlMatches[2],
-        urlMatches[3],
-        ext_prefix
-      );
-      return;
-    }
+    let matches: RegExpExecArray;
 
     switch (true) {
       // match :extension
@@ -66,6 +52,28 @@ export async function addExtensionDarwin(
           '\nadd_unstable_extension',
           ext_name,
           ext_version,
+          ext_prefix
+        );
+        return;
+      // match extensions from GitHub. Do this before checking for semver as
+      // the version may match that as well
+      case /.*-(.*)\/(.*)@(.*)/.test(extension):
+        matches = /.*-(.*)\/(.*)@(.*)/.exec(extension) as RegExpExecArray;
+        if (matches == null) {
+          // Shouldn't happen
+          add_script += await utils.getUnsupportedLog(
+            extension,
+            version,
+            'darwin'
+          );
+          return;
+        }
+        add_script += await utils.joins(
+          '\nadd_extension_from_github',
+          ext_name,
+          matches[1],
+          matches[2],
+          matches[3],
           ext_prefix
         );
         return;
@@ -239,21 +247,7 @@ export async function addExtensionLinux(
     const version_extension: string = version + extension;
     const [ext_name, ext_version]: string[] = extension.split('-');
     const ext_prefix = await utils.getExtensionPrefix(ext_name);
-
-    // Install extensions from a GitHub tarball. This needs to be checked first
-    // as the version may also match the semver check below.
-    const urlMatches = extension.match(/.*-(.*)\/(.*)@(.*)/);
-    if (urlMatches != null) {
-      add_script += await utils.joins(
-        '\nadd_extension_from_github',
-        ext_name,
-        urlMatches[1],
-        urlMatches[2],
-        urlMatches[3],
-        ext_prefix
-      );
-      return;
-    }
+    let matches: RegExpExecArray;
 
     switch (true) {
       // Match :extension
@@ -293,6 +287,28 @@ export async function addExtensionLinux(
           '\nadd_unstable_extension',
           ext_name,
           ext_version,
+          ext_prefix
+        );
+        return;
+      // match extensions from GitHub. Do this before checking for semver as
+      // the version may match that as well
+      case /.*-(.*)\/(.*)@(.*)/.test(extension):
+        matches = /.*-(.*)\/(.*)@(.*)/.exec(extension) as RegExpExecArray;
+        if (matches == null) {
+          // Shouldn't happen
+          add_script += await utils.getUnsupportedLog(
+            extension,
+            version,
+            'linux'
+          );
+          return;
+        }
+        add_script += await utils.joins(
+          '\nadd_extension_from_github',
+          ext_name,
+          matches[1],
+          matches[2],
+          matches[3],
           ext_prefix
         );
         return;

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -17,6 +17,22 @@ export async function addExtensionDarwin(
     const version_extension: string = version + extension;
     const [ext_name, ext_version]: string[] = extension.split('-');
     const ext_prefix = await utils.getExtensionPrefix(ext_name);
+
+    // Install extensions from a GitHub tarball. This needs to be checked first
+    // as the version may also match the semver check below.
+    const urlMatches = extension.match(/.*-(.*)\/(.*)@(.*)/);
+    if (urlMatches != null) {
+      add_script += await utils.joins(
+        '\nadd_extension_from_github',
+        ext_name,
+        urlMatches[1],
+        urlMatches[2],
+        urlMatches[3],
+        ext_prefix
+      );
+      return;
+    }
+
     switch (true) {
       // match :extension
       case /^:/.test(ext_name):
@@ -142,6 +158,15 @@ export async function addExtensionWindows(
           ext_version.replace('stable', '')
         );
         break;
+      // match extensions from GitHub. Do this before checking for semver as
+      // the version may match that as well
+      case /.*-(.*)\/(.*)@(.*)/.test(extension):
+        add_script += await utils.getUnsupportedLog(
+          extension,
+          version,
+          'win32'
+        );
+        break;
       // match semver without state
       case /.*-\d+\.\d+\.\d+$/.test(version_extension):
         add_script += await utils.joins(
@@ -214,6 +239,22 @@ export async function addExtensionLinux(
     const version_extension: string = version + extension;
     const [ext_name, ext_version]: string[] = extension.split('-');
     const ext_prefix = await utils.getExtensionPrefix(ext_name);
+
+    // Install extensions from a GitHub tarball. This needs to be checked first
+    // as the version may also match the semver check below.
+    const urlMatches = extension.match(/.*-(.*)\/(.*)@(.*)/);
+    if (urlMatches != null) {
+      add_script += await utils.joins(
+        '\nadd_extension_from_github',
+        ext_name,
+        urlMatches[1],
+        urlMatches[2],
+        urlMatches[3],
+        ext_prefix
+      );
+      return;
+    }
+
     switch (true) {
       // Match :extension
       case /^:/.test(ext_name):

--- a/src/scripts/common.sh
+++ b/src/scripts/common.sh
@@ -279,8 +279,10 @@ add_extension_from_github() {
   (
     add_devtools phpize
     delete_extension "$extension"
-    git clone --recurse-submodules -b "$release" https://github.com/"$org"/"$repo" /tmp/"$repo-$release" || exit 1
+    git clone -n https://github.com/"$org"/"$repo" /tmp/"$repo-$release" || exit 1
     cd /tmp/"$repo-$release" || exit 1
+    git checkout "$release" || exit 1
+    git submodule update --init --recursive || exit 1
     phpize && ./configure && make -j"$(nproc)" && sudo make install
     enable_extension "$extension" "$prefix"
   ) >/dev/null 2>&1

--- a/src/scripts/common.sh
+++ b/src/scripts/common.sh
@@ -268,3 +268,21 @@ add_composertool() {
 php_semver() {
   php"$version" -v | grep -Eo -m 1 "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1
 }
+
+# Function to install extension from a GitHub repository
+add_extension_from_github() {
+  extension=$1
+  org=$2
+  repo=$3
+  release=$4
+  prefix=$5
+  (
+    add_devtools phpize
+    delete_extension "$extension"
+    git clone --recurse-submodules -b "$release" https://github.com/"$org"/"$repo" /tmp/"$repo-$release" || exit 1
+    cd /tmp/"$repo-$release" || exit 1
+    phpize && ./configure && make -j"$(nproc)" && sudo make install
+    enable_extension "$extension" "$prefix"
+  ) >/dev/null 2>&1
+  add_extension_log "$extension-$org/$repo@$release" "Installed and enabled"
+}

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -39,24 +39,6 @@ add_pecl_extension() {
   fi
 }
 
-# Function to install extension from a GitHub repository
-add_extension_from_github() {
-  extension=$1
-  org=$2
-  repo=$3
-  release=$4
-  prefix=$5
-  (
-    add_devtools phpize
-    delete_extension "$extension"
-    git clone --recurse-submodules -b "$release" https://github.com/"$org"/"$repo" /tmp/"$repo-$release" || exit 1
-    cd /tmp/"$repo-$release" || exit 1
-    phpize && ./configure && make -j"$(nproc)" && sudo make install
-    enable_extension "$extension" "$prefix"
-  ) >/dev/null 2>&1
-  add_extension_log "$extension-$org/$repo@$release" "Installed and enabled"
-}
-
 # Function to fetch a brew tap
 fetch_brew_tap() {
   tap=$1

--- a/src/scripts/darwin.sh
+++ b/src/scripts/darwin.sh
@@ -39,6 +39,24 @@ add_pecl_extension() {
   fi
 }
 
+# Function to install extension from a GitHub repository
+add_extension_from_github() {
+  extension=$1
+  org=$2
+  repo=$3
+  release=$4
+  prefix=$5
+  (
+    add_devtools phpize
+    delete_extension "$extension"
+    git clone --recurse-submodules -b "$release" https://github.com/"$org"/"$repo" /tmp/"$repo-$release" || exit 1
+    cd /tmp/"$repo-$release" || exit 1
+    phpize && ./configure && make -j"$(nproc)" && sudo make install
+    enable_extension "$extension" "$prefix"
+  ) >/dev/null 2>&1
+  add_extension_log "$extension-$org/$repo@$release" "Installed and enabled"
+}
+
 # Function to fetch a brew tap
 fetch_brew_tap() {
   tap=$1

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -142,24 +142,6 @@ add_pecl_extension() {
   fi
 }
 
-# Function to install extension from a GitHub repository
-add_extension_from_github() {
-  extension=$1
-  org=$2
-  repo=$3
-  release=$4
-  prefix=$5
-  (
-    add_devtools phpize
-    delete_extension "$extension"
-    git clone --recurse-submodules -b "$release" https://github.com/"$org"/"$repo" /tmp/"$repo-$release" || exit 1
-    cd /tmp/"$repo-$release" || exit 1
-    phpize && ./configure && make -j"$(nproc)" && sudo make install
-    enable_extension "$extension" "$prefix"
-  ) >/dev/null 2>&1
-  add_extension_log "$extension-$org/$repo@$release" "Installed and enabled"
-}
-
 # Function to setup phpize and php-config.
 add_devtools() {
   tool=$1

--- a/src/scripts/linux.sh
+++ b/src/scripts/linux.sh
@@ -142,23 +142,22 @@ add_pecl_extension() {
   fi
 }
 
-# Function to install extension from source
-add_extension_from_source() {
+# Function to install extension from a GitHub repository
+add_extension_from_github() {
   extension=$1
-  repo=$2
-  release=$3
-  args=$4
+  org=$2
+  repo=$3
+  release=$4
   prefix=$5
   (
     add_devtools phpize
     delete_extension "$extension"
-    get -q -n "/tmp/$extension.tar.gz" "https://github.com/$repo/archive/$release.tar.gz"
-    tar xf /tmp/"$extension".tar.gz -C /tmp
-    cd /tmp/"$extension-$release" || exit 1
-    phpize && ./configure "$args" && make -j"$(nproc)" && sudo make install
+    git clone --recurse-submodules -b "$release" https://github.com/"$org"/"$repo" /tmp/"$repo-$release" || exit 1
+    cd /tmp/"$repo-$release" || exit 1
+    phpize && ./configure && make -j"$(nproc)" && sudo make install
     enable_extension "$extension" "$prefix"
   ) >/dev/null 2>&1
-  add_extension_log "$extension-$release" "Installed and enabled"
+  add_extension_log "$extension-$org/$repo@$release" "Installed and enabled"
 }
 
 # Function to setup phpize and php-config.


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Allow extensions to be compiled from GitHub sources
labels: enhancement

---

## A Pull Request should be associated with a Discussion.

Note: no discussion available as I built this for my own needs and want to start a discussion based on the changes I made.

### Description

This PR allows installing extensions from source. This is done by using a special extension format of the form `<extension>-<org>/<repo>@<version>`. Currently, only GitHub is supported and the repository is checked out using `git clone --recurse-submodules -b <version> https://github.com/<org>/<repo>`. This is supported on Linux and OSX, but not on Windows environments.

The rationale for adding this was that I didn't want to have separate steps depending on what extension version to install. This way, I can provide the repository URL and branch name as version string, allowing installing stable versions and compiling from source in a single step in a matrix. This was inspired by the leftover `install_extension_from_source`, which this PR also removes as it's unused (and replaced by this PR).

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.
- [x] I have checked the edited scripts for syntax.
- [x] I have tested the changes in an integration test (linux only, can run on OSX separately): https://github.com/alcaeus/mongo-php-library/runs/1741774149 (also, please ignore the PHPUnit failure - that is unrelated).

### Further discussion

- Should we allow passing commit hashes as well? This is not supported due to using `git clone` but could be supported as well.
- Should we provide way for users to customise the build, e.g. arguments to pass to `configure`? If so, this might require more changes to the action (including potentially changing the format of the `extensions` input)
- I have yet to figure out whether this will play nice with `shivammathur/cache-extensions`. I assume there will be issues if somebody installed `ext-org/repo@master` and the commit hash changes before the cache is invalidated. This needs documentation at the very least. This can be worked around by supporting commit hashes (see above).

Let me know if you have any concerns about adding this, I'm happy to talk about potential alternatives.