### PR TITLE
Move php version default out of action.yml and update inputs

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -264,9 +264,7 @@ describe('Utils tests', () => {
   });
 
   it('checking resolveVersion', async () => {
-    await expect(utils.resolveVersion()).rejects.toThrow(
-      "Neither 'php-version' nor 'php-version-file' inputs were supplied, and could not find '.php-version' file."
-    );
+    expect(await utils.resolveVersion()).toBe('latest');
 
     process.env['php-version-file'] = '.phpenv-version';
     await expect(utils.resolveVersion()).rejects.toThrow(

--- a/action.yml
+++ b/action.yml
@@ -6,25 +6,20 @@ branding:
   icon: 'play-circle'
 inputs:
   php-version:
-    description: 'Setup PHP version.'
-    default: '8.2'
-    required: true
+    description: 'Setup PHP version. Reads from .php-version if unset. Defaults to latest.'
+  php-version-file:
+    description: 'File containing the PHP version to use. Defaults to .php-version if unset.'
   extensions:
     description: 'Setup PHP extensions.'
-    required: false
   ini-file:
     description: 'Set base ini file.'
     default: 'production'
-    required: false
   ini-values:
     description: 'Add values to php.ini.'
-    required: false
   coverage: 
     description: 'Setup code coverage driver.'
-    required: false
   tools:
     description: 'Setup popular tools globally.'
-    required: false
 outputs:
   php-version:
     description: 'PHP version in semver format'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1298,7 +1298,7 @@ async function resolveVersion() {
         core.info(`Resolved ${versionFile} as ${version}`);
     }
     if (!version) {
-        throw new Error("Neither 'php-version' nor 'php-version-file' inputs were supplied, and could not find '.php-version' file.");
+        version = 'latest';
     }
     return version;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -446,9 +446,7 @@ export async function resolveVersion(): Promise<string> {
   }
 
   if (!version) {
-    throw new Error(
-      "Neither 'php-version' nor 'php-version-file' inputs were supplied, and could not find '.php-version' file."
-    );
+    version = 'latest';
   }
 
   return version;


### PR DESCRIPTION
---
name: 🐞 Bug Fix
about: The php version input has a hardcoded default that stops the file input added in https://github.com/shivammathur/setup-php/pull/690 from working
labels: bug

---

## A Pull Request should be associated with a Discussion.

> If you're fixing a bug, adding a new feature or improving something please provide the details in discussions,
> so that the development can be pointed in the intended direction.

Related discussion: https://github.com/shivammathur/setup-php/issues/629

> Further notes in [Contribution Guidelines](.github/CONTRIBUTING.md)
> Thank you for your contribution.

### Description

The `php-version` input overrides any `php-version-file` provided, so it can't have a default value anymore, because that means https://github.com/shivammathur/setup-php/pull/690 doesn't fallback to the file correctly when no inputs are provided.

Instead of supplying the default via the action.yml I've made it so `resolveVersion` returns `'latest'` instead of raising an error  when neither inputs are provided, which maintains backwards compatibility.

> In case this PR introduced TypeScript/JavaScript code changes:

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.

> In case this PR edits any scripts:

- [x] I have checked the edited scripts for syntax.
- [x] I have tested the changes in an integration test (If yes, provide workflow YAML and link).

<!--
- Please target the develop branch when submitting the pull request.
-->