### PR TITLE
Update Phive configuration

### DIFF
--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -201,6 +201,7 @@ describe('Tools tests', () => {
     version     | php_version | os_version  | script
     ${'latest'} | ${'7.4'}    | ${'linux'}  | ${'add_tool https://phar.io/releases/phive.phar phive'}
     ${'1.2.3'}  | ${'7.4'}    | ${'darwin'} | ${'add_tool https://github.com/phar-io/phive/releases/download/1.2.3/phive-1.2.3.phar phive'}
+    ${'1.2.3'}  | ${'7.2'}    | ${'win32'}  | ${'Add-Tool https://github.com/phar-io/phive/releases/download/0.14.5/phive-0.14.5.phar phive'}
     ${'1.2.3'}  | ${'7.1'}    | ${'win32'}  | ${'Add-Tool https://github.com/phar-io/phive/releases/download/0.13.5/phive-0.13.5.phar phive'}
     ${'latest'} | ${'5.6'}    | ${'win32'}  | ${'Add-Tool https://github.com/phar-io/phive/releases/download/0.12.1/phive-0.12.1.phar phive'}
     ${'latest'} | ${'5.5'}    | ${'win32'}  | ${'Phive is not supported on PHP 5.5'}

--- a/dist/index.js
+++ b/dist/index.js
@@ -685,6 +685,9 @@ async function addPhive(data) {
         case /7\.1/.test(data['php_version']):
             data['version'] = data['version'].replace('latest', '0.13.5');
             break;
+        case /7\.2/.test(data['php_version']):
+            data['version'] = data['version'].replace('latest', '0.14.5');
+            break;
     }
     if (data['version'] === 'latest') {
         data['domain'] = data['domain'] + '/releases';

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -298,6 +298,9 @@ export async function addPhive(data: RS): Promise<string> {
     case /7\.1/.test(data['php_version']):
       data['version'] = data['version'].replace('latest', '0.13.5');
       break;
+    case /7\.2/.test(data['php_version']):
+      data['version'] = data['version'].replace('latest', '0.14.5');
+      break;
   }
   if (data['version'] === 'latest') {
     data['domain'] = data['domain'] + '/releases';


### PR DESCRIPTION
---
name: ⚙ Improvement
about: Update Phive configuration
labels: enhancement

---

### Description

Phive has released version `0.15.0` which ups the minimum supported PHP version to PHP 7.3.

This updates the switch statement for Phive to take this into account.

Ref: https://github.com/phar-io/phive/releases

> In case this PR introduced TypeScript/JavaScript code changes:

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.

> In case this PR edits any scripts:

- [x] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).


**_P.S.: Hope I've done it right as I'm not familiar with writing code for GH actions._**