### PR TITLE
feat: add support for the embed SAPI

### DIFF
--- a/src/configs/php_debug_packages
+++ b/src/configs/php_debug_packages
@@ -1,6 +1,7 @@
 cgi
 cli
 curl
+embed
 fpm
 intl
 mbstring

--- a/src/configs/php_packages
+++ b/src/configs/php_packages
@@ -2,6 +2,7 @@ cgi
 cli
 curl
 dev
+embed
 fpm
 intl
 mbstring


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Add support for the embed SAPI
labels: enhancement

---

### Description

Attempt to support the embed SAPI to compile and test FrankenPHP with setup-php (https://github.com/dunglas/frankenphp/pull/157). This could also allow using NGINX Unix with setup-php.