### PR TITLE
Fix composer v2 version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ These tools can be set up globally using the `tools` input. It accepts a string 
   uses: shivammathur/setup-php@v2
   with:
     php-version: '8.5'
-    tools: composer:v1
+    tools: composer:v2
 ```
 
 - If you do not use composer in your workflow, you can specify `tools: none` to skip it.


### PR DESCRIPTION
It should already have been v2 according to the step's name. I imagine the v1 is a typo.