### PR TITLE
docs(example): fix a typo in the strategy of the sage example

### DIFF
--- a/examples/sage.yml
+++ b/examples/sage.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.4', '8.0', '8.1']
-        node-versions: [16']
+        node-versions: ['16']
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
fix a typo in the sage example