### PR TITLE
Tools: add support for phpDocumentor

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ PHP extensions can be set up using the `extensions` input. It accepts a `string`
 
 These tools can be set up globally using the `tools` input. It accepts a string in csv-format.
 
-`behat`, `blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `php-config`, `php-cs-fixer`, `phpcbf`, `phpcpd`, `phpcs`, `phpize`, `phplint`, `phpmd`, `phpspec`, `phpstan`, `phpunit`, `phpunit-bridge`, `prestissimo`, `protoc`, `psalm`, `symfony` or `symfony-cli`, `vapor` or `vapor-cli`, `wp` or `wp-cli`
+`behat`, `blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `php-config`, `php-cs-fixer`, `phpcbf`, `phpcpd`, `phpcs`, `phpdoc` or `phpDocumentor`, `phpize`, `phplint`, `phpmd`, `phpspec`, `phpstan`, `phpunit`, `phpunit-bridge`, `prestissimo`, `protoc`, `psalm`, `symfony` or `symfony-cli`, `vapor` or `vapor-cli`, `wp` or `wp-cli`
 
 ```yaml
 - name: Setup PHP with tools

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -373,7 +373,7 @@ describe('Tools tests', () => {
 
   it.each([
     [
-      'blackfire, blackfire-player, cs2pr, flex, grpc_php_plugin, php-cs-fixer, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, phpunit-bridge, php-config, phpize, protoc, symfony, vapor, wp',
+      'blackfire, blackfire-player, cs2pr, flex, grpc_php_plugin, php-cs-fixer, phpDocumentor, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, phpunit-bridge, php-config, phpize, protoc, symfony, vapor, wp',
       [
         'add_tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-stable.phar,https://getcomposer.org/composer-stable.phar composer',
         'add_blackfire',
@@ -382,6 +382,7 @@ describe('Tools tests', () => {
         'add_composertool flex flex symfony/',
         'add_grpc_php_plugin latest',
         'add_tool https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.2.1/php-cs-fixer.phar php-cs-fixer "-V"',
+        'add_tool https://github.com/phpDocumentor/phpDocumentor/releases/latest/download/phpDocumentor.phar phpDocumentor "--version"',
         'add_composertool phplint phplint overtrue/',
         'add_tool https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar phpstan "-V"',
         'add_tool https://phar.phpunit.de/phpunit.phar phpunit "--version"',
@@ -408,7 +409,7 @@ describe('Tools tests', () => {
 
   it.each([
     [
-      'behat, blackfire, blackfire-player, composer-normalize, composer-require-checker, composer-unused, cs2pr:1.2.3, flex, grpc_php_plugin:1.2.3, infection, phan, phan:1.2.3, phing:1.2.3, phinx, phive:1.2.3, php-config, phpcbf, phpcpd, phpcs, phpize, phpmd, phpspec, phpunit-bridge:5.6, protoc:v1.2.3, psalm, symfony-cli, symfony:1.2.3, vapor-cli, wp-cli',
+      'behat, blackfire, blackfire-player, composer-normalize, composer-require-checker, composer-unused, cs2pr:1.2.3, flex, grpc_php_plugin:1.2.3, infection, phan, phan:1.2.3, phing:1.2.3, phinx, phive:1.2.3, php-config, phpcbf, phpcpd, phpcs, phpdoc, phpize, phpmd, phpspec, phpunit-bridge:5.6, protoc:v1.2.3, psalm, symfony-cli, symfony:1.2.3, vapor-cli, wp-cli',
       [
         'add_tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-stable.phar,https://getcomposer.org/composer-stable.phar composer',
         'add_composertool behat behat behat/',
@@ -430,6 +431,7 @@ describe('Tools tests', () => {
         'add_tool https://github.com/squizlabs/PHP_CodeSniffer/releases/latest/download/phpcbf.phar phpcbf "--version"',
         'add_tool https://phar.phpunit.de/phpcpd.phar phpcpd "--version"',
         'add_tool https://github.com/squizlabs/PHP_CodeSniffer/releases/latest/download/phpcs.phar phpcs "--version"',
+        'add_tool https://github.com/phpDocumentor/phpDocumentor/releases/latest/download/phpDocumentor.phar phpDocumentor "--version"',
         'add_devtools phpize',
         'add_tool https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar phpmd "--version"',
         'add_composertool phpspec phpspec phpspec/',

--- a/src/configs/tools.json
+++ b/src/configs/tools.json
@@ -56,6 +56,15 @@
     "version_prefix": "",
     "version_parameter": "--version"
   },
+  "phpDocumentor": {
+    "type": "phar",
+    "repository": "phpDocumentor/phpDocumentor",
+    "extension": ".phar",
+    "domain": "https://github.com",
+    "alias": "phpdoc",
+    "version_prefix": "v",
+    "version_parameter": "--version"
+  },
   "phpmd": {
     "type": "phar",
     "repository": "phpmd/phpmd",


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Add a new feature
labels: enhancement
---

## A Pull Request should be associated with a Discussion.

Related discussion: #497

### Description

This PR adds support for the phpDocumentor tool via the `tools` input to setup-php.

phpDocumentor has also been aliased to `phpdoc` for convenience.

I have added a test to the `linux` test for the base name and to the `darwin` test for the alias.
👉🏻 Should I also add a test to the `windows` test ?
👉🏻 Should I add a test for downloading different versions ?


> In case this PR introduced TypeScript/JavaScript code changes:

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.

Note: running these scripts, automatically added two unrelated changes to the PR, which I have manually removed (had to disable the `pre-commit` hook to do so). The changes were to `package-lock.json` and to `dist/index.js`. Not sure what's going on there.

> In case this PR edits any scripts:

- [ ] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).
