### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,15 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 15 * * 6'
+permissions:
+  contents: read
+
 jobs:
   codeql:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 15 * * 6'
+permissions:
+  contents: read
+
 jobs:
   create:
+    permissions:
+      contents: none
     name: Create
     runs-on: ${{ matrix.operating-system }}
     strategy:
@@ -45,6 +50,8 @@ jobs:
           name: lists
           path: php${{ matrix.php-versions }}-${{ matrix.operating-system }}.md
   update:
+    permissions:
+      contents: write  # for Git to git push
     name: Update
     needs: create
     runs-on: ubuntu-latest

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,6 +16,9 @@ on:
     paths-ignore:
       - '**.md'
       - 'examples/**'
+permissions:
+  contents: read
+
 jobs:
   run:
     name: Run

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,6 +17,9 @@ on:
     paths-ignore:
       - '**.md'
       - 'examples/**'
+permissions:
+  contents: read
+
 jobs:
   run:
     name: Run


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
