### PR TITLE
🐞 Bug Fix: make symfony-cli installation faster on Linux

### DIFF
--- a/src/scripts/tools/symfony.sh
+++ b/src/scripts/tools/symfony.sh
@@ -1,11 +1,11 @@
 add_symfony_helper() {
-  if command -v brew >/dev/null; then
-    add_brew_tap symfony-cli/homebrew-tap
-    brew install symfony-cli/tap/symfony-cli
-  else
+  if [ "$(uname -s)" = "Linux" ]; then
     arch=$(dpkg --print-architecture)
     get -s -n "" "https://github.com/symfony-cli/symfony-cli/releases/latest/download/symfony-cli_linux_$arch.tar.gz" | sudo tar -xz -C "${tool_path_dir:?}"
     sudo chmod a+x /usr/local/bin/symfony
+  elif [ "$(uname -s)" = "Darwin" ]; then
+    add_brew_tap symfony-cli/homebrew-tap
+    brew install symfony-cli/tap/symfony-cli
   fi
 }
 


### PR DESCRIPTION
This PR make `symfony-cli` installation faster on Linux. Fixes #640.

Brew is available on Ubuntu runners but is very slow. Downloading the binary directly is faster.

> In case this PR introduced TypeScript/JavaScript code changes:

- [ ] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [ ] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.

> In case this PR edits any scripts:

- [x] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).