### PR TITLE
Use systemctl instead of services to install blackfire

### DIFF
--- a/src/scripts/tools/blackfire.sh
+++ b/src/scripts/tools/blackfire.sh
@@ -16,7 +16,7 @@ add_blackfire_darwin() {
 blackfire_config() {
   if [[ -n $BLACKFIRE_SERVER_ID ]] && [[ -n $BLACKFIRE_SERVER_TOKEN ]]; then
     blackfire agent:config --server-id="$BLACKFIRE_SERVER_ID" --server-token="$BLACKFIRE_SERVER_TOKEN"
-    [ "$os" = "Linux" ] && sudo service blackfire-agent restart
+    [ "$os" = "Linux" ] && sudo systemctl start blackfire-agent
     [ "$os" = "Darwin" ] && brew services start blackfire
   fi
   if [[ -n $BLACKFIRE_CLIENT_ID ]] && [[ -n $BLACKFIRE_CLIENT_TOKEN ]]; then


### PR DESCRIPTION
---
name: 🐞 Bug Fix
about: You found a bug
labels: bug

---

## A Pull Request should be associated with a Discussion.

> If you're fixing a bug, adding a new feature or improving something please provide the details in discussions,
> so that the development can be pointed in the intended direction.

Related discussion: <!-- Please link the related discussion -->

> Further notes in [Contribution Guidelines](.github/CONTRIBUTING.md)
> Thank you for your contribution.

### Description

This PR changes `sudo service blackfire-agent start` to `sudo systemctl start blackfire-agent`

> In case this PR edits any scripts:

- [x] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).
