### PR TITLE
Add Laravel Cloud CLI Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ This disables all core and third-party shared extensions and thus, can break som
 
 These tools can be set up globally using the `tools` input. It accepts a string in csv-format.
 
-[`backward-compatibility-check`], [`behat`], [`blackfire`], [`blackfire-player`], [`box`], [`castor`], [`churn`], [`codeception`], [`composer`], [`composer-dependency-analyser`], [`composer-normalize`], [`composer-prefetcher`], [`composer-require-checker`], [`composer-unused`], [`cpx`], [`cs2pr`], [`deployer`], [`ecs`], [`flex`], [`grpc_php_plugin`], [`infection`], [`mago`], [`name-collision-detector`], [`parallel-lint`], [`pecl`], [`phan`], [`phing`], [`phinx`], [`phive`], [`php-config`], [`php-cs-fixer`], [`php-scoper`], [`phpcbf`], [`phpcpd`], [`phpcs`], [`phpdoc`] or [`phpDocumentor`], [`phpize`], [`phplint`], [`phpmd`], [`phpspec`], [`phpstan`], [`phpunit`], [`phpunit-bridge`], [`phpunit-polyfills`], [`pie`], [`pint`], [`prestissimo`], [`protoc`], [`psalm`], [`rector`], [`symfony`] or [`symfony-cli`], [`vapor`] or [`vapor-cli`], [`wp`] or [`wp-cli`]
+[`backward-compatibility-check`], [`behat`], [`blackfire`], [`blackfire-player`], [`box`], [`castor`], [`churn`], [`codeception`], [`composer`], [`composer-dependency-analyser`], [`composer-normalize`], [`composer-prefetcher`], [`composer-require-checker`], [`composer-unused`], [`cpx`], [`cs2pr`], [`deployer`], [`ecs`], [`flex`], [`grpc_php_plugin`], [`infection`], [`laravel-cloud`] or [`cloud-cli`], [`mago`], [`name-collision-detector`], [`parallel-lint`], [`pecl`], [`phan`], [`phing`], [`phinx`], [`phive`], [`php-config`], [`php-cs-fixer`], [`php-scoper`], [`phpcbf`], [`phpcpd`], [`phpcs`], [`phpdoc`] or [`phpDocumentor`], [`phpize`], [`phplint`], [`phpmd`], [`phpspec`], [`phpstan`], [`phpunit`], [`phpunit-bridge`], [`phpunit-polyfills`], [`pie`], [`pint`], [`prestissimo`], [`protoc`], [`psalm`], [`rector`], [`symfony`] or [`symfony-cli`], [`vapor`] or [`vapor-cli`], [`wp`] or [`wp-cli`]
 
 ```yaml
 - name: Setup PHP with tools
@@ -1096,6 +1096,7 @@ Many users and organizations support setup-php via [GitHub Sponsors](https://git
 [`box`]:                      https://github.com/humbug/box
 [`castor`]:                   https://github.com/jolicode/castor
 [`churn`]:                    https://github.com/bmitch/churn-php
+[`cloud-cli`]:                https://cloud.laravel.com/docs/api/cli
 [`codeception`]:              https://codeception.com/
 [`composer`]:                 https://getcomposer.org/
 [`composer-dependency-analyser`]: https://github.com/shipmonk-rnd/composer-dependency-analyser
@@ -1110,6 +1111,7 @@ Many users and organizations support setup-php via [GitHub Sponsors](https://git
 [`flex`]:                     https://github.com/symfony/flex
 [`grpc_php_plugin`]:          https://grpc.io/
 [`infection`]:                https://infection.github.io/
+[`laravel-cloud`]:            https://cloud.laravel.com/docs/api/cli
 [`mago`]:                     https://github.com/carthage-software/mago
 [`name-collision-detector`]:  https://github.com/shipmonk/name-collision-detector
 [`parallel-lint`]:            https://github.com/php-parallel-lint/PHP-Parallel-Lint

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -635,13 +635,14 @@ describe('Tools tests', () => {
 
   it.each([
     [
-      'blackfire, blackfire-player, box, churn, cpx, cs2pr, flex, grpc_php_plugin, mago, name-collision-detector, parallel-lint, php-cs-fixer, php-scoper, phpDocumentor, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, phpunit-bridge, phpunit-polyfills, pint, php-config, phpize, protoc, symfony, vapor, wp, pie',
+      'blackfire, blackfire-player, box, churn, cloud-cli, cpx, cs2pr, flex, grpc_php_plugin, mago, name-collision-detector, parallel-lint, php-cs-fixer, php-scoper, phpDocumentor, phplint, phpstan, phpunit, pecl, phing, phinx, phinx:1.2.3, phive, phpunit-bridge, phpunit-polyfills, pint, php-config, phpize, protoc, symfony, vapor, wp, pie',
       [
         'add_tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-7.4-stable.phar,https://artifacts.setup-php.com/composer/composer-7.4-stable.phar,https://dl.cloudsmith.io/public/shivammathur/composer-cache/raw/files/composer-7.4-stable.phar,https://getcomposer.org/composer-stable.phar composer',
         'add_blackfire',
         'add_tool https://get.blackfire.io/blackfire-player-v1.22.0.phar blackfire-player "-V"',
         'add_tool https://github.com/box-project/box/releases/latest/download/box.phar box "--version"',
         'add_tool https://github.com/bmitch/churn-php/releases/latest/download/churn.phar churn "-V"',
+        'add_composer_tool cloud-cli cloud-cli laravel/ scoped',
         'add_tool https://github.com/laravel/cpx/releases/latest/download/cpx cpx "--version"',
         'add_tool https://github.com/staabm/annotate-pull-request-from-checkstyle/releases/latest/download/cs2pr cs2pr "-V"',
         'add_composer_tool flex flex symfony/ global',
@@ -681,7 +682,7 @@ describe('Tools tests', () => {
 
   it.each([
     [
-      'backward-compatibility-check, behat, blackfire, blackfire-player, churn, composer-dependency-analyser, composer-normalize, composer-require-checker, composer-unused, cpx:2.0.0, cs2pr:1.2.3, ecs, flex, grpc_php_plugin:1.2.3, infection, mago:0.26.1, name-collision-detector, phan, phan:1.2.3, phing:1.2.3, phinx, phive:1.2.3, php-config, phpcbf, phpcpd, phpcs, phpdoc, phpize, phpmd, phpspec, phpunit-bridge:5.6, phpunit-polyfills:1.0.1, protoc:v1.2.3, psalm, rector, symfony-cli, vapor-cli, wp-cli, pie',
+      'backward-compatibility-check, behat, blackfire, blackfire-player, churn, composer-dependency-analyser, composer-normalize, composer-require-checker, composer-unused, cpx:2.0.0, cs2pr:1.2.3, ecs, flex, grpc_php_plugin:1.2.3, infection, laravel-cloud, mago:0.26.1, name-collision-detector, phan, phan:1.2.3, phing:1.2.3, phinx, phive:1.2.3, php-config, phpcbf, phpcpd, phpcs, phpdoc, phpize, phpmd, phpspec, phpunit-bridge:5.6, phpunit-polyfills:1.0.1, protoc:v1.2.3, psalm, rector, symfony-cli, vapor-cli, wp-cli, pie',
       [
         'add_tool https://github.com/shivammathur/composer-cache/releases/latest/download/composer-7.4-stable.phar,https://artifacts.setup-php.com/composer/composer-7.4-stable.phar,https://dl.cloudsmith.io/public/shivammathur/composer-cache/raw/files/composer-7.4-stable.phar,https://getcomposer.org/composer-stable.phar composer',
         'add_composer_tool behat behat behat/ scoped',
@@ -697,6 +698,7 @@ describe('Tools tests', () => {
         'add_composer_tool flex flex symfony/ global',
         'add_grpc_php_plugin 1.2.3',
         'add_tool https://github.com/infection/infection/releases/latest/download/infection.phar infection "-V"',
+        'add_composer_tool cloud-cli cloud-cli laravel/ scoped',
         'add_mago 0.26.1',
         'add_composer_tool name-collision-detector name-collision-detector shipmonk/ scoped',
         'add_tool https://github.com/phan/phan/releases/latest/download/phan.phar phan "-v"',

--- a/src/configs/tools.json
+++ b/src/configs/tools.json
@@ -242,6 +242,12 @@
     "repository": "laravel/vapor-cli",
     "scope": "scoped"
   },
+  "cloud-cli": {
+    "type": "composer",
+    "alias": "laravel-cloud",
+    "repository": "laravel/cloud-cli",
+    "scope": "scoped"
+  },
   "rector": {
     "type": "composer",
     "repository": "rector/rector",

--- a/src/scripts/tools/add_tools.ps1
+++ b/src/scripts/tools/add_tools.ps1
@@ -221,6 +221,9 @@ Function Add-ToolsHelper() {
     $extensions += @('dom', 'json', 'libxml', 'mbstring', 'xml', 'xmlwriter')
   } elseif($tool -eq "phpunit-bridge") {
     $extensions += @('dom', 'pdo', 'tokenizer', 'xmlwriter')
+  } elseif($tool -eq "cloud-cli") {
+    $extensions += @('fileinfo', 'json', 'mbstring', 'zip', 'simplexml')
+    Copy-Item $env:cloud_cli_bin\cloud.bat -Destination $env:cloud_cli_bin\cloud-cli.bat
   } elseif($tool -eq "vapor-cli") {
     $extensions += @('fileinfo', 'json', 'mbstring', 'zip', 'simplexml')
     Copy-Item $env:vapor_cli_bin\vapor.bat -Destination $env:vapor_cli_bin\vapor-cli.bat

--- a/src/scripts/tools/add_tools.ps1
+++ b/src/scripts/tools/add_tools.ps1
@@ -222,7 +222,7 @@ Function Add-ToolsHelper() {
   } elseif($tool -eq "phpunit-bridge") {
     $extensions += @('dom', 'pdo', 'tokenizer', 'xmlwriter')
   } elseif($tool -eq "cloud-cli") {
-    $extensions += @('fileinfo', 'json', 'mbstring', 'zip', 'simplexml')
+    $extensions += @('sockets')
     Copy-Item $env:cloud_cli_bin\cloud.bat -Destination $env:cloud_cli_bin\cloud-cli.bat
   } elseif($tool -eq "vapor-cli") {
     $extensions += @('fileinfo', 'json', 'mbstring', 'zip', 'simplexml')

--- a/src/scripts/tools/add_tools.sh
+++ b/src/scripts/tools/add_tools.sh
@@ -186,7 +186,7 @@ add_tools_helper() {
       sudo cp "$tool_path_dir"/phpunit "$composer_bin"
     fi
   elif [ "$tool" = "cloud-cli" ]; then
-    extensions+=(fileinfo json mbstring zip simplexml)
+    extensions+=(dom iconv sockets tokenizer)
     sudo ln -s "$scoped_dir"/vendor/bin/cloud "$scoped_dir"/vendor/bin/cloud-cli 2>/dev/null || true
   elif [ "$tool" = "vapor-cli" ]; then
     extensions+=(fileinfo json mbstring zip simplexml)

--- a/src/scripts/tools/add_tools.sh
+++ b/src/scripts/tools/add_tools.sh
@@ -185,6 +185,9 @@ add_tools_helper() {
     if [ -e "$tool_path_dir"/phpunit ] && [ -d "$composer_bin" ]; then
       sudo cp "$tool_path_dir"/phpunit "$composer_bin"
     fi
+  elif [ "$tool" = "cloud-cli" ]; then
+    extensions+=(fileinfo json mbstring zip simplexml)
+    sudo ln -s "$scoped_dir"/vendor/bin/cloud "$scoped_dir"/vendor/bin/cloud-cli 2>/dev/null || true
   elif [ "$tool" = "vapor-cli" ]; then
     extensions+=(fileinfo json mbstring zip simplexml)
     sudo ln -s "$scoped_dir"/vendor/bin/vapor "$scoped_dir"/vendor/bin/vapor-cli 2>/dev/null || true


### PR DESCRIPTION
Summary
Adds support for the Laravel Cloud CLI (https://cloud.laravel.com/docs/api/cli) to the tools input. Users can now install it with laravel-cloud or cloud-cli, with optional version pinning.

```
- uses: shivammathur/setup-php@v2
  with:
    tools: laravel-cloud          # or: cloud-cli
    # tools: cloud-cli:0.5.0      # pinned version
```

The package is installed globally via Composer in a scoped directory (laravel/cloud-cli), mirroring the existing vapor-cli setup. Both the cloud binary and a cloud-cli alias are placed on PATH.