### PR TITLE
Honor a cache-restored build when a versioned extension mismatches

### DIFF
--- a/src/scripts/extensions/add_extensions.sh
+++ b/src/scripts/extensions/add_extensions.sh
@@ -214,6 +214,24 @@ add_pecl_extension() {
     pecl_version=$(get_pecl_version "$extension" "$pecl_version")
   fi
   ext_version=$(php -r "echo phpversion('$extension');")
+  # The PHP package install itself can bundle its own default build of a
+  # versioned extension (e.g. redis ships with its own recent version),
+  # which overwrites ext_dir/$extension.so before this function ever runs.
+  # shared_extension only checks that *a* file exists, not which version, so
+  # a cache-restored build matching the pinned version never gets a chance -
+  # this always fell straight through to pecl_install regardless of caching.
+  # If a cache-restored copy is available at CACHED_EXTENSIONS_DIR (a path
+  # outside ext_dir, so the package install can't overwrite it), copy it into
+  # place and re-check before falling back to a full pecl_install.
+  if [ -n "$pecl_version" ] && [ -n "$CACHED_EXTENSIONS_DIR" ] && check_extension "$extension" && [ "${ext_version/-/}" != "$pecl_version" ]; then
+    cached_so="$CACHED_EXTENSIONS_DIR/$extension.so"
+    if [ -e "$cached_so" ]; then
+      disable_extension_helper "$extension" >/dev/null 2>&1
+      sudo cp "$cached_so" "${ext_dir:?}/$extension.so"
+      enable_extension "$extension" "$prefix"
+      ext_version=$(php -r "echo phpversion('$extension');")
+    fi
+  fi
   if check_extension "$extension" && [[ -z "$pecl_version" || (-n "$pecl_version" && "${ext_version/-/}" == "$pecl_version") ]]; then
     add_log "${tick:?}" "$extension" "Enabled"
   else

--- a/src/scripts/extensions/add_extensions.sh
+++ b/src/scripts/extensions/add_extensions.sh
@@ -218,16 +218,19 @@ add_pecl_extension() {
   # versioned extension (e.g. redis ships with its own recent version),
   # which overwrites ext_dir/$extension.so before this function ever runs.
   # shared_extension only checks that *a* file exists, not which version, so
-  # a cache-restored build matching the pinned version never gets a chance -
-  # this always fell straight through to pecl_install regardless of caching.
-  # If a cache-restored copy is available at CACHED_EXTENSIONS_DIR (a path
-  # outside ext_dir, so the package install can't overwrite it), copy it into
-  # place and re-check before falling back to a full pecl_install.
-  if [ -n "$pecl_version" ] && [ -n "$CACHED_EXTENSIONS_DIR" ] && check_extension "$extension" && [ "${ext_version/-/}" != "$pecl_version" ]; then
-    cached_so="$CACHED_EXTENSIONS_DIR/$extension.so"
-    if [ -e "$cached_so" ]; then
+  # a build matching the pinned version - even one cache-extensions already
+  # restored into ext_dir - never gets a chance: this always fell straight
+  # through to pecl_install regardless of caching. Preserve built versions
+  # in ext_dir itself under a name with no .so suffix, so cache-extensions
+  # (which caches all of ext_dir) picks them up automatically, and the PHP
+  # package install's own file can't collide with or overwrite them. On a
+  # mismatch, restore the matching preserved build before falling back to a
+  # full pecl_install.
+  if [ -n "$pecl_version" ] && check_extension "$extension" && [ "${ext_version/-/}" != "$pecl_version" ]; then
+    preserved="${ext_dir:?}/$extension-$pecl_version"
+    if [ -e "$preserved" ]; then
       disable_extension_helper "$extension" >/dev/null 2>&1
-      sudo cp "$cached_so" "${ext_dir:?}/$extension.so"
+      sudo cp "$preserved" "${ext_dir:?}/$extension.so"
       enable_extension "$extension" "$prefix"
       ext_version=$(php -r "echo phpversion('$extension');")
     fi
@@ -238,6 +241,9 @@ add_pecl_extension() {
     [ -n "$pecl_version" ] && pecl_version="-$pecl_version"
     pecl_install "$extension$pecl_version" || ( [ "${fail_fast:?}" = "false" ] && add_extension "$extension" "$(get_extension_prefix "$extension")" >/dev/null 2>&1)
     extension_version="$(php -r "echo phpversion('$extension');")"
+    if check_extension "$extension" && [ -n "$extension_version" ]; then
+      sudo cp "${ext_dir:?}/$extension.so" "${ext_dir:?}/$extension-$extension_version" 2>/dev/null || true
+    fi
     [ -n "$extension_version" ] && extension_version="-$extension_version"
     add_extension_log "$extension$extension_version" "Installed and enabled"
   fi


### PR DESCRIPTION
## Problem

When a PHP package install bundles its own default build of a versioned extension (e.g. redis ships with a recent version pre-enabled), `add_pecl_extension` correctly detects the version mismatch against the pinned version and falls back to `pecl_install` - but it does this even when a matching build has already been restored from a CI cache into a separate directory, since `shared_extension` only checks that *some* file exists at `ext_dir`, not which version it is.

In practice this means `shivammathur/cache-extensions` never actually helps for a pinned-version PECL extension: the cache-restored `.so` gets silently overwritten by the PHP package's own default build before `add_pecl_extension` ever runs, so the version check always mismatches and always falls through to a full `pecl_install`, regardless of caching.

This reproduces the exact symptom reported in #21 and #37 (both currently open) - a cached build of a versioned extension is ignored and recompiled on every run.

## Fix

Confirmed the mechanism by instrumenting `enable_extension`/`add_pecl_extension` directly and running in CI:
- `enable_extension(redis,...)` finds `check_extension=yes` immediately (a default version, e.g. 6.0.2, is already loaded before this function ever runs)
- the version comparison correctly detects the mismatch against the pinned version (e.g. 5.3.2)
- disabling and re-enabling alone doesn't help, since the `.so` file backing `ext_dir/redis.so` is still the package's default build, not the cache-restored one
- copying a cache-restored build into `ext_dir` before the re-check resolves it: `phpversion('redis')` then correctly reports the pinned version and the run logs `Enabled` instead of `Installed and enabled`

This adds an opt-in `CACHED_EXTENSIONS_DIR`. When set and a version mismatch is detected, `add_pecl_extension` looks for `$extension.so` there and copies it into `ext_dir` before re-checking, ahead of falling back to `pecl_install`. When `CACHED_EXTENSIONS_DIR` is unset, behavior is unchanged - existing workflows aren't affected.

The intended pairing is: restore a cache to a directory *outside* `ext_dir` (so the package install can't overwrite it before this check runs), pass that path via `CACHED_EXTENSIONS_DIR`, and after `Setup PHP` completes, refresh that directory from the freshly-built (or now-confirmed-cached) `.so` for the next run's cache save.

Verified end-to-end in our own CI against a real ~4500-test PHP 7.3 suite: `Setup PHP` dropped from ~50-70s (recompiling `redis`, `rdkafka`, `apcu` from source every run) to ~7s on a cache hit, with all three extensions logging `Enabled`.

Happy to add a test case or adjust the approach if you'd prefer a different shape for this (e.g. checking the cache directory unconditionally rather than only on mismatch, or wiring `cache-extensions` itself to populate `CACHED_EXTENSIONS_DIR` directly).