### PR TITLE
GH Actions: don't run cron jobs on forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   codeql:
+    if: github.event.repository.fork == false
     permissions:
       actions: read  # for github/codeql-action/init to get workflow details
       contents: read  # for actions/checkout to fetch code

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   create:
+    if: github.event.repository.fork == false
     permissions:
       contents: none
     name: Create
@@ -92,6 +93,7 @@ jobs:
           name: lists-php${{ matrix.php-versions }}-${{ matrix.operating-system }}.md
           path: php${{ matrix.php-versions }}-${{ matrix.operating-system }}.md
   update:
+    if: github.event.repository.fork == false
     permissions:
       contents: write  # for Git to git push
     name: Update


### PR DESCRIPTION
### Description

While workflows are disabled by default in forks, it is quite common for contributors to enable them to verify CI will pass before submitting a pull request.

When enabling workflow runs in forks, it's "all or nothing". This means that:
* All workflows which are only intended to be run on the canonical repo will also be enabled.
    These workflows will also often need access to repo-specific secrets and will typically fail when run from a fork.
* Workflows which contain cron jobs will also be enabled.
    Depending on the type of account the contributor has, this can burn through their "CI minutes".

This commit is based on a review of workflows containing cron jobs and disables running these two particular jobs when the workflow is triggered in a fork (either by a cron job or via the `workflow_dispatch` trigger).
