### PR TITLE
Tools: add support for PHP Parallel Lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ PHP extensions can be set up using the `extensions` input. It accepts a `string`
 
 These tools can be set up globally using the `tools` input. It accepts a string in csv-format.
 
-`behat`, `blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `php-config`, `php-cs-fixer`, `phpcbf`, `phpcpd`, `phpcs`, `phpdoc` or `phpDocumentor`, `phpize`, `phplint`, `phpmd`, `phpspec`, `phpstan`, `phpunit`, `phpunit-bridge`, `prestissimo`, `protoc`, `psalm`, `symfony` or `symfony-cli`, `vapor` or `vapor-cli`, `wp` or `wp-cli`
+`behat`, `blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `parallel-lint`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `php-config`, `php-cs-fixer`, `phpcbf`, `phpcpd`, `phpcs`, `phpdoc` or `phpDocumentor`, `phpize`, `phplint`, `phpmd`, `phpspec`, `phpstan`, `phpunit`, `phpunit-bridge`, `prestissimo`, `protoc`, `psalm`, `symfony` or `symfony-cli`, `vapor` or `vapor-cli`, `wp` or `wp-cli`
 
 ```yaml
 - name: Setup PHP with tools

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -373,7 +373,7 @@ describe('Tools tests', () => {
 
   it.each([
     [
-      'blackfire, blackfire-player, cs2pr, flex, grpc_php_plugin, php-cs-fixer, phpDocumentor, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, phpunit-bridge, php-config, phpize, protoc, symfony, vapor, wp',
+      'blackfire, blackfire-player, cs2pr, flex, grpc_php_plugin, parallel-lint, php-cs-fixer, phpDocumentor, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, phpunit-bridge, php-config, phpize, protoc, symfony, vapor, wp',
       [
         'add_tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-stable.phar,https://getcomposer.org/composer-stable.phar composer',
         'add_blackfire',
@@ -381,6 +381,7 @@ describe('Tools tests', () => {
         'add_tool https://github.com/staabm/annotate-pull-request-from-checkstyle/releases/latest/download/cs2pr cs2pr "-V"',
         'add_composertool flex flex symfony/',
         'add_grpc_php_plugin latest',
+        'add_tool https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/latest/download/parallel-lint.phar parallel-lint "--version"',
         'add_tool https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.2.1/php-cs-fixer.phar php-cs-fixer "-V"',
         'add_tool https://github.com/phpDocumentor/phpDocumentor/releases/latest/download/phpDocumentor.phar phpDocumentor "--version"',
         'add_composertool phplint phplint overtrue/',

--- a/src/configs/tools.json
+++ b/src/configs/tools.json
@@ -31,6 +31,14 @@
     "version_prefix": "",
     "version_parameter": "-v"
   },
+  "parallel-lint": {
+    "type": "phar",
+    "repository": "php-parallel-lint/PHP-Parallel-Lint",
+    "extension": ".phar",
+    "domain": "https://github.com",
+    "version_prefix": "v",
+    "version_parameter": "--version"
+  },
   "php-cs-fixer": {
     "type": "phar",
     "repository": "FriendsOfPHP/PHP-CS-Fixer",


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Add a new feature
labels: enhancement
---

## A Pull Request should be associated with a Discussion.

Fixes #499

### Description

This PR adds support for the [PHP Parallel Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint) tool via the `tools` input to setup-php.

I have added a test to the `linux` test.

> In case this PR introduced TypeScript/JavaScript code changes:

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.

> In case this PR edits any scripts:

- [ ] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).
