### PR TITLE
Example code: remove `--no-interaction` from Composer commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ These tools can be set up globally using the `tools` input. It accepts a string 
 - Input `tools` is useful to set up tools which you only use in GitHub Actions, thus keeping your `composer.json` tidy.
 - If you do not want to use all your dev-dependencies in GitHub Actions workflow, you can run composer with `--no-dev` and install required tools using `tools` input to speed up your workflow.
 - If you have a tool in your `composer.json`, do not set up it with `tools` input as the two instances of the tool might conflict.
-- By default, `COMPOSER_NO_INTERACTION` is set to `1` and `COMPOSER_PROCESS_TIMEOUT` is set to `0`.
+- By default, `COMPOSER_NO_INTERACTION` is set to `1` and `COMPOSER_PROCESS_TIMEOUT` is set to `0`. In effect, this means that Composer commands in your scripts do not need to specify `--no-interaction`.
 
 ## :signal_strength: Coverage Support
 

--- a/examples/cakephp-mysql.yml
+++ b/examples/cakephp-mysql.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --prefer-dist --optimize-autoloader
-          composer run-script post-install-cmd --no-interaction
+          composer run-script post-install-cmd
 
       # Add a step to run migrations if required
       - name: Test with phpunit

--- a/examples/cakephp-postgres.yml
+++ b/examples/cakephp-postgres.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --prefer-dist --optimize-autoloader
-          composer run-script post-install-cmd --no-interaction
+          composer run-script post-install-cmd
 
       # Add a step to run migrations if required
       - name: Test with phpunit

--- a/examples/cakephp.yml
+++ b/examples/cakephp.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --prefer-dist --optimize-autoloader
-          composer run-script post-install-cmd --no-interaction
+          composer run-script post-install-cmd
 
       - name: Test with phpunit
         run: vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
---
name: ⚙ Improvement
about: You found a bug, want to improve something or add a new feature
labels: enhancement

---

### Description

~~All Composer commands used in CI should use `--no-interaction` to prevent them hanging in case interaction is expected.~~

~~This adds the `--no-interaction` argument to all Composer example code which did not have the argument yet.~~

All Composer commands used in CI should use `--no-interaction` to prevent them hanging in case interaction is expected. However, as setupPHP sets the `COMPOSER_NO_INTERACTION` flag (as of this version), this is not needed when using setupPHP.

This removes redundant `--no-interaction` arguments from the example code.

Also see: https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

