### PR TITLE
Add automatic detection of required PHP version from Composer's platform setting

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -300,13 +300,6 @@ describe('Utils tests', () => {
     );
     expect(await utils.readPHPVersion()).toBe('7.4.33');
 
-    existsSync
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true);
-    readFileSync.mockReturnValue('{ "require": { "php": "^8.2" } }');
-    expect(await utils.readPHPVersion()).toBe('^8.2');
-
     existsSync.mockClear();
     readFileSync.mockClear();
   });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -282,6 +282,31 @@ describe('Utils tests', () => {
     process.env['php-version'] = '8.2';
     expect(await utils.readPHPVersion()).toBe('8.2');
 
+    delete process.env['php-version-file'];
+    delete process.env['php-version'];
+
+    existsSync.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    readFileSync.mockReturnValue(
+      '{ "platform-overrides": { "php": "7.3.25" } }'
+    );
+    expect(await utils.readPHPVersion()).toBe('7.3.25');
+
+    existsSync
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    readFileSync.mockReturnValue(
+      '{ "config": { "platform": { "php": "7.4.33" } } }'
+    );
+    expect(await utils.readPHPVersion()).toBe('7.4.33');
+
+    existsSync
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    readFileSync.mockReturnValue('{ "require": { "php": "^8.2" } }');
+    expect(await utils.readPHPVersion()).toBe('^8.2');
+
     existsSync.mockClear();
     readFileSync.mockClear();
   });

--- a/dist/index.js
+++ b/dist/index.js
@@ -1371,6 +1371,27 @@ async function readPHPVersion() {
     else if (versionFile !== '.php-version') {
         throw new Error(`Could not find '${versionFile}' file.`);
     }
+    const composerLock = 'composer.lock';
+    if (fs_1.default.existsSync(composerLock)) {
+        const lockFileContents = JSON.parse(fs_1.default.readFileSync(composerLock, 'utf8'));
+        if (lockFileContents['platform-overrides'] &&
+            lockFileContents['platform-overrides']['php']) {
+            return lockFileContents['platform-overrides']['php'];
+        }
+    }
+    const composerJson = 'composer.json';
+    if (fs_1.default.existsSync(composerJson)) {
+        const composerFileContents = JSON.parse(fs_1.default.readFileSync(composerJson, 'utf8'));
+        if (composerFileContents['config'] &&
+            composerFileContents['config']['platform'] &&
+            composerFileContents['config']['platform']['php']) {
+            return composerFileContents['config']['platform']['php'];
+        }
+        if (composerFileContents['require'] &&
+            composerFileContents['require']['php']) {
+            return composerFileContents['require']['php'];
+        }
+    }
     return 'latest';
 }
 exports.readPHPVersion = readPHPVersion;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1387,10 +1387,6 @@ async function readPHPVersion() {
             composerFileContents['config']['platform']['php']) {
             return composerFileContents['config']['platform']['php'];
         }
-        if (composerFileContents['require'] &&
-            composerFileContents['require']['php']) {
-            return composerFileContents['require']['php'];
-        }
     }
     return 'latest';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -464,12 +464,6 @@ export async function readPHPVersion(): Promise<string> {
     ) {
       return composerFileContents['config']['platform']['php'];
     }
-    if (
-      composerFileContents['require'] &&
-      composerFileContents['require']['php']
-    ) {
-      return composerFileContents['require']['php'];
-    }
   }
 
   return 'latest';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -440,6 +440,38 @@ export async function readPHPVersion(): Promise<string> {
   } else if (versionFile !== '.php-version') {
     throw new Error(`Could not find '${versionFile}' file.`);
   }
+
+  const composerLock = 'composer.lock';
+  if (fs.existsSync(composerLock)) {
+    const lockFileContents = JSON.parse(fs.readFileSync(composerLock, 'utf8'));
+    if (
+      lockFileContents['platform-overrides'] &&
+      lockFileContents['platform-overrides']['php']
+    ) {
+      return lockFileContents['platform-overrides']['php'];
+    }
+  }
+
+  const composerJson = 'composer.json';
+  if (fs.existsSync(composerJson)) {
+    const composerFileContents = JSON.parse(
+      fs.readFileSync(composerJson, 'utf8')
+    );
+    if (
+      composerFileContents['config'] &&
+      composerFileContents['config']['platform'] &&
+      composerFileContents['config']['platform']['php']
+    ) {
+      return composerFileContents['config']['platform']['php'];
+    }
+    if (
+      composerFileContents['require'] &&
+      composerFileContents['require']['php']
+    ) {
+      return composerFileContents['require']['php'];
+    }
+  }
+
   return 'latest';
 }
 


### PR DESCRIPTION
---
name: ⚙ Improvement
about: Supports automatic detection of PHP version from composer.lock or composer.json file
labels: enhancement

---

This is related to #751 and should help with #629, #713, and #639.

### Description

This PR adds detection of [the "config.platform.php" setting available in composer.json](https://getcomposer.org/doc/06-config.md#platform) (which is also saved as platform-overrides.php in composer.lock), so that the required PHP version for an application using Composer will be automatically detected.

As the config.platform.php setting forces Composer to lock dependencies to a specific PHP version, it's a perfect way to detect the "required" version of PHP for a project without any risk of conflicts due to differing versions.

> In case this PR introduced TypeScript/JavaScript code changes:

- [x] I have written test cases for the changes in this pull request
- [x] I have run `npm run format` before the commit.
- [x] I have run `npm run lint` before the commit.
- [x] I have run `npm run release` before the commit.
- [x] `npm test` returns with no unit test errors and all code covered.