### PR TITLE
feat: Add Box and PHP-Scoper as tools

### DIFF
--- a/src/configs/tools.json
+++ b/src/configs/tools.json
@@ -300,5 +300,23 @@
     "extension": ".phar",
     "version_parameter": "--version",
     "version_prefix": "v"
+  },
+  "box": {
+    "type": "phar",
+    "repository": "box-project/box",
+    "packagist": "humbug/box",
+    "extension": ".phar",
+    "domain": "https://github.com",
+    "version_prefix": "",
+    "version_parameter": "--version"
+  },
+  "php-scoper": {
+    "type": "phar",
+    "repository": "humbug/php-scoper",
+    "packagist": "humbug/php-scoper",
+    "extension": ".phar",
+    "domain": "https://github.com",
+    "version_prefix": "",
+    "version_parameter": "--version"
   }
 }


### PR DESCRIPTION
This PR proposes to add [Box](https://github.com/box-project/box) and [PHP-Scoper](https://github.com/humbug/php-scoper) as available tools.