### PR TITLE
Enhancement: use capability-based runner detection instead of `RUNNER_ENVIRONMENT`

### DIFF
--- a/src/scripts/unix.sh
+++ b/src/scripts/unix.sh
@@ -54,16 +54,17 @@ read_env() {
   [ "${debug:-${DEBUG:-false}}" = "true" ] && debug=debug && update=true || debug=release
   [[ "${phpts:-${PHPTS:-nts}}" = "ts" || "${phpts:-${PHPTS:-nts}}" = "zts" ]] && ts=zts && update=true || ts=nts
   fail_fast="${fail_fast:-${FAIL_FAST:-false}}"
-  [[ ( -z "$ImageOS" && -z "$ImageVersion" ) ||
-     ( -n "$RUNNER_ENVIRONMENT" && "$RUNNER_ENVIRONMENT" = "self-hosted" ) ||
-     -n "$ACT" || -n "$CONTAINER" ]] && _runner=self-hosted || _runner=github
+  if [[ -n "$ImageOS" && -n "$ImageVersion" && -z "$ACT" && -z "$CONTAINER" ]]; then
+    _runner=github
+  else
+    _runner=self-hosted
+  fi
   runner="${runner:-${RUNNER:-$_runner}}"
   tool_path_dir="${setup_php_tools_dir:-${SETUP_PHP_TOOLS_DIR:-/usr/local/bin}}"
   tool_cache_path_dir="${setup_php_tool_cache_dir:-${SETUP_PHP_TOOL_CACHE_DIR:-${RUNNER_TOOL_CACHE:-/opt/hostedtoolcache}/setup-php/tools}}"  
 
-  if [[ "$runner" = "github" && $_runner = "self-hosted" ]]; then
-    fail_fast=true
-    add_log "$cross" "Runner" "Runner set as github in self-hosted environment"
+  if [[ "$runner" = "github" && -n "$RUNNER_ENVIRONMENT" && "$RUNNER_ENVIRONMENT" = "self-hosted" ]]; then
+    add_log "$tick" "Runner" "GitHub-compatible image detected on third-party runner"
   fi
 
   # Set Update to true if the ubuntu github image does not have PHP PPA.


### PR DESCRIPTION
Related discussion: https://github.com/shivammathur/setup-php/issues/1056

### Description

Third-party runner providers (Depot, Blacksmith, Namespace, BuildJet) mirror GitHub's official runner images but set `RUNNER_ENVIRONMENT=self-hosted`.

The existing detection treats this as a bare self-hosted runner, routing PHP installation through the slower php-builder path (~>1min) instead of the fast pre-built php-ubuntu binaries (few seconds or at least <30s).

Replace the `RUNNER_ENVIRONMENT` check with capability-based detection: if both `ImageOS` and `ImageVersion` are set (and not ACT/container), classify as github.

This restores the pre-[df8d1233](https://github.com/mfn/setup-php/commit/df8d123345439a28295110b98e6cdb58563d67b7) approach of trusting image markers over hosting metadata. Also replace the fail-fast guard with an informational log for third-party runner visibility.

> In case this PR edits any scripts:

- [x] I have checked the edited scripts for syntax.
- [x] I have tested the changes in an integration test (If yes, provide workflow YAML and link).
  
  I can't provide a public link, I tested this in a private org owned repo with depot-hosted runners (and also with github runners, making sure both directions worked)
  Before:
  <img width="640" height="470" alt="image" src="https://github.com/user-attachments/assets/48207d26-e446-4acc-97c5-0320d152144e" />
  After:
  <img width="640" height="472" alt="image" src="https://github.com/user-attachments/assets/724988d2-bcbf-4c20-ab7d-dd3f7335f68a" />

