### PR TITLE
Update readme with additional tools support

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ PHP extensions can be setup using the `extensions` input. It accepts a `string` 
 
 These tools can be setup globally using the `tools` input. It accepts a string in csv-format.
 
-`behat`, `blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `phpcbf`, `phpcpd`, `php-config`, `php-cs-fixer`, `phpcs`, `phpize`, `phpmd`, `phpspec`, `phpstan`, `phpunit`, `prestissimo`, `protoc`, `psalm`, `symfony`, `vapor-cli`
+`behat`, `blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `php-config`, `php-cs-fixer`, `phpcbf`, `phpcpd`, `phpcs`, `phpize`, `phplint`, `phpmd`, `phpspec`, `phpstan`, `phpunit`, `prestissimo`, `protoc`, `psalm`, `symfony`, `symfony-cli`, `vapor-cli`, `wp-cli`
 
 ```yaml
 - name: Setup PHP with tools


### PR DESCRIPTION
---
name: ⚙ Improvement on the readme
about: Update the list of supported tools
labels: enhancement

---

## A Pull Request should be associated with a Discussion.

Related discussion: #187 

### Description

This PR adds `wp-cli` to the list of supported tools, also sorts the list of supported tools alphabetically. The PR #188 was merged a while ago, and it would be good that this tool is mentioned (I realized it was supported when I searched the issues 😄 ).

EDIT: Apparently, not only `wp-cli` was added, but `phplint` and `symfony-cli` as well.