### PR TITLE
Phpunit versions

### DIFF
--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -540,4 +540,22 @@ describe('Tools tests', () => {
     process.env['GITHUB_TOKEN'] = token;
     expect(await tools.addTools(tools_csv, '7.4', 'linux')).toContain(script);
   });
+
+  it.each`
+    tools_csv    | php_version | resolved
+    ${'phpunit'} | ${'8.2'}    | ${'/phpunit.phar'}
+    ${'phpunit'} | ${'8.1'}    | ${'/phpunit.phar'}
+    ${'phpunit'} | ${'8.0'}    | ${'/phpunit-9.6.8.phar'}
+    ${'phpunit'} | ${'7.3'}    | ${'/phpunit-9.6.8.phar'}
+    ${'phpunit'} | ${'7.2'}    | ${'/phpunit-8.5.33.phar'}
+    ${'phpunit'} | ${'7.1'}    | ${'/phpunit-7.5.20.phar'}
+    ${'phpunit'} | ${'7.0'}    | ${'/phpunit-6.5.14.phar'}
+  `(
+    'checking error: $tools_csv',
+    async ({tools_csv, php_version, resolved}) => {
+      expect(await tools.addTools(tools_csv, php_version, 'linux')).toContain(
+        resolved
+      );
+    }
+  );
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -885,6 +885,17 @@ async function addPhive(data) {
 }
 exports.addPhive = addPhive;
 async function addPHPUnitTools(data) {
+    if (data['version'] == 'latest') {
+        if (/7\.3|8\.0/.test(data['php_version'])) {
+            data['version'] = '9.6.8';
+        } else if (/7\.[2-3]/.test(data['php_version'])) {
+            data['version'] = '8.5.33';
+        } else if (/7\.[1-3]/.test(data['php_version'])) {
+            data['version'] = '7.5.20';
+        } else if (/7\.[0-2]/.test(data['php_version'])) {
+            data['version'] = '6.5.14';
+        }
+    }
     data['url'] = await getPharUrl(data);
     return await addArchive(data);
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -392,6 +392,17 @@ export async function addPhive(data: RS): Promise<string> {
  * @param data
  */
 export async function addPHPUnitTools(data: RS): Promise<string> {
+  if (data['version'] == 'latest') {
+    if (/7\.3|8\.0/.test(data['php_version'])) {
+      data['version'] = '9.6.8';
+    } else if (/7\.[2-3]/.test(data['php_version'])) {
+      data['version'] = '8.5.33';
+    } else if (/7\.[1-3]/.test(data['php_version'])) {
+      data['version'] = '7.5.20';
+    } else if (/7\.[0-2]/.test(data['php_version'])) {
+      data['version'] = '6.5.14';
+    }
+  }
   data['url'] = await getPharUrl(data);
   return await addArchive(data);
 }


### PR DESCRIPTION
---
name: ⚙ Improvement: Make PHPUnit versions compatible with the PHP version installed
about: If you just let the `phpunit` version be `latest` (by not defining a specific version), then it can be incompatible with the version of php defined.  This PR fixes that issue.
labels: enhancement

---

## A Pull Request should be associated with a Discussion.

Related discussion: https://github.com/shivammathur/setup-php/issues/694

### Description

This PR makes an improvement to adding `phpunit` as a tool.  If you just let the `phpunit` version be `latest` (by not defining a specific version), then it can be incompatible with the version of php defined.  This PR adds version checking for phpunit and the php being setup.

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [ ] I have run `npm run release` before the commit.
- [ ] `npm test` returns with no unit test errors and all code covered.

For those last two points:

The `npm run release` failed with the following error:

```
➜  setup-php git:(phpunit-versions) ✗ npm run release                                

> setup-php@2.25.1 release
> ncc build -o dist && git add -f dist/

Error: Cannot find module 'setup-php/lib/install.js'. Please verify that the package.json has a valid "main" entry
```

I could see no information in the CONTRIBUTION guide as to how to resolve that.  I forced the change into the `dist` folder so that I could test it out in my own fork.

As to the tests: my tests passed just fine.  But there were a couple outside of the scope of what I changed that failed - and failed before I even made any changes.

Here's a screenshot of it in practise.  I cannot link to the action run as it's a private repo.

![Screenshot 2023-05-24 at 13 53 45](https://github.com/shivammathur/setup-php/assets/684421/ab2612c1-d7f8-4604-9e16-6a9f893f14ba)
