### PR TITLE
fix: directly download linux archive from symfony-cli releases

### DIFF
--- a/src/scripts/tools/symfony.sh
+++ b/src/scripts/tools/symfony.sh
@@ -3,26 +3,10 @@ add_symfony_with_brew() {
   brew install symfony-cli/tap/symfony-cli
 }
 
-get_symfony_artifact_url() {
-    arch=$(dpkg --print-architecture)
-    url=$(get -s -n "" https://raw.githubusercontent.com/symfony-cli/homebrew-tap/main/Formula/symfony-cli.rb 2<&1 | grep -m 1 "url.*linux.*${arch}" | cut -d\" -f 2)
-    if [ -z "$url" ]; then
-      url=$(get -s -n "" https://api.github.com/repos/symfony-cli/symfony-cli/releases 2<&1 | grep -m 1 "url.*linux.*${arch}.*gz\"" | cut -d\" -f 4)
-    fi
-    echo "$url"
-}
-
 add_symfony_helper() {
   if [ "$(uname -s)" = "Linux" ]; then
-    url="$(get_symfony_artifact_url)"
-    if [ -z "$url" ]; then
-      . "${0%/*}"/tools/brew.sh
-      configure_brew
-      add_symfony_with_brew
-    else
-      get -s -n "" "$url" | sudo tar -xz -C "${tool_path_dir:?}" 2>/dev/null
-      sudo chmod a+x /usr/local/bin/symfony
-    fi
+    get -s -n "" "https://github.com/symfony-cli/symfony-cli/releases/latest/download/symfony-cli_linux_$(dpkg --print-architecture).tar.gz" | sudo tar -xz -C "${tool_path_dir:?}" 2>/dev/null
+    sudo chmod a+x /usr/local/bin/symfony
   elif [ "$(uname -s)" = "Darwin" ]; then
     add_symfony_with_brew
   fi


### PR DESCRIPTION

### Description


Changed to download directly Symfony CLI from artifacts to hopefully make it more stable.

Right now the Symfony CLI download fails flakely for us:

<img width="410" height="108" alt="image" src="https://github.com/user-attachments/assets/ca731307-4726-4ce5-b415-cd8f73f2e12e" />


- [ ] I have written test cases for the changes in this pull request
- [X] I have run `npm run format` before the commit.
- [X] I have run `npm run lint` before the commit.
- [ ] I have run `npm run release` before the commit.
- [X] `npm test` returns with no unit test errors and all code covered.

> In case this PR edits any scripts:

- [X] I have checked the edited scripts for syntax.
- [ ] I have tested the changes in an integration test (If yes, provide workflow YAML and link).

<!--
- Please target the develop branch when submitting the pull request.
-->