### PR TITLE
Tools: add PHPUnit Polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ PHP extensions can be set up using the `extensions` input. It accepts a `string`
 
 These tools can be set up globally using the `tools` input. It accepts a string in csv-format.
 
-`behat`, `blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `parallel-lint`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `php-config`, `php-cs-fixer`, `phpcbf`, `phpcpd`, `phpcs`, `phpdoc` or `phpDocumentor`, `phpize`, `phplint`, `phpmd`, `phpspec`, `phpstan`, `phpunit`, `phpunit-bridge`, `prestissimo`, `protoc`, `psalm`, `symfony` or `symfony-cli`, `vapor` or `vapor-cli`, `wp` or `wp-cli`
+`behat`, `blackfire`, `blackfire-player`, `codeception`, `composer`, `composer-normalize`, `composer-prefetcher`, `composer-require-checker`, `composer-unused`, `cs2pr`, `deployer`, `flex`, `grpc_php_plugin`, `infection`, `parallel-lint`, `pecl`, `phan`, `phing`, `phinx`, `phive`, `php-config`, `php-cs-fixer`, `phpcbf`, `phpcpd`, `phpcs`, `phpdoc` or `phpDocumentor`, `phpize`, `phplint`, `phpmd`, `phpspec`, `phpstan`, `phpunit`, `phpunit-bridge`, `phpunit-polyfills`, `prestissimo`, `protoc`, `psalm`, `symfony` or `symfony-cli`, `vapor` or `vapor-cli`, `wp` or `wp-cli`
 
 ```yaml
 - name: Setup PHP with tools

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -373,7 +373,7 @@ describe('Tools tests', () => {
 
   it.each([
     [
-      'blackfire, blackfire-player, cs2pr, flex, grpc_php_plugin, parallel-lint, php-cs-fixer, phpDocumentor, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, phpunit-bridge, php-config, phpize, protoc, symfony, vapor, wp',
+      'blackfire, blackfire-player, cs2pr, flex, grpc_php_plugin, parallel-lint, php-cs-fixer, phpDocumentor, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, phpunit-bridge, phpunit-polyfills, php-config, phpize, protoc, symfony, vapor, wp',
       [
         'add_tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-stable.phar,https://getcomposer.org/composer-stable.phar composer',
         'add_blackfire',
@@ -393,6 +393,7 @@ describe('Tools tests', () => {
         'add_composertool phinx phinx:1.2.3 robmorgan/',
         'add_tool https://phar.io/releases/phive.phar phive "status"',
         'add_composertool phpunit-bridge phpunit-bridge symfony/',
+        'add_composertool phpunit-polyfills phpunit-polyfills yoast/',
         'add_devtools php-config',
         'add_devtools phpize',
         'add_protoc latest',
@@ -410,7 +411,7 @@ describe('Tools tests', () => {
 
   it.each([
     [
-      'behat, blackfire, blackfire-player, composer-normalize, composer-require-checker, composer-unused, cs2pr:1.2.3, flex, grpc_php_plugin:1.2.3, infection, phan, phan:1.2.3, phing:1.2.3, phinx, phive:1.2.3, php-config, phpcbf, phpcpd, phpcs, phpdoc, phpize, phpmd, phpspec, phpunit-bridge:5.6, protoc:v1.2.3, psalm, symfony-cli, symfony:1.2.3, vapor-cli, wp-cli',
+      'behat, blackfire, blackfire-player, composer-normalize, composer-require-checker, composer-unused, cs2pr:1.2.3, flex, grpc_php_plugin:1.2.3, infection, phan, phan:1.2.3, phing:1.2.3, phinx, phive:1.2.3, php-config, phpcbf, phpcpd, phpcs, phpdoc, phpize, phpmd, phpspec, phpunit-bridge:5.6, phpunit-polyfills:1.0.1, protoc:v1.2.3, psalm, symfony-cli, symfony:1.2.3, vapor-cli, wp-cli',
       [
         'add_tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-stable.phar,https://getcomposer.org/composer-stable.phar composer',
         'add_composertool behat behat behat/',
@@ -437,6 +438,7 @@ describe('Tools tests', () => {
         'add_tool https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar phpmd "--version"',
         'add_composertool phpspec phpspec phpspec/',
         'add_composertool phpunit-bridge phpunit-bridge:5.6.* symfony/',
+        'add_composertool phpunit-polyfills phpunit-polyfills:1.0.1 yoast/',
         'add_protoc 1.2.3',
         'add_tool https://github.com/vimeo/psalm/releases/latest/download/psalm.phar psalm "-v"',
         'add_tool https://github.com/symfony/cli/releases/latest/download/symfony_darwin_amd64 symfony-cli "version"',

--- a/src/configs/tools.json
+++ b/src/configs/tools.json
@@ -139,6 +139,10 @@
     "type": "composer",
     "repository": "symfony/phpunit-bridge"
   },
+  "phpunit-polyfills": {
+    "type": "composer",
+    "repository": "yoast/phpunit-polyfills"
+  },
   "prestissimo": {
     "type": "composer",
     "repository": "hirak/prestissimo"


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Add a new feature
labels: enhancement
---

## A Pull Request should be associated with a Discussion.

Fixes #502 


### Description

This PR adds support for the [PHPUnit Polyfills](https://github.com/Yoast/PHPUnit-Polyfills) tool via the `tools` input to setup-php.

I have added a test to the `linux` test and a second test with a specific version to the `darwin` test.

> In case this PR introduced TypeScript/JavaScript code changes:

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.

Note: running these scripts, automatically added two unrelated changes to the PR, which I have manually removed (had to disable the `pre-commit` hook to do so). The changes were to `package-lock.json` and to `dist/index.js`. Not sure what's going on there.

> In case this PR edits any scripts:

- [ ] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).
