### PR TITLE
Document php-version can come from platform overrides in composer.lock or composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,10 @@ Disable coverage for these reasons:
 - Accepts `nightly` to set up a nightly build from the master branch of PHP.
 - Accepts the format `d.x`, where `d` is the major version. For example `5.x`, `7.x` and `8.x`.  
 - See [PHP support](#tada-php-support) for the supported PHP versions.
-- If not specified, it looks for `php-version-file` input.
+- If not specified, it looks for the following in order:
+  - The `php-version-file` input if it exists
+  - A `composer.lock` file and the `platform-overrides.php` value
+  - A `composer.json` file and the `config.platform.php` value
 
 #### `php-version-file` (optional)
 

--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Disable coverage for these reasons:
 - Specify the PHP version you want to set up.
 - Accepts a `string`. For example `'8.0'`.
 - Accepts `latest` to set up the latest stable PHP version.
+- Accepts `lowest` to set up the lowest supported PHP version.
 - Accepts `nightly` to set up a nightly build from the master branch of PHP.
 - Accepts the format `d.x`, where `d` is the major version. For example `5.x`, `7.x` and `8.x`.  
 - See [PHP support](#tada-php-support) for the supported PHP versions.


### PR DESCRIPTION
---
name: ⚙ Improvement
about: Add documentation that php-version can come from the platform override version set in composer.lock or composer.json
labels: enhancement

---

## A Pull Request should be associated with a Discussion.

> If you're fixing a bug, adding a new feature or improving something please provide the details in discussions,
> so that the development can be pointed in the intended direction.

Related discussion: None

> Further notes in [Contribution Guidelines](.github/CONTRIBUTING.md)
> Thank you for your contribution.

### Description

This PR documents the behavior in the [readPHPVersion() method in utils.js](https://github.com/shivammathur/setup-php/blob/main/src/utils.ts#L431)

> In case this PR introduced TypeScript/JavaScript code changes:

- [na] I have written test cases for the changes in this pull request
- [na] I have run `npm run format` before the commit.
- [na] I have run `npm run lint` before the commit.
- [na] I have run `npm run release` before the commit.
- [na] `npm test` returns with no unit test errors and all code covered.

> In case this PR edits any scripts:

- [na] I have checked the edited scripts for syntax.
- [na] I have tested the changes in an integration test (If yes, provide workflow YAML and link).

<!--
- Please target the develop branch when submitting the pull request.
-->