### PR TITLE
Relay: Support PHP 8.4 and 8.5

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -31,14 +31,14 @@ export async function addExtensionDarwin(
       case /.+-.+\/.+@.+/.test(extension):
         add_script += await utils.parseExtensionSource(extension, ext_prefix);
         return;
-      // match 7.4relay...8.3relay
+      // match 7.4relay...8.5relay
       // match 5.3blackfire...8.3blackfire
       // match 5.3blackfire-(semver)...8.3blackfire-(semver)
       // match couchbase, event, geos, pdo_oci, oci8, http, pecl_http
       // match 5.3ioncube...8.2ioncube
       // match 7.0phalcon3...7.3phalcon3, 7.2phalcon4...7.4phalcon4, and 7.4phalcon5...8.3phalcon5
       // match 7.0zephir_parser...8.3zephir_parser
-      case /^(7\.4|8\.[0-3])relay(-v?\d+\.\d+\.\d+)?$/.test(version_extension):
+      case /^(7\.4|8\.[0-5])relay(-v?\d+\.\d+\.\d+)?$/.test(version_extension):
       case /^(5\.[3-6]|7\.[0-4]|8\.[0-3])blackfire(-\d+\.\d+\.\d+)?$/.test(
         version_extension
       ):
@@ -263,7 +263,7 @@ export async function addExtensionLinux(
       case /.+-.+\/.+@.+/.test(extension):
         add_script += await utils.parseExtensionSource(extension, ext_prefix);
         return;
-      // match 7.4relay...8.3relay
+      // match 7.4relay...8.5relay
       // match 5.3blackfire...8.3blackfire
       // match 5.3blackfire-(semver)...8.3blackfire-(semver)
       // match 5.3pdo_cubrid...7.2php_cubrid, 5.3cubrid...7.4cubrid
@@ -271,7 +271,7 @@ export async function addExtensionLinux(
       // match 5.3ioncube...8.2ioncube
       // match 7.0phalcon3...7.3phalcon3, 7.2phalcon4...7.4phalcon4, 7.4phalcon5...8.3phalcon5
       // match 7.0zephir_parser...8.3zephir_parser
-      case /^(7\.4|8\.[0-3])relay(-v?\d+\.\d+\.\d+)?$/.test(version_extension):
+      case /^(7\.4|8\.[0-5])relay(-v?\d+\.\d+\.\d+)?$/.test(version_extension):
       case /^(5\.[3-6]|7\.[0-4]|8\.[0-3])blackfire(-\d+\.\d+\.\d+)?$/.test(
         version_extension
       ):


### PR DESCRIPTION
### Description

This PR adds support to install Relay on PHP 8.4 and 8.5.

> In case this PR introduced TypeScript/JavaScript code changes:

- [ ] I have written test cases for the changes in this pull request
- [ ] I have run `npm run format` before the commit.
- [ ] I have run `npm run lint` before the commit.
- [ ] I have run `npm run release` before the commit.
- [ ] `npm test` returns with no unit test errors and all code covered.

> In case this PR edits any scripts:

- [x] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).
