### PR TITLE
Change TOOLS_DIR to SETUP_PHP_TOOLS_DIR to prevent regression

### DIFF
--- a/src/scripts/unix.sh
+++ b/src/scripts/unix.sh
@@ -55,7 +55,7 @@ read_env() {
   fail_fast="${fail_fast:-${FAIL_FAST:-false}}"
   [[ -z "${ImageOS}" && -z "${ImageVersion}" || -n ${ACT} ]] && _runner=self-hosted || _runner=github
   runner="${runner:-${RUNNER:-$_runner}}"
-  tool_path_dir="${tools_dir:-${TOOLS_DIR:-/usr/local/bin}}"
+  tool_path_dir="${setup_php_tools_dir:-${SETUP_PHP_TOOLS_DIR:-/usr/local/bin}}"
 
   if [[ "$runner" = "github" && $_runner = "self-hosted" ]]; then
     fail_fast=true
@@ -76,7 +76,7 @@ read_env() {
   export runner
   export update
   export ts
-  export tools_dir_path
+  export tool_path_dir
 }
 
 # Function to create a lock.


### PR DESCRIPTION
---
name: 🐞 Bug Fix - Change TOOLS_DIR to SETUP_PHP_TOOLS_DIR to prevent regression
about: Rename "TOOLS_DIR" to "SETUP_PHP_TOOLS_DIR" to prevent regression issue.
labels: enhancement

---

Related discussion: 
#943 - Original Issue
#937 - Original PR by @Sn0wCrack 
https://github.com/shivammathur/setup-php/pull/937#issuecomment-2817070777 - Proposed fix by @shivammathur 

### Description

As outlined in issue #943 the "TOOLS_DIR" env variable encounters an issue. @shivammathur mentioned changing "TOOLS_DIR" to "SETUP_PHP_TOOLS_DIR" to prevent this regression issue. This PR makes that change.

- [X] I have checked the edited scripts for syntax.
- [X] I have tested the changes in an integration test (If yes, provide workflow YAML and link).

Workflow Action Test: https://github.com/JMoodyFWD/cphalcon/actions/runs/14865714594
Workflow Action YAML: https://github.com/JMoodyFWD/cphalcon/actions/runs/14865714594/workflow
