### PR TITLE
fix deprecation warning from Github using new env var for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ If your project uses composer, you can persist the composer's internal cache dir
 ```yaml
 - name: Get composer cache directory
   id: composer-cache
-  run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+  run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
 - name: Cache dependencies
   uses: actions/cache@v2


### PR DESCRIPTION
This PR fixes a warning received by Github using one of the examples from the README.

More info here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/